### PR TITLE
fix(docker): runtime stage glibc mismatch; switch to distroless/cc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,36 +35,24 @@ COPY schemas/ schemas/
 # Build the real release binary
 RUN cargo build --release
 
+# Pre-create app state dirs so they can be copied into the distroless
+# runtime (which has no shell to mkdir at runtime).
+RUN mkdir -p /app/queue_db /app/data
+
 ##############################
 #         Runtime Stage      #
 ##############################
-FROM ubuntu:20.04
+# Distroless/cc ships glibc 2.36 (matches builder), libssl3, and CA roots,
+# and runs as the built-in `nonroot` user (uid 65532). Previously this
+# stage was ubuntu:20.04 (glibc 2.31) which silently produced binaries
+# that crashed at startup with `GLIBC_2.32/2.33/2.34/2.35 not found`.
+FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /app
 
-# Install runtime dependencies
-RUN apt-get update && \
-    apt-get install -y ca-certificates libssl1.1 && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=builder --chown=nonroot:nonroot /app/target/release/timefusion /usr/local/bin/timefusion
+COPY --from=builder --chown=nonroot:nonroot /app/queue_db /app/queue_db
+COPY --from=builder --chown=nonroot:nonroot /app/data     /app/data
 
-# Create a non-root user
-RUN groupadd -r appgroup && useradd -r -g appgroup appuser
-
-# Create and set permissions for directories
-RUN mkdir -p /app/queue_db /app/data && \
-    chown -R appuser:appgroup /app /app/queue_db /app/data && \
-    chmod -R 775 /app /app/queue_db /app/data
-
-# Copy the compiled binary from the builder stage
-COPY --from=builder /app/target/release/timefusion /usr/local/bin/timefusion
-
-# Adjust ownership of the binary
-RUN chown appuser:appgroup /usr/local/bin/timefusion
-
-# Expose the required ports
 EXPOSE 80 5432
 
-# Switch to the non-root user
-USER appuser
-
-# Start the application
 ENTRYPOINT ["/usr/local/bin/timefusion"]


### PR DESCRIPTION
## Summary

Every recent timefusion image (verified back through `474bb07`, `9b16a7a`, `228e8f6`, `b12e708`, `f23d55f`) fails on startup with:

```
/usr/local/bin/timefusion: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found
/usr/local/bin/timefusion: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
/usr/local/bin/timefusion: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found
/usr/local/bin/timefusion: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found
```

Root cause: builder runs on \`rust:1.91-slim-bookworm\` (Debian 12, glibc 2.36), runtime was on \`ubuntu:20.04\` (glibc 2.31). CI didn't catch it because it never actually runs the published image.

Switching the runtime stage to \`gcr.io/distroless/cc-debian12:nonroot\`:
- ships glibc 2.36 (matches builder), libssl3, and CA roots
- runs as the built-in \`nonroot\` user (uid 65532)
- \`ldd\` on the binary shows only \`libc\`/\`libm\`/\`libgcc_s\` — no libssl link — so \`distroless/cc\` is sufficient

Image size drops **~588 MB → ~278 MB**.

\`/app/queue_db\` and \`/app/data\` are now pre-created in the builder stage and \`COPY --chown\`-ed into the distroless runtime (no shell available at build time in the runtime stage).

## Test plan
- [x] Smoke-built locally — binary launches, OpenTelemetry initializes, Foyer cache opens, WAL is created, control reaches the expected \`AWS_S3_BUCKET unset\` error rather than dying at the dynamic linker
- [ ] CI build + push to ghcr.io
- [ ] Deploy on CapRover and confirm \`SELECT version();\` over pgwire