### PR TITLE
fix: greedy memory pool default + batch queue default + CI smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,40 @@ jobs:
           cache-to: type=gha,mode=max
           debug: true
 
+      # Pull the published image and verify the binary actually starts.
+      # We previously shipped images that exited at the dynamic linker
+      # (GLIBC mismatch from a builder/runtime base skew) because nothing
+      # between "image pushed" and "CapRover deploys it" had ever executed
+      # the binary. With TIMEFUSION_ALLOW_INSECURE_AUTH the process can
+      # boot without secrets, reach the PGWire listen call, then we kill
+      # it. SIGTERM via `timeout` exits 124; anything else means the
+      # binary crashed and we must NOT deploy it.
+      - name: Smoke test pushed image
+        run: |
+          docker pull "$IMAGE_URL"
+          set +e
+          docker run --rm \
+            -e TIMEFUSION_ALLOW_INSECURE_AUTH=true \
+            -e AWS_S3_BUCKET=smoke -e AWS_REGION=us-east-1 \
+            -e AWS_ACCESS_KEY_ID=smoke -e AWS_SECRET_ACCESS_KEY=smoke \
+            -e RUST_LOG=info \
+            --name tf-smoke "$IMAGE_URL" &
+          PID=$!
+          # Give it 12s to reach the PGWire listen log; then kill.
+          for i in $(seq 1 12); do
+            if docker logs tf-smoke 2>&1 | grep -q "Listening on 0.0.0.0:5432"; then
+              echo "smoke: PGWire listening, image OK"
+              docker kill tf-smoke >/dev/null 2>&1 || true
+              wait $PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "smoke: binary never reached PGWire listen — last logs:"
+          docker logs tf-smoke 2>&1 | tail -40
+          docker kill tf-smoke >/dev/null 2>&1 || true
+          exit 1
+
       - id: deploy
         name: Deploy Image to CapRover
         uses: caprover/deploy-from-github@v1.1.2

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,7 +334,7 @@ pub struct CoreConfig {
     pub timefusion_table_prefix:         String,
     #[serde(default)]
     pub timefusion_config_database_url:  Option<String>,
-    #[serde(default)]
+    #[serde(default = "d_true")]
     pub enable_batch_queue:              bool,
     #[serde(default = "d_batch_queue_capacity")]
     pub timefusion_batch_queue_capacity: usize,
@@ -559,6 +559,30 @@ pub struct MaintenanceConfig {
     pub timefusion_recompress_schedule:        String,
 }
 
+/// Which DataFusion `MemoryPool` to back the runtime with.
+///
+/// - `Greedy` (default): all consumers share the full pool; first-come,
+///   first-served. Right for write-heavy workloads where INSERTs dominate
+///   and per-statement memory needs vary widely (e.g. one batch is 50 MB
+///   of Arrow, another is 5 MB). FairSpillPool would slice the pool into
+///   per-consumer quotas (`pool / num_consumers`) and reject any consumer
+///   whose batch exceeded its slot — bit us in prod on 2026-05-28 when
+///   ~30 concurrent INSERTs each got a ~76 MB slot and every 700-row
+///   batch hit `Memory limit exceeded`.
+/// - `FairSpill`: slot-per-consumer fairness. Better for ad-hoc query
+///   workloads with many concurrent users where one large query
+///   shouldn't starve the others. Not the right default for ingest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryPoolKind {
+    Greedy,
+    FairSpill,
+}
+
+fn d_memory_pool() -> MemoryPoolKind {
+    MemoryPoolKind::Greedy
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct MemoryConfig {
     #[serde(default = "d_mem_gb")]
@@ -567,6 +591,8 @@ pub struct MemoryConfig {
     pub timefusion_memory_fraction:              f64,
     #[serde(default)]
     pub timefusion_sort_spill_reservation_bytes: Option<usize>,
+    #[serde(default = "d_memory_pool")]
+    pub timefusion_memory_pool:                  MemoryPoolKind,
     #[serde(default = "d_true")]
     pub timefusion_tracing_record_metrics:       bool,
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1068,10 +1068,18 @@ impl Database {
         let _ = options.set("datafusion.execution.memory_fraction", &memory_fraction.to_string());
         let _ = options.set("datafusion.execution.sort_spill_reservation_bytes", &sort_spill_reservation_bytes.to_string());
 
-        // Create runtime environment with FairSpillPool for per-query memory fairness
+        // Memory pool: defaults to Greedy (single global cap, no per-consumer slicing)
+        // for ingest-heavy workloads. Opt into FairSpill for ad-hoc multi-tenant
+        // query workloads via TIMEFUSION_MEMORY_POOL=fair_spill.
         let pool_size = (memory_limit_bytes as f64 * memory_fraction) as usize;
+        let pool: Arc<dyn datafusion::execution::memory_pool::MemoryPool> = match self.config.memory.timefusion_memory_pool {
+            crate::config::MemoryPoolKind::Greedy =>
+                Arc::new(datafusion::execution::memory_pool::GreedyMemoryPool::new(pool_size)),
+            crate::config::MemoryPoolKind::FairSpill =>
+                Arc::new(datafusion::execution::memory_pool::FairSpillPool::new(pool_size)),
+        };
         let runtime_env = RuntimeEnvBuilder::new()
-            .with_memory_pool(Arc::new(datafusion::execution::memory_pool::FairSpillPool::new(pool_size)))
+            .with_memory_pool(pool)
             .build()
             .expect("Failed to create runtime environment");
 


### PR DESCRIPTION
## Summary

Three changes prompted by the 2026-05-28 prod incident where every monoscope INSERT bounced with `Memory limit exceeded: ... > 76MB hard limit`.

### 1. Memory pool default: `FairSpillPool` → `GreedyMemoryPool`

Root cause of the incident. `FairSpillPool` divides the pool into per-consumer slots (`pool_size / num_consumers`). Under ingest load with ~30 concurrent INSERT writers, every slot collapses to ~76 MB, and any 700-row Arrow batch exceeds that. The full pool was 28.8 GB but no individual consumer could use it.

`GreedyMemoryPool` shares a single global cap. First-come, first-served, no per-consumer slicing. Right model when INSERTs dominate.

Behind a new env var so the old behavior is still reachable: `TIMEFUSION_MEMORY_POOL=fair_spill` opts back into `FairSpillPool` for ad-hoc multi-tenant query workloads where you'd rather have fairness than throughput.

### 2. `enable_batch_queue` default: `false` → `true`

The previous `#[serde(default)]` left this at `bool::default() = false`. Deleting the env var silently disabled the batch queue (slow path). Now uses `d_true`, matching prod-correct behavior — same fix shape as the other `bool` fields in `MemoryConfig` (`timefusion_tracing_record_metrics`).

### 3. CI smoke step: run the published image before deploying

Triggered by the recent glibc / distroless fixes. Several broken images had been shipping for weeks because nothing in CI ever ran the binary — the build step only compiled and pushed. PR #19 fixed glibc, PR #20 shrunk size, but neither would have been *prevented* by the existing pipeline.

The new step:
- Pulls the image we just pushed
- Runs it with `TIMEFUSION_ALLOW_INSECURE_AUTH=true` + dummy AWS env
- Waits for `"Listening on 0.0.0.0:5432"` log
- Kills the container on success and proceeds to CapRover deploy
- Fails CI (and aborts the deploy) if 12s pass with no listen line

Catches dynamic-linker breaks, panic-at-startup bugs, missing-file-in-image bugs. Two-minute cost, blocks broken images from reaching prod.

## Test plan
- [x] Code compiles (locally; CI will reverify)
- [ ] CI build succeeds
- [ ] CI smoke step succeeds with this PR's image (validates the smoke step itself)
- [ ] CapRover deploy fires (via existing workflow)
- [ ] Re-enable `ENABLE_TIMEFUSION_WRITES=True` on monoscope, watch TF for absence of `Memory limit exceeded` lines