### PR TITLE
fix(write-layer): use flush_all_now under memory pressure

### DIFF
--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -328,14 +328,21 @@ impl BufferedWriteLayer {
 
     #[instrument(skip(self, batches), fields(project_id, table_name, batch_count))]
     pub async fn insert(&self, project_id: &str, table_name: &str, batches: Vec<RecordBatch>) -> anyhow::Result<()> {
-        // Check memory pressure and trigger early flush if needed
+        // Check memory pressure and trigger early flush if needed.
+        // We use `flush_all_now` (not `flush_completed_buckets`) here because
+        // under memory pressure the data consuming the budget is almost
+        // always the *current* bucket — `flush_completed_buckets` only
+        // drains buckets older than `bucket_duration_secs`, which leaves
+        // the current-bucket pressure unrelieved and the next insert
+        // still fails. `flush_all_now` includes the current bucket and
+        // matches what an operator would do manually in this state.
         if self.is_memory_pressure() {
             warn!(
-                "Memory pressure detected ({}MB >= {}MB), triggering early flush",
+                "Memory pressure detected ({}MB >= {}MB), triggering early flush_all_now",
                 self.effective_memory_bytes() / (1024 * 1024),
                 self.config.buffer.max_memory_mb()
             );
-            if let Err(e) = self.flush_completed_buckets().await {
+            if let Err(e) = self.flush_all_now().await {
                 error!("Early flush due to memory pressure failed: {}", e);
             }
         }


### PR DESCRIPTION
Today's smoking gun for monoscope dual-write failures.

`BufferedWriteLayer::insert()` triggers an early flush when memory pressure is detected — but it calls `flush_completed_buckets()`, which only drains buckets with `bucket_id < current_bucket_id`. Under sustained ingest, all incoming writes go into the *current* bucket; the current bucket is by definition never 'completed', so the pressure-triggered flush does nothing, the buffer counter doesn't decrement, and the very next insert fails with `Memory limit exceeded: X + Y > Z hard limit`.

Observed in production:
- 7 min of monoscope writes → 140 GB tracked MemBuffer usage (on a 128 GB host)
- 421 `flush_completed_buckets` calls fired during that window
- 128 `Memory pressure detected` warnings
- **0 buckets evicted**

Default `TIMEFUSION_BUCKET_DURATION_SECS` is 600 (10 min); monoscope writes carry near-now timestamps so 100% of traffic lands in the current bucket — there's literally nothing for `flush_completed_buckets` to drain.

## Fix

Switch the pressure-path flush to `flush_all_now()`, which includes the current bucket. This matches the warning log's intent ('triggering early flush') and is what an operator would do manually in this state. The scheduled eviction task keeps using `flush_completed_buckets` so the healthy-load path doesn't pay the small-batch parquet-file overhead.

## Test plan
- [ ] CI green + smoke step (from #21) passes
- [ ] Auto-deploy to captain
- [ ] Re-enable `ENABLE_TIMEFUSION_WRITES=True` and verify TF eviction count grows, `Memory limit exceeded` drops to ~zero, `TIMEFUSION_WRITE_FAILED` on monoscope drops to ~zero