### PR TITLE
fix: unhang delta writes from PGWire + require integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run all tests
-        timeout-minutes: 15
-        run: cargo test --all-features -- --include-ignored
+        run: cargo test --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run all tests
-        run: cargo test --all-features
+        timeout-minutes: 15
+        run: cargo test --all-features -- --include-ignored

--- a/src/database.rs
+++ b/src/database.rs
@@ -1786,25 +1786,30 @@ impl Database {
             // Hold the write lock for the entire operation to prevent concurrent conflicts
             let mut table = table_ref.write().await;
 
-            // Update the table state to get the latest version before writing
-            if let Err(e) = table.update_state().await {
-                debug!("Failed to update table state before write (attempt {}): {}", retry_count + 1, e);
-            }
+            let _ = table.update_state().await;
 
+            // block_in_place lets delta-rs's internal executor run without
+            // colliding with the outer PGWire tokio runtime. Without this the
+            // write hangs when triggered from a PGWire INSERT (issue #11).
+            let table_clone = table.clone();
+            let batches_clone = batches.clone();
+            let partitions_clone = schema.partitions.clone();
+            let writer_props_clone = writer_properties.clone();
             let write_span = tracing::trace_span!(parent: &span, "delta.write_operation", retry_attempt = retry_count + 1);
-            let write_result = async {
-                // Schema evolution enabled: new columns will be automatically added to the table
-                table
-                    .clone()
-                    .write(batches.clone())
-                    .with_partition_columns(schema.partitions.clone())
-                    .with_writer_properties(writer_properties.clone())
-                    .with_save_mode(deltalake::protocol::SaveMode::Append)
-                    .with_schema_mode(deltalake::operations::write::SchemaMode::Merge)
-                    .await
-            }
-            .instrument(write_span)
-            .await;
+            let write_result = write_span.in_scope(|| {
+                tokio::task::block_in_place(|| {
+                    let handle = tokio::runtime::Handle::current();
+                    handle.block_on(async move {
+                        table_clone
+                            .write(batches_clone)
+                            .with_partition_columns(partitions_clone)
+                            .with_writer_properties(writer_props_clone)
+                            .with_save_mode(deltalake::protocol::SaveMode::Append)
+                            .with_schema_mode(deltalake::operations::write::SchemaMode::Merge)
+                            .await
+                    })
+                })
+            });
 
             match write_result {
                 Ok(new_table) => {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1786,11 +1786,16 @@ impl Database {
             // Hold the write lock for the entire operation to prevent concurrent conflicts
             let mut table = table_ref.write().await;
 
-            let _ = table.update_state().await;
+            if let Err(e) = table.update_state().await {
+                debug!("Failed to update table state before write (attempt {}): {}", retry_count + 1, e);
+            }
 
             // block_in_place lets delta-rs's internal executor run without
             // colliding with the outer PGWire tokio runtime. Without this the
             // write hangs when triggered from a PGWire INSERT (issue #11).
+            // REQUIRES a multi-thread tokio runtime — panics on current_thread.
+            // All production paths (warp server, PGWire server) use multi-thread;
+            // tests calling this must use #[tokio::test(flavor = "multi_thread")].
             let table_clone = table.clone();
             let batches_clone = batches.clone();
             let partitions_clone = schema.partitions.clone();

--- a/src/dml.rs
+++ b/src/dml.rs
@@ -557,8 +557,8 @@ pub async fn perform_delta_delete(database: &Database, table_name: &str, project
 /// Common Delta operation logic
 async fn perform_delta_operation<F, Fut>(database: &Database, table_name: &str, project_id: &str, operation: F) -> Result<u64>
 where
-    F: FnOnce(deltalake::DeltaTable) -> Fut,
-    Fut: std::future::Future<Output = Result<(deltalake::DeltaTable, u64)>>,
+    F: FnOnce(deltalake::DeltaTable) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<(deltalake::DeltaTable, u64)>> + Send,
 {
     // Use resolve_table which routes to unified or custom table based on storage config
     let table_lock = database
@@ -572,7 +572,13 @@ where
     // overwrite with the stale snapshot from the closure's clone.
     let mut guard = table_lock.write().await;
     guard.update_state().await.map_err(|e| DataFusionError::Execution(format!("Failed to refresh table state: {}", e)))?;
-    let (new_table, rows_affected) = operation(guard.clone()).await?;
+    // block_in_place: same rationale as insert_records_batch in database.rs —
+    // delta-rs's internal executor conflicts with the outer PGWire runtime.
+    let table_clone = guard.clone();
+    let (new_table, rows_affected) = tokio::task::block_in_place(|| {
+        let handle = tokio::runtime::Handle::current();
+        handle.block_on(async move { operation(table_clone).await })
+    })?;
     *guard = new_table;
     Ok(rows_affected)
 }

--- a/src/dml.rs
+++ b/src/dml.rs
@@ -574,6 +574,7 @@ where
     guard.update_state().await.map_err(|e| DataFusionError::Execution(format!("Failed to refresh table state: {}", e)))?;
     // block_in_place: same rationale as insert_records_batch in database.rs —
     // delta-rs's internal executor conflicts with the outer PGWire runtime.
+    // REQUIRES a multi-thread tokio runtime — panics on current_thread.
     let table_clone = guard.clone();
     let (new_table, rows_affected) = tokio::task::block_in_place(|| {
         let handle = tokio::runtime::Handle::current();


### PR DESCRIPTION
Narrow runtime-safety fix for the PGWire write path. Original CI-hardening framing was wrong (see review notes below); this PR is now just the block_in_place wrapper.

## Why

delta-rs runs its own internal executor for writes. When invoked from inside another tokio runtime (the PGWire server, the warp server's request handlers), the nested executors can deadlock. The fix is to wrap the delta-rs call in `tokio::task::block_in_place` + `Handle::current().block_on(...)` so delta-rs runs on a blocking worker thread without contending with the outer runtime.

## Changes

- `src/database.rs::insert_records_batch` — wrap the delta-rs `.write()` call.
- `src/dml.rs::perform_delta_operation` — same wrapper for the UPDATE/DELETE path; tighten the closure bounds to `Send + 'static`.
- Comments document the multi-thread runtime requirement at each call site.

## Not in this PR (corrected from the original)

- The CI `--include-ignored` change was reverted after review. `test_postgres_integration` is not gated by `#[ignore]` on master — it was already running. `--include-ignored` would instead pull in 9 tests explicitly marked unsafe for shared CI (concurrent writes against shared Delta state, OnceLock-shared `delta_rs_api_test`, simultaneous-write-both-legs `buffer_consistency_test`, `tantivy_e2e_test`), some with 180s timeouts that wedge under GHA. A separate, narrower CI tightening would need to either target specific tests by name or factor the slow-but-stable suite into its own job.

## Test plan
- [ ] Format / Clippy / Check / Test green
- [ ] `test_postgres_integration` continues to pass (was already in the Test job; the runtime fix shouldn't change observable behavior on the current test, just make the path safer against future test additions and the UPDATE/DELETE path)