### PR TITLE
fmt: rustfmt single-line for memory pool match block

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1073,15 +1073,10 @@ impl Database {
         // query workloads via TIMEFUSION_MEMORY_POOL=fair_spill.
         let pool_size = (memory_limit_bytes as f64 * memory_fraction) as usize;
         let pool: Arc<dyn datafusion::execution::memory_pool::MemoryPool> = match self.config.memory.timefusion_memory_pool {
-            crate::config::MemoryPoolKind::Greedy =>
-                Arc::new(datafusion::execution::memory_pool::GreedyMemoryPool::new(pool_size)),
-            crate::config::MemoryPoolKind::FairSpill =>
-                Arc::new(datafusion::execution::memory_pool::FairSpillPool::new(pool_size)),
+            crate::config::MemoryPoolKind::Greedy => Arc::new(datafusion::execution::memory_pool::GreedyMemoryPool::new(pool_size)),
+            crate::config::MemoryPoolKind::FairSpill => Arc::new(datafusion::execution::memory_pool::FairSpillPool::new(pool_size)),
         };
-        let runtime_env = RuntimeEnvBuilder::new()
-            .with_memory_pool(pool)
-            .build()
-            .expect("Failed to create runtime environment");
+        let runtime_env = RuntimeEnvBuilder::new().with_memory_pool(pool).build().expect("Failed to create runtime environment");
 
         let runtime_env = Arc::new(runtime_env);
 


### PR DESCRIPTION
Follow-up to #21 — CI's Format check failed because my multi-line match arms didn't match rustfmt's preferred form. Single-line equivalents (semantically identical). No code behavior change.