### PR TITLE
ci+tests: safe cleanups split from #11

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Build and Deploy
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/src/database.rs
+++ b/src/database.rs
@@ -539,7 +539,10 @@ impl Database {
             match crate::secret_crypto::decrypt_or_passthrough(&config.s3_secret_access_key) {
                 Ok(v) => config.s3_secret_access_key = v,
                 Err(e) => {
-                    error!("Skipping {}/{}: cannot decrypt s3_secret_access_key: {}", config.project_id, config.table_name, e);
+                    error!(
+                        "Skipping {}/{}: cannot decrypt s3_secret_access_key: {}",
+                        config.project_id, config.table_name, e
+                    );
                     continue;
                 }
             }

--- a/src/secret_crypto.rs
+++ b/src/secret_crypto.rs
@@ -7,11 +7,14 @@
 //! can be rolled out without a forced backfill — re-encrypt with
 //! `timefusion encrypt-secret <value>` and UPDATE the row.
 
-use aes_gcm::aead::{Aead, KeyInit, OsRng, rand_core::RngCore};
-use aes_gcm::{Aes256Gcm, Key, Nonce};
+use std::sync::OnceLock;
+
+use aes_gcm::{
+    Aes256Gcm, Key, Nonce,
+    aead::{Aead, KeyInit, OsRng, rand_core::RngCore},
+};
 use anyhow::{Context, Result, anyhow, bail};
 use base64::{Engine, engine::general_purpose::STANDARD as B64};
-use std::sync::OnceLock;
 
 pub const ENC_PREFIX: &str = "enc:v1:";
 const KEY_ENV: &str = "TIMEFUSION_CONFIG_ENCRYPTION_KEY";
@@ -64,7 +67,9 @@ pub fn decrypt_or_passthrough(value: &str) -> Result<String> {
         bail!("encrypted secret payload too short");
     }
     let (nonce, ct) = bytes.split_at(NONCE_LEN);
-    let pt = c.decrypt(Nonce::from_slice(nonce), ct).map_err(|e| anyhow!("AES-GCM decrypt failed (key mismatch or tampered ciphertext): {e}"))?;
+    let pt = c
+        .decrypt(Nonce::from_slice(nonce), ct)
+        .map_err(|e| anyhow!("AES-GCM decrypt failed (key mismatch or tampered ciphertext): {e}"))?;
     String::from_utf8(pt).context("decrypted secret is not valid UTF-8")
 }
 

--- a/tests/test_dml_operations.rs
+++ b/tests/test_dml_operations.rs
@@ -85,7 +85,7 @@ mod test_dml_operations {
     // UPDATE Tests
 
     #[serial]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_update_query() -> Result<()> {
         timefusion::test_utils::init_test_logging();
         let test_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
@@ -141,7 +141,7 @@ mod test_dml_operations {
     // DELETE Tests
 
     #[serial]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_delete_with_predicate() -> Result<()> {
         timefusion::test_utils::init_test_logging();
         let test_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
@@ -191,7 +191,7 @@ mod test_dml_operations {
     }
 
     #[serial]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_delete_all_matching() -> Result<()> {
         let test_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
         let cfg = create_test_config(&test_id);


### PR DESCRIPTION
Splits the truly zero-risk hunks out of #11 so they can land independently of the runtime/UDF rewrite.

## Changes
- **deploy.yml**: stop running the deploy workflow on `pull_request` (push-to-master only).
- **test_dml_operations.rs**: switch 3 DML tests to `#[tokio::test(flavor = "multi_thread")]`. Harmless on master; required by the `block_in_place` work in the follow-up PR.

## Out of scope (stays on #11 / follow-up)
- `block_in_place` runtime fix in `database.rs` + `dml.rs`
- `to_char` / `at_time_zone` / `to_json` UDF rewrites (has a null-handling bug to fix — see review on #11)
- Foyer dedicated runtimes
- CI policy hardening (drop `continue-on-error` on `--ignored`, un-ignore `test_postgres_integration`). That posture only works once the runtime fix lands, so it ships with the follow-up.

## Test plan
- [ ] CI green on this branch
- [ ] `cargo test --all-features` locally