### PR TITLE
perf(release): fat LTO + codegen-units=1 + strip symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,16 @@ harness = false
 default = []
 test = []
 
+# Release builds prioritize binary size + runtime speed over compile time.
+# fat LTO + single codegen-unit lets the optimizer inline across crates;
+# `strip = "symbols"` drops debug symbols. Roughly halves the published
+# image size, mostly by shrinking the embedded binary. CI compile time
+# goes up — acceptable for ghcr.io tags.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
 # Local patch: arrow-pg 0.13.0's UUID parameter decoder calls
 # `portal.parameter::<String>`, which pgwire rejects for the UUID OID and
 # breaks any client (Hasql, tokio-postgres binary) sending UUIDs. Vendored


### PR DESCRIPTION
## Summary

Cuts the published image size by ~44% by shrinking the embedded Rust binary.

The recent #19 swap from `ubuntu:20.04` to `gcr.io/distroless/cc-debian12:nonroot` already dropped the image from **588 MB → 278 MB** by switching base. The remaining ~250 MB was the binary itself — compiled without LTO and with debug symbols still in. This PR turns on:

- `lto = "fat"` — whole-program optimization across all crates
- `codegen-units = 1` — single translation unit lets LTO inline aggressively
- `strip = "symbols"` — drop debug symbols at link time

**Measured locally on captain (Docker 28, x86_64):**

| Image | Size |
|---|---|
| `ghcr.io/.../timefusion:474bb07` (pre-#19, ubuntu:20.04) | 588 MB |
| `timefusion:glibcfix-distroless` (post-#19, distroless, no LTO) | 278 MB |
| `timefusion:strip-lto` (this PR) | **155 MB** |

Binary launches cleanly (OpenTelemetry init → AWS handlers → Foyer cache → PGWire server up). No miscompile observed.

## Tradeoff

CI compile time goes up materially. Fat LTO + single codegen-unit means the optimizer treats the whole tree as one big translation unit with no final-pass parallelism. Local dev should keep using `cargo build` without `--release`; this only affects published `ghcr.io` tags.

## Test plan
- [x] Smoke-built locally — image is 155 MB
- [x] Smoke-launched the binary — process starts, no GLIBC/dyn-link errors, no LTO miscompile
- [ ] CI build succeeds
- [ ] Deploy on captain, verify write+read round-trip (PR #19 is already validated end-to-end with io_uring writes via custom seccomp profile)