### PR TITLE
fix(pgwire): rewrite ABORT -> ROLLBACK at simple-query entry

### DIFF
--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -177,6 +177,29 @@ impl LoggingSimpleQueryHandler {
     }
 }
 
+/// Rewrites Postgres synonyms that DataFusion's SQL parser doesn't accept.
+///
+/// `ABORT [ WORK | TRANSACTION ]` is a Postgres alias for `ROLLBACK`. Hasql's
+/// connection pool emits `ABORT` defensively on session acquisition to clear
+/// any leftover transaction state; without this rewrite, every Hasql client
+/// (e.g. monoscope) sees its first statement on each connection fail with
+/// `sql parser error: Expected: an SQL statement, found: ABORT`, which then
+/// poisons the whole session.
+fn rewrite_pg_synonyms(query: &str) -> std::borrow::Cow<'_, str> {
+    let stripped = query.trim_start();
+    if stripped.len() < 5 {
+        return std::borrow::Cow::Borrowed(query);
+    }
+    let (head, rest) = stripped.split_at(5);
+    if !head.eq_ignore_ascii_case("ABORT") {
+        return std::borrow::Cow::Borrowed(query);
+    }
+    if !(rest.is_empty() || rest.starts_with(|c: char| c.is_whitespace() || c == ';')) {
+        return std::borrow::Cow::Borrowed(query);
+    }
+    std::borrow::Cow::Owned(format!("ROLLBACK{}", rest))
+}
+
 fn classify_query(query: &str) -> (&'static str, &'static str) {
     let q = query.trim().to_lowercase();
     if q.starts_with("select") || q.contains(" select ") {
@@ -231,6 +254,8 @@ impl SimpleQueryHandler for LoggingSimpleQueryHandler {
         C::Error: Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
+        let rewritten = rewrite_pg_synonyms(query);
+        let query = rewritten.as_ref();
         let span = tracing::Span::current();
         let (query_type, operation) = classify_query(query);
         span.record("query.type", query_type);
@@ -240,6 +265,31 @@ impl SimpleQueryHandler for LoggingSimpleQueryHandler {
 
         let execute_span = tracing::trace_span!(parent: &span, "datafusion.execute");
         <DfSessionService as SimpleQueryHandler>::do_query(&self.inner, client, query).instrument(execute_span).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_pg_synonyms;
+
+    #[test]
+    fn abort_rewrites_to_rollback() {
+        assert_eq!(rewrite_pg_synonyms("ABORT"), "ROLLBACK");
+        assert_eq!(rewrite_pg_synonyms("ABORT;"), "ROLLBACK;");
+        assert_eq!(rewrite_pg_synonyms("  abort  "), "ROLLBACK  ");
+        assert_eq!(rewrite_pg_synonyms("Abort Work"), "ROLLBACK Work");
+        assert_eq!(rewrite_pg_synonyms("ABORT TRANSACTION;"), "ROLLBACK TRANSACTION;");
+    }
+
+    #[test]
+    fn non_abort_queries_are_borrowed_unchanged() {
+        // Cow::Borrowed is the fast path; we just check the content is identical.
+        assert_eq!(rewrite_pg_synonyms("SELECT 1"), "SELECT 1");
+        assert_eq!(rewrite_pg_synonyms("BEGIN"), "BEGIN");
+        assert_eq!(rewrite_pg_synonyms("ROLLBACK"), "ROLLBACK");
+        // Don't false-match identifiers/columns that start with ABORT.
+        assert_eq!(rewrite_pg_synonyms("SELECT aborted FROM t"), "SELECT aborted FROM t");
+        assert_eq!(rewrite_pg_synonyms("ABORTED"), "ABORTED");
     }
 }
 


### PR DESCRIPTION
## Summary

Discovered today during monoscope dual-write rollout: 100% write failure with

```
sql parser error: Expected: an SQL statement, found: ABORT
```

Hasql's connection pool emits `ABORT` defensively on session acquisition to clear leftover transaction state. DataFusion's SQL parser doesn't recognize `ABORT` (the Postgres synonym for `ROLLBACK`), so every Hasql-based client (monoscope being the immediate one) sees its first statement on each newly acquired connection fail, then the session is poisoned and subsequent INSERTs never run.

## Fix

Rewrite at the `LoggingSimpleQueryHandler` entry (TF's existing pgwire middleware layer) — no parser changes, no vendor patches. The rewriter:

- Detects `ABORT` followed by EOL / whitespace / semicolon (so identifiers like `aborted`, `abort_count` don't false-match)
- Returns `Cow::Borrowed` on the fast path (every non-ABORT query pays just a 5-byte case-insensitive prefix check)
- Preserves the rest of the statement (`ABORT WORK` → `ROLLBACK WORK`, `ABORT TRANSACTION;` → `ROLLBACK TRANSACTION;`)

Unit tests cover the positive and negative cases.

## Why simple-query is sufficient

Hasql emits BEGIN/COMMIT/ROLLBACK/ABORT via the simple-query protocol because they don't take parameters — no need for prepare. The `QueryError "ABORT" []` format in monoscope's error log (`[]` = no params) confirms this. The fix lands in the simple-query path where it's seen.

If a future client sends ABORT through the extended-query protocol, this PR doesn't help; we'd then add the same rewrite in `LoggingExtendedQueryHandler`'s `query_parser`. Left as a follow-up only if needed.

## Test plan

- [x] Unit tests (positive + negative cases)
- [ ] CI green
- [ ] Smoke step (added in #21) passes
- [ ] Deploy on captain
- [ ] Flip `ENABLE_TIMEFUSION_WRITES=True` on monoscope, watch for absence of `TIMEFUSION_WRITE_FAILED` and presence of `delta.insert_batch` events
