### PR TITLE
Add Variant type support for semi-structured JSON columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4860,6 +4860,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet-variant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066f3e371a47d5b0bfd9491992f2400e4f155511d0c9bcfaca04bac7f1e33600"
+dependencies = [
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.12.1",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497db08281ed670f7e5119116b961282d50645a28b2afb97686f18e2e4034414"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.12.1",
+ "parquet-variant",
+ "parquet-variant-json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9958f58a045ec273727651a3d07e32b382a7732f7cae86d26d80e9ec0acf2e3b"
+dependencies = [
+ "arrow-schema",
+ "base64",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6804,6 +6848,9 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "rand 0.9.2",
  "regex",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ bincode = { version = "2.0", features = ["serde"] }
 walrus-rust = "0.2.0"
 thiserror = "2.0"
 strum = { version = "0.27", features = ["derive"] }
+# Parquet Variant support for proper semi-structured data encoding
+parquet-variant = "0.2.0"
+parquet-variant-compute = "0.2.0"
+parquet-variant-json = "0.2.0"
 
 [dev-dependencies]
 sqllogictest = { git = "https://github.com/risinglightdb/sqllogictest-rs.git" }

--- a/schemas/otel_logs_and_spans.yaml
+++ b/schemas/otel_logs_and_spans.yaml
@@ -49,7 +49,7 @@ fields:
     data_type: Int32
     nullable: true
   - name: body
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: duration
     data_type: Int64
@@ -61,7 +61,7 @@ fields:
     data_type: 'Timestamp(Microsecond, Some("UTC"))'
     nullable: true
   - name: context
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: context___trace_id
     data_type: Utf8
@@ -79,13 +79,13 @@ fields:
     data_type: Utf8
     nullable: true
   - name: events
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: links
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: attributes
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: attributes___client___address
     data_type: Utf8
@@ -235,7 +235,7 @@ fields:
     data_type: Utf8
     nullable: true
   - name: resource
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: resource___service___name
     data_type: Utf8
@@ -268,7 +268,7 @@ fields:
     data_type: "List(Utf8)"
     nullable: false
   - name: errors
-    data_type: Utf8
+    data_type: Variant
     nullable: true
   - name: log_pattern
     data_type: Utf8

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ pub mod schema_loader;
 pub mod statistics;
 pub mod telemetry;
 pub mod test_utils;
+pub mod variant_utils;
 pub mod wal;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,19 +1,34 @@
 pub mod test_helpers {
     use crate::schema_loader::get_default_schema;
+    use crate::variant_utils::{VARIANT_COLUMNS, convert_batch_json_to_variant, variant_data_type};
+    use arrow::datatypes::{DataType, Field, Schema};
     use arrow_json::ReaderBuilder;
     use datafusion::arrow::record_batch::RecordBatch;
     use serde_json::{Value, json};
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     pub fn json_to_batch(records: Vec<Value>) -> anyhow::Result<RecordBatch> {
         let schema = get_default_schema().schema_ref();
+        // Create a parsing schema with Utf8 for Variant columns (arrow_json can't parse Variant)
+        let parse_schema = Arc::new(Schema::new(
+            schema.fields().iter().map(|f| {
+                if VARIANT_COLUMNS.contains(&f.name().as_str()) && *f.data_type() == variant_data_type() {
+                    Arc::new(Field::new(f.name(), DataType::Utf8, f.is_nullable()))
+                } else {
+                    f.clone()
+                }
+            }).collect::<Vec<_>>()
+        ));
         let json_data = records.into_iter().map(|v| v.to_string()).collect::<Vec<_>>().join("\n");
 
-        ReaderBuilder::new(schema.clone())
+        let batch = ReaderBuilder::new(parse_schema)
             .build(std::io::Cursor::new(json_data.as_bytes()))?
             .next()
-            .ok_or_else(|| anyhow::anyhow!("Failed to read batch"))?
-            .map_err(Into::into)
+            .ok_or_else(|| anyhow::anyhow!("Failed to read batch"))??;
+
+        // Convert Utf8 JSON columns to Variant
+        convert_batch_json_to_variant(batch).map_err(|e| anyhow::anyhow!("{}", e))
     }
 
     pub fn create_default_record() -> HashMap<String, Value> {

--- a/src/variant_utils.rs
+++ b/src/variant_utils.rs
@@ -1,0 +1,405 @@
+//! Variant type utilities for converting between JSON and Variant,
+//! and providing UDFs that work with both Variant and Utf8 inputs.
+//!
+//! This module uses the parquet-variant crate for proper Variant binary encoding
+//! as specified in the Parquet Variant specification.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, StringArray, StructArray};
+use arrow::datatypes::{DataType, Field, Fields};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, ScalarValue};
+use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility};
+use arrow::array::{BinaryArray, BinaryViewArray, StringBuilder};
+use parquet_variant::Variant;
+use parquet_variant_compute::json_to_variant;
+use parquet_variant_json::VariantToJson;
+
+/// Columns that should be stored as Variant type
+pub const VARIANT_COLUMNS: &[&str] = &["body", "context", "events", "links", "attributes", "resource", "errors"];
+
+/// Get the Arrow DataType for Variant (Struct with metadata and value BinaryView fields)
+/// This matches the parquet-variant-compute output
+pub fn variant_data_type() -> DataType {
+    DataType::Struct(Fields::from(vec![
+        Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+        Arc::new(Field::new("value", DataType::BinaryView, false)),
+    ]))
+}
+
+/// Check if an array is a Variant type (Struct with metadata and value fields)
+pub fn is_variant_array(array: &ArrayRef) -> bool {
+    if let DataType::Struct(fields) = array.data_type() {
+        fields.len() == 2
+            && fields.iter().any(|f| f.name() == "metadata" && matches!(f.data_type(), DataType::BinaryView | DataType::Binary))
+            && fields.iter().any(|f| f.name() == "value" && matches!(f.data_type(), DataType::BinaryView | DataType::Binary))
+    } else {
+        false
+    }
+}
+
+/// Check if a ColumnarValue is a Variant type
+pub fn is_variant_columnar(value: &ColumnarValue) -> bool {
+    match value {
+        ColumnarValue::Array(arr) => is_variant_array(arr),
+        ColumnarValue::Scalar(ScalarValue::Struct(arr)) => is_variant_array(&(arr.clone() as ArrayRef)),
+        _ => false,
+    }
+}
+
+/// Convert a JSON string array to a Variant array using proper parquet-variant encoding
+pub fn json_to_variant_array(json_array: &StringArray) -> Result<ArrayRef, DataFusionError> {
+    let array_ref: ArrayRef = Arc::new(json_array.clone());
+    let variant_array = json_to_variant(&array_ref)
+        .map_err(|e| DataFusionError::Execution(format!("Failed to convert JSON to Variant: {}", e)))?;
+    Ok(Arc::new(variant_array.into_inner()))
+}
+
+/// Convert a Variant array to a JSON string array
+/// Handles both Binary and BinaryView field types
+pub fn variant_to_json_array(variant_array: &StructArray) -> Result<ArrayRef, DataFusionError> {
+    let metadata_col = variant_array.column_by_name("metadata")
+        .ok_or_else(|| DataFusionError::Execution("Missing metadata field in Variant".to_string()))?;
+    let value_col = variant_array.column_by_name("value")
+        .ok_or_else(|| DataFusionError::Execution("Missing value field in Variant".to_string()))?;
+
+    // Helper to get bytes from either Binary or BinaryView array
+    fn get_bytes<'a>(arr: &'a ArrayRef, idx: usize) -> Option<&'a [u8]> {
+        if let Some(binary) = arr.as_any().downcast_ref::<BinaryArray>() {
+            if binary.is_null(idx) { None } else { Some(binary.value(idx)) }
+        } else if let Some(binary_view) = arr.as_any().downcast_ref::<BinaryViewArray>() {
+            if binary_view.is_null(idx) { None } else { Some(binary_view.value(idx)) }
+        } else {
+            None
+        }
+    }
+
+    let mut builder = StringBuilder::new();
+    for i in 0..variant_array.len() {
+        if variant_array.is_null(i) {
+            builder.append_null();
+        } else {
+            let metadata = get_bytes(metadata_col, i)
+                .ok_or_else(|| DataFusionError::Execution("Missing metadata bytes".to_string()))?;
+            let value = get_bytes(value_col, i)
+                .ok_or_else(|| DataFusionError::Execution("Missing value bytes".to_string()))?;
+            let variant = Variant::new(metadata, value);
+            let json_str = variant.to_json_string()
+                .map_err(|e| DataFusionError::Execution(format!("Failed to convert Variant to JSON: {}", e)))?;
+            builder.append_value(&json_str);
+        }
+    }
+
+    Ok(Arc::new(builder.finish()))
+}
+
+/// Convert a ColumnarValue to JSON string if it's a Variant, otherwise pass through
+pub fn ensure_json_columnar(value: &ColumnarValue) -> Result<ColumnarValue, DataFusionError> {
+    if !is_variant_columnar(value) {
+        return Ok(value.clone());
+    }
+
+    match value {
+        ColumnarValue::Array(arr) => {
+            let struct_arr = arr.as_any().downcast_ref::<StructArray>().ok_or_else(|| DataFusionError::Execution("Expected StructArray".to_string()))?;
+            let json_arr = variant_to_json_array(struct_arr)?;
+            Ok(ColumnarValue::Array(json_arr))
+        }
+        ColumnarValue::Scalar(scalar) => {
+            if let ScalarValue::Struct(arr) = scalar {
+                let json_arr = variant_to_json_array(arr)?;
+                let json_str = json_arr.as_any().downcast_ref::<StringArray>().ok_or_else(|| DataFusionError::Execution("Expected StringArray".to_string()))?;
+                if json_str.is_null(0) {
+                    Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+                } else {
+                    Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(json_str.value(0).to_string()))))
+                }
+            } else {
+                Ok(value.clone())
+            }
+        }
+    }
+}
+
+/// Convert a RecordBatch, transforming JSON string columns (Utf8) to Variant for specified columns
+pub fn convert_batch_json_to_variant(batch: RecordBatch) -> Result<RecordBatch, DataFusionError> {
+    let schema = batch.schema();
+    let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+    let mut new_fields: Vec<Arc<Field>> = Vec::with_capacity(batch.num_columns());
+
+    for (i, field) in schema.fields().iter().enumerate() {
+        let column = batch.column(i);
+
+        if VARIANT_COLUMNS.contains(&field.name().as_str()) && matches!(field.data_type(), DataType::Utf8 | DataType::LargeUtf8) {
+            // Convert UTF8 JSON string to Variant using proper parquet-variant encoding
+            let string_array = column.as_any().downcast_ref::<StringArray>().ok_or_else(|| DataFusionError::Execution("Expected StringArray".to_string()))?;
+            let variant_array = json_to_variant_array(string_array)?;
+            let variant_field = Arc::new(Field::new(field.name(), variant_data_type(), field.is_nullable()));
+            new_columns.push(variant_array);
+            new_fields.push(variant_field);
+        } else {
+            new_columns.push(column.clone());
+            new_fields.push(field.clone());
+        }
+    }
+
+    let new_schema = Arc::new(arrow::datatypes::Schema::new(new_fields));
+    RecordBatch::try_new(new_schema, new_columns).map_err(|e| DataFusionError::Execution(format!("Failed to create batch: {}", e)))
+}
+
+// ============================================================================
+// Replacement UDFs that work with both Variant and Utf8 inputs
+// ============================================================================
+
+/// Create the json_get UDF (-> operator) that works with both Variant and Utf8
+pub fn create_json_get_udf() -> ScalarUDF {
+    ScalarUDF::from(VariantAwareJsonGetUDF::new())
+}
+
+/// Create the json_get_str UDF (->> operator) that works with both Variant and Utf8
+pub fn create_json_get_str_udf() -> ScalarUDF {
+    ScalarUDF::from(VariantAwareJsonGetStrUDF::new())
+}
+
+/// Create the json_length UDF that works with both Variant and Utf8
+pub fn create_json_length_udf() -> ScalarUDF {
+    ScalarUDF::from(VariantAwareJsonLengthUDF::new())
+}
+
+/// Create the json_contains UDF that works with both Variant and Utf8
+pub fn create_json_contains_udf() -> ScalarUDF {
+    ScalarUDF::from(VariantAwareJsonContainsUDF::new())
+}
+
+// ============================================================================
+// UDF Implementations
+// ============================================================================
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+struct VariantAwareJsonGetUDF {
+    signature: Signature,
+}
+
+impl VariantAwareJsonGetUDF {
+    fn new() -> Self {
+        Self { signature: Signature::variadic_any(Volatility::Immutable) }
+    }
+}
+
+impl ScalarUDFImpl for VariantAwareJsonGetUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "json_get"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
+        if args.args.len() < 2 {
+            return Err(DataFusionError::Execution("json_get requires at least 2 arguments".to_string()));
+        }
+
+        // Convert first argument from Variant to JSON if needed
+        let json_arg = ensure_json_columnar(&args.args[0])?;
+
+        // Call the underlying datafusion-functions-json implementation
+        let mut new_args = args.args.clone();
+        new_args[0] = json_arg;
+
+        // Use the json_get UDF from datafusion-functions-json
+        datafusion_functions_json::udfs::json_get_udf().invoke_with_args(ScalarFunctionArgs { args: new_args, ..args })
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+struct VariantAwareJsonGetStrUDF {
+    signature: Signature,
+}
+
+impl VariantAwareJsonGetStrUDF {
+    fn new() -> Self {
+        Self { signature: Signature::variadic_any(Volatility::Immutable) }
+    }
+}
+
+impl ScalarUDFImpl for VariantAwareJsonGetStrUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "json_get_str"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
+        if args.args.len() < 2 {
+            return Err(DataFusionError::Execution("json_get_str requires at least 2 arguments".to_string()));
+        }
+
+        let json_arg = ensure_json_columnar(&args.args[0])?;
+        let mut new_args = args.args.clone();
+        new_args[0] = json_arg;
+
+        datafusion_functions_json::udfs::json_get_str_udf().invoke_with_args(ScalarFunctionArgs { args: new_args, ..args })
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+struct VariantAwareJsonLengthUDF {
+    signature: Signature,
+}
+
+impl VariantAwareJsonLengthUDF {
+    fn new() -> Self {
+        Self { signature: Signature::variadic_any(Volatility::Immutable) }
+    }
+}
+
+impl ScalarUDFImpl for VariantAwareJsonLengthUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "json_length"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
+        Ok(DataType::UInt64)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
+        if args.args.is_empty() {
+            return Err(DataFusionError::Execution("json_length requires at least 1 argument".to_string()));
+        }
+
+        let json_arg = ensure_json_columnar(&args.args[0])?;
+        let mut new_args = args.args.clone();
+        new_args[0] = json_arg;
+
+        datafusion_functions_json::udfs::json_length_udf().invoke_with_args(ScalarFunctionArgs { args: new_args, ..args })
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+struct VariantAwareJsonContainsUDF {
+    signature: Signature,
+}
+
+impl VariantAwareJsonContainsUDF {
+    fn new() -> Self {
+        Self { signature: Signature::variadic_any(Volatility::Immutable) }
+    }
+}
+
+impl ScalarUDFImpl for VariantAwareJsonContainsUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "json_contains"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
+        if args.args.len() < 2 {
+            return Err(DataFusionError::Execution("json_contains requires at least 2 arguments".to_string()));
+        }
+
+        let json_arg = ensure_json_columnar(&args.args[0])?;
+        let mut new_args = args.args.clone();
+        new_args[0] = json_arg;
+
+        datafusion_functions_json::udfs::json_contains_udf().invoke_with_args(ScalarFunctionArgs { args: new_args, ..args })
+    }
+}
+
+/// Register all variant-aware JSON functions in the session context
+pub fn register_variant_json_functions(ctx: &mut datafusion::execution::context::SessionContext) {
+    // Register our variant-aware replacements that override the datafusion-functions-json ones
+    ctx.register_udf(create_json_get_udf());
+    ctx.register_udf(create_json_get_str_udf());
+    ctx.register_udf(create_json_length_udf());
+    ctx.register_udf(create_json_contains_udf());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_variant_data_type() {
+        let dt = variant_data_type();
+        assert!(matches!(dt, DataType::Struct(_)));
+    }
+
+    #[test]
+    fn test_json_to_variant_roundtrip() {
+        let json_data = vec![Some(r#"{"name": "test", "value": 123}"#), None, Some(r#"[1, 2, 3]"#)];
+        let json_array = StringArray::from(json_data);
+
+        // Convert to variant
+        let variant_arr = json_to_variant_array(&json_array).unwrap();
+
+        // Convert back to JSON
+        let struct_arr = variant_arr.as_any().downcast_ref::<StructArray>().unwrap();
+        let json_back = variant_to_json_array(struct_arr).unwrap();
+        let json_str = json_back.as_any().downcast_ref::<StringArray>().unwrap();
+
+        assert_eq!(json_str.len(), 3);
+        assert!(!json_str.is_null(0));
+        assert!(json_str.is_null(1));
+        assert!(!json_str.is_null(2));
+
+        // Verify content (JSON may be reordered but should parse to same value)
+        let parsed_original: serde_json::Value = serde_json::from_str(r#"{"name": "test", "value": 123}"#).unwrap();
+        let parsed_roundtrip: serde_json::Value = serde_json::from_str(json_str.value(0)).unwrap();
+        assert_eq!(parsed_original, parsed_roundtrip);
+
+        let parsed_array: serde_json::Value = serde_json::from_str(json_str.value(2)).unwrap();
+        assert_eq!(parsed_array, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_is_variant_array() {
+        let json_array = StringArray::from(vec![Some(r#"{"key": "value"}"#)]);
+        let variant_arr = json_to_variant_array(&json_array).unwrap();
+
+        assert!(is_variant_array(&variant_arr));
+
+        // Non-variant array should return false
+        let string_arr: ArrayRef = Arc::new(StringArray::from(vec!["test"]));
+        assert!(!is_variant_array(&string_arr));
+    }
+}


### PR DESCRIPTION
## Summary

- Add proper Parquet Variant type support for semi-structured JSON columns using `parquet-variant` crates
- Convert JSON columns (`body`, `context`, `events`, `links`, `attributes`, `resource`, `errors`) from `Utf8` to `Variant` type
- Create transparent wrapper UDFs so existing SQL queries continue to work unchanged

## Changes

### New Dependencies
- `parquet-variant` v0.2.0 - Core Variant type
- `parquet-variant-compute` v0.2.0 - JSON to Variant conversion
- `parquet-variant-json` v0.2.0 - Variant to JSON conversion

### New Module: `variant_utils.rs`
- `json_to_variant_array()` - Convert JSON strings to Variant binary format
- `variant_to_json_array()` - Convert Variant back to JSON for queries
- Variant-aware wrapper UDFs (`json_get`, `json_get_str`, `json_length`, `json_contains`) that handle both Variant and UTF8 inputs

### Schema Changes
- `schemas/otel_logs_and_spans.yaml` - Changed 7 columns from `Utf8` to `Variant`
- `schema_loader.rs` - Added `variant_arrow_type()` and `variant_delta_type()` functions

### Protocol Support (Prepared)
- Added `create_variant_protocol()` function ready for when delta-rs adds variantType support
- Currently disabled because delta-rs `ProtocolChecker` doesn't include `variantType` in supported features

## Technical Notes

- Variant data is stored as `Struct<metadata: BinaryView, value: BinaryView>` per Parquet Variant spec
- The binary encoding is correct; only the protocol feature marker is missing until delta-rs adds support
- All existing SQL queries work unchanged thanks to the transparent wrapper UDFs

## Test plan

- [x] Unit tests for variant_utils roundtrip conversion pass
- [x] batch_queue tests pass with Variant columns
- [x] Build compiles without warnings
- [ ] Integration tests with minio (requires minio running)