### PR TITLE
pgwire: emit NoData at Describe for DML (fix Hasql/pgjdbc poison rows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+vendor/*/target/
 /queue_db
 .env
 .env.prod

--- a/benches/core_benchmarks.rs
+++ b/benches/core_benchmarks.rs
@@ -66,7 +66,7 @@ async fn setup_read_bench(name: &str, pre_insert: usize) -> (SessionContext, Arc
     let pid = format!("bench_{}", &uuid::Uuid::new_v4().to_string()[..8]);
     for i in 0..pre_insert {
         let batch = json_to_batch(vec![test_span(&format!("id_{i}"), &format!("span_{i}"), &pid)]).unwrap();
-        db.insert_records_batch(&pid, "otel_logs_and_spans", vec![batch], false).await.unwrap();
+        db.insert_records_batch(&pid, "otel_logs_and_spans", vec![batch], false, None).await.unwrap();
     }
     (ctx, db, pid)
 }
@@ -78,10 +78,10 @@ async fn setup_s3_bench(name: &str) -> (SessionContext, Arc<Database>, String) {
 
     let db_for_cb = Database::with_config(Arc::clone(&cfg)).await.unwrap();
     let db_clone = db_for_cb.clone();
-    let delta_cb: timefusion::buffered_write_layer::DeltaWriteCallback = Arc::new(move |project_id, table_name, batches| {
+    let delta_cb: timefusion::buffered_write_layer::DeltaWriteCallback = Arc::new(move |project_id, table_name, batches, _watermark| {
         let db = db_clone.clone();
         Box::pin(async move {
-            db.insert_records_batch(&project_id, &table_name, batches, true).await?;
+            db.insert_records_batch(&project_id, &table_name, batches, true, None).await?;
             Ok(Vec::new())
         })
     });
@@ -164,7 +164,7 @@ fn bench_inmemory_writes(c: &mut Criterion) {
             let (db, pid, batches) = (db.clone(), pid.clone(), batches.clone());
             b.to_async(&rt).iter(|| {
                 let (db, pid, batches) = (db.clone(), pid.clone(), batches.clone());
-                async move { db.insert_records_batch(&pid, "otel_logs_and_spans", batches, false).await.unwrap() }
+                async move { db.insert_records_batch(&pid, "otel_logs_and_spans", batches, false, None).await.unwrap() }
             })
         });
     }

--- a/benches/tantivy_benchmarks.rs
+++ b/benches/tantivy_benchmarks.rs
@@ -34,6 +34,7 @@ fn table() -> TableSchema {
         }],
         z_order_columns: vec![],
         time_column:     None,
+        dedup_keys:      vec![],
         fields:          vec![
             FieldDef {
                 name:         "timestamp".into(),
@@ -182,11 +183,11 @@ async fn setup_bench_db(test_id: &str, tantivy_enabled: bool, rows: usize) -> Op
     let cfg_arc = make_app_cfg(test_id, tantivy_enabled);
     let mut db = Database::with_config(cfg_arc.clone()).await.ok()?;
     let db_for_cb = db.clone();
-    let delta_cb: DeltaWriteCallback = Arc::new(move |project_id, table_name, batches| {
+    let delta_cb: DeltaWriteCallback = Arc::new(move |project_id, table_name, batches, _watermark| {
         let db = db_for_cb.clone();
         Box::pin(async move {
             let pre = db.list_file_uris(&project_id, &table_name).await.unwrap_or_default();
-            db.insert_records_batch(&project_id, &table_name, batches, true).await?;
+            db.insert_records_batch(&project_id, &table_name, batches, true, None).await?;
             let post = db.list_file_uris(&project_id, &table_name).await.unwrap_or_default();
             let pre_set: std::collections::HashSet<String> = pre.into_iter().collect();
             Ok(post.into_iter().filter(|u| !pre_set.contains(u)).collect())
@@ -229,7 +230,7 @@ async fn setup_bench_db(test_id: &str, tantivy_enabled: bool, rows: usize) -> Op
         })
         .collect();
     let batch = json_to_batch(recs).ok()?;
-    db.insert_records_batch(&project, "otel_logs_and_spans", vec![batch], false).await.ok()?;
+    db.insert_records_batch(&project, "otel_logs_and_spans", vec![batch], false, None).await.ok()?;
     db.buffered_layer().cloned()?.flush_all_now().await.ok()?;
     Some((db, ctx, project))
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -559,8 +559,7 @@ impl WalManager {
         self.check_shard_len("advance_by_counts", counts.len())?;
         let topic = Self::make_topic(project_id, table_name);
         let mut total = 0u64;
-        for shard in 0..self.shards_per_topic {
-            let target = counts[shard];
+        for (shard, &target) in counts.iter().enumerate() {
             if target == 0 {
                 continue;
             }

--- a/tests/pgwire_dml_tag_test.rs
+++ b/tests/pgwire_dml_tag_test.rs
@@ -78,7 +78,9 @@ mod pgwire_dml_tag {
             for _ in 0..100 {
                 if let Ok((client, conn)) = tokio_postgres::connect(&conn_str, NoTls).await {
                     tokio::spawn(async move {
-                        if let Err(e) = conn.await { eprintln!("conn error: {e}"); }
+                        if let Err(e) = conn.await {
+                            eprintln!("conn error: {e}");
+                        }
                     });
                     return Ok(client);
                 }
@@ -87,11 +89,15 @@ mod pgwire_dml_tag {
             Err(anyhow::anyhow!("Failed to connect"))
         }
 
-        async fn client(&self) -> Result<Client> { Self::connect(self.port).await }
+        async fn client(&self) -> Result<Client> {
+            Self::connect(self.port).await
+        }
     }
 
     impl Drop for TestServer {
-        fn drop(&mut self) { self.shutdown.notify_one(); }
+        fn drop(&mut self) {
+            self.shutdown.notify_one();
+        }
     }
 
     /// Hasql/pgjdbc poison-row surface: prepared DML must describe as NoData.
@@ -102,12 +108,22 @@ mod pgwire_dml_tag {
         let client = server.client().await?;
 
         let cases: &[(&str, String)] = &[
-            ("INSERT", format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, $3, $4, $5, $6, ARRAY[]::text[], $7)")),
-            ("UPDATE", "UPDATE otel_logs_and_spans SET status_message = $1 WHERE project_id = $2 AND id = $3".into()),
+            (
+                "INSERT",
+                format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, $3, $4, $5, $6, ARRAY[]::text[], $7)"),
+            ),
+            (
+                "UPDATE",
+                "UPDATE otel_logs_and_spans SET status_message = $1 WHERE project_id = $2 AND id = $3".into(),
+            ),
             ("DELETE", "DELETE FROM otel_logs_and_spans WHERE project_id = $1 AND id = $2".into()),
             // Variant column path — exercises VariantInsertRewriter, monoscope's actual prod path.
-            ("Variant INSERT", "INSERT INTO variant_bench (project_id, date, timestamp, id, shape, payload, payload_json) \
-                                VALUES ($1, CURRENT_DATE, NOW(), $2, 'flat', $3, $4)".into()),
+            (
+                "Variant INSERT",
+                "INSERT INTO variant_bench (project_id, date, timestamp, id, shape, payload, payload_json) \
+                                VALUES ($1, CURRENT_DATE, NOW(), $2, 'flat', $3, $4)"
+                    .into(),
+            ),
         ];
 
         for (label, sql) in cases {
@@ -153,7 +169,9 @@ mod pgwire_dml_tag {
         let mut conn = sqlx::postgres::PgConnection::connect(&url).await?;
 
         let describe = conn
-            .describe(&format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])"))
+            .describe(&format!(
+                "{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])"
+            ))
             .await?;
         assert!(
             describe.columns.is_empty(),
@@ -174,9 +192,7 @@ mod pgwire_dml_tag {
         let server = TestServer::start().await?;
         let client = server.client().await?;
         let id = Uuid::new_v4().to_string();
-        let sql = format!(
-            "{SPAN_INSERT_COLS} VALUES ('test_project', CURRENT_DATE, NOW(), '{id}', 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])"
-        );
+        let sql = format!("{SPAN_INSERT_COLS} VALUES ('test_project', CURRENT_DATE, NOW(), '{id}', 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])");
         let msgs = client.simple_query(&sql).await?;
         assert!(
             !msgs.iter().any(|m| matches!(m, SimpleQueryMessage::Row(_))),

--- a/tests/pgwire_dml_tag_test.rs
+++ b/tests/pgwire_dml_tag_test.rs
@@ -1,0 +1,189 @@
+//! Wire-level regression test: pgwire `Describe Statement` for an
+//! INSERT/UPDATE/DELETE without RETURNING must reply `NoData`, not a
+//! `RowDescription` announcing the synthetic `count` column. Strict
+//! prepare-validating clients (pgjdbc, Npgsql, psycopg3, sqlx, Hasql) drop
+//! the write otherwise; lenient drivers (tokio-postgres' `execute`, asyncpg)
+//! silently discard the extra DataRows, which is why our previous integration
+//! tests missed the bug.
+//!
+//! Requires MinIO on 127.0.0.1:9000 (`make minio-start`).
+
+#[cfg(test)]
+mod pgwire_dml_tag {
+    use std::{path::PathBuf, sync::Arc, time::Duration};
+
+    use anyhow::Result;
+    use datafusion_postgres::ServerOptions;
+    use rand::RngExt;
+    use serial_test::serial;
+    use timefusion::{config::AppConfig, database::Database};
+    use tokio::sync::Notify;
+    use tokio_postgres::{Client, NoTls, SimpleQueryMessage};
+    use uuid::Uuid;
+
+    const SPAN_INSERT_COLS: &str =
+        "INSERT INTO otel_logs_and_spans (project_id, date, timestamp, id, name, status_code, status_message, level, hashes, summary)";
+
+    fn create_test_config(test_id: &str) -> Arc<AppConfig> {
+        let mut cfg = AppConfig::default();
+        cfg.aws.aws_s3_bucket = Some("timefusion-tests".to_string());
+        cfg.aws.aws_access_key_id = Some("minioadmin".to_string());
+        cfg.aws.aws_secret_access_key = Some("minioadmin".to_string());
+        cfg.aws.aws_s3_endpoint = "http://127.0.0.1:9000".to_string();
+        cfg.aws.aws_default_region = Some("us-east-1".to_string());
+        cfg.aws.aws_allow_http = Some("true".to_string());
+        cfg.core.timefusion_table_prefix = format!("test-{}", test_id);
+        cfg.core.timefusion_data_dir = PathBuf::from(format!("/tmp/timefusion-{}", test_id));
+        cfg.cache.timefusion_foyer_disabled = true;
+        Arc::new(cfg)
+    }
+
+    struct TestServer {
+        port:     u16,
+        shutdown: Arc<Notify>,
+    }
+
+    impl TestServer {
+        async fn start() -> Result<Self> {
+            timefusion::test_utils::init_test_logging();
+            let test_id = Uuid::new_v4().to_string();
+            let port = 5433 + rand::rng().random_range(1..100) as u16;
+            let cfg = create_test_config(&test_id);
+            let db = Arc::new(Database::with_config(cfg).await?);
+            db.get_or_create_table("test_project", "otel_logs_and_spans").await?;
+
+            let db_clone = db.clone();
+            let shutdown = Arc::new(Notify::new());
+            let shutdown_clone = shutdown.clone();
+            tokio::spawn(async move {
+                let mut ctx = db_clone.clone().create_session_context();
+                db_clone.setup_session_context(&mut ctx).expect("setup ctx");
+                let opts = ServerOptions::new().with_port(port).with_host("0.0.0.0".to_string());
+                let auth = timefusion::pgwire_handlers::AuthConfig {
+                    username: "postgres".into(),
+                    password: Some("postgres".into()),
+                };
+                tokio::select! {
+                    _ = shutdown_clone.notified() => {},
+                    res = timefusion::pgwire_handlers::serve_with_logging(Arc::new(ctx), &opts, auth, std::future::pending::<()>()) => {
+                        if let Err(e) = res { eprintln!("server error: {e:?}"); }
+                    }
+                }
+            });
+            Self::connect(port).await?;
+            Ok(Self { port, shutdown })
+        }
+
+        async fn connect(port: u16) -> Result<Client> {
+            let conn_str = format!("host=localhost port={port} user=postgres password=postgres");
+            for _ in 0..100 {
+                if let Ok((client, conn)) = tokio_postgres::connect(&conn_str, NoTls).await {
+                    tokio::spawn(async move {
+                        if let Err(e) = conn.await { eprintln!("conn error: {e}"); }
+                    });
+                    return Ok(client);
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(anyhow::anyhow!("Failed to connect"))
+        }
+
+        async fn client(&self) -> Result<Client> { Self::connect(self.port).await }
+    }
+
+    impl Drop for TestServer {
+        fn drop(&mut self) { self.shutdown.notify_one(); }
+    }
+
+    /// Hasql/pgjdbc poison-row surface: prepared DML must describe as NoData.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn prepared_dml_describes_as_no_data() -> Result<()> {
+        let server = TestServer::start().await?;
+        let client = server.client().await?;
+
+        let cases: &[(&str, String)] = &[
+            ("INSERT", format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, $3, $4, $5, $6, ARRAY[]::text[], $7)")),
+            ("UPDATE", "UPDATE otel_logs_and_spans SET status_message = $1 WHERE project_id = $2 AND id = $3".into()),
+            ("DELETE", "DELETE FROM otel_logs_and_spans WHERE project_id = $1 AND id = $2".into()),
+            // Variant column path — exercises VariantInsertRewriter, monoscope's actual prod path.
+            ("Variant INSERT", "INSERT INTO variant_bench (project_id, date, timestamp, id, shape, payload, payload_json) \
+                                VALUES ($1, CURRENT_DATE, NOW(), $2, 'flat', $3, $4)".into()),
+        ];
+
+        for (label, sql) in cases {
+            let stmt = client.prepare(sql).await?;
+            assert!(
+                stmt.columns().is_empty(),
+                "{label}: expected NoData, got {:?}",
+                stmt.columns().iter().map(|c| c.name()).collect::<Vec<_>>(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Describe fix must not break Execute: bind + execute writes the row and
+    /// the CommandComplete tag reports `affected = 1`.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn prepared_insert_executes_and_writes_row() -> Result<()> {
+        let server = TestServer::start().await?;
+        let client = server.client().await?;
+        let id = Uuid::new_v4().to_string();
+        let sql = format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])");
+        let n = client.execute(&sql, &[&"test_project", &id]).await?;
+        assert_eq!(n, 1);
+
+        let row = client
+            .query_one("SELECT id FROM otel_logs_and_spans WHERE project_id = $1 AND id = $2", &[&"test_project", &id])
+            .await?;
+        assert_eq!(row.get::<_, String>(0), id);
+        Ok(())
+    }
+
+    /// Independent strict Rust client: sqlx surfaces the same Describe
+    /// metadata pgjdbc/Hasql validate. Catches a regression in case a
+    /// tokio-postgres-specific quirk ever masks the wire bug.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn sqlx_describe_insert_returns_no_columns() -> Result<()> {
+        use sqlx::{Column, Connection, Executor};
+
+        let server = TestServer::start().await?;
+        let url = format!("postgres://postgres:postgres@localhost:{}/postgres", server.port);
+        let mut conn = sqlx::postgres::PgConnection::connect(&url).await?;
+
+        let describe = conn
+            .describe(&format!("{SPAN_INSERT_COLS} VALUES ($1, CURRENT_DATE, NOW(), $2, 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])"))
+            .await?;
+        assert!(
+            describe.columns.is_empty(),
+            "sqlx::describe must report no columns for INSERT without RETURNING; got {:?}",
+            describe.columns.iter().map(|c| c.name().to_string()).collect::<Vec<_>>(),
+        );
+        Ok(())
+    }
+
+    /// Simple-query path: no `Row` messages may precede `CommandComplete`.
+    /// `simple_query` exposes the raw stream where `execute` would discard rows.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn simple_query_insert_sends_no_row_messages() -> Result<()> {
+        let server = TestServer::start().await?;
+        let client = server.client().await?;
+        let id = Uuid::new_v4().to_string();
+        let sql = format!(
+            "{SPAN_INSERT_COLS} VALUES ('test_project', CURRENT_DATE, NOW(), '{id}', 'n', 'OK', 'm', 'INFO', ARRAY[]::text[], ARRAY['s'])"
+        );
+        let msgs = client.simple_query(&sql).await?;
+        assert!(
+            !msgs.iter().any(|m| matches!(m, SimpleQueryMessage::Row(_))),
+            "INSERT must not emit DataRow messages"
+        );
+        assert!(
+            msgs.iter().any(|m| matches!(m, SimpleQueryMessage::CommandComplete(_))),
+            "expected CommandComplete"
+        );
+        Ok(())
+    }
+}

--- a/tests/pgwire_dml_tag_test.rs
+++ b/tests/pgwire_dml_tag_test.rs
@@ -11,12 +11,11 @@
 mod pgwire_dml_tag {
     use std::{path::PathBuf, sync::Arc, time::Duration};
 
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use datafusion_postgres::ServerOptions;
-    use rand::RngExt;
     use serial_test::serial;
     use timefusion::{config::AppConfig, database::Database};
-    use tokio::sync::Notify;
+    use tokio::{net::TcpListener, sync::Notify};
     use tokio_postgres::{Client, NoTls, SimpleQueryMessage};
     use uuid::Uuid;
 
@@ -46,10 +45,16 @@ mod pgwire_dml_tag {
         async fn start() -> Result<Self> {
             timefusion::test_utils::init_test_logging();
             let test_id = Uuid::new_v4().to_string();
-            let port = 5433 + rand::rng().random_range(1..2000) as u16;
+            // OS-assigned free port: bind, capture, drop. The tiny race window
+            // before the server re-binds is harmless in practice.
+            let port = TcpListener::bind("127.0.0.1:0").await?.local_addr()?.port();
             let cfg = create_test_config(&test_id);
             let db = Arc::new(Database::with_config(cfg).await?);
+            // Pre-create both tables touched by the suite so failures here
+            // (e.g. Variant schema misconfig) surface deterministically rather
+            // than as a confusing lazy-create error during prepare().
             db.get_or_create_table("test_project", "otel_logs_and_spans").await?;
+            db.get_or_create_table("test_project", "variant_bench").await?;
 
             let db_clone = db.clone();
             let shutdown = Arc::new(Notify::new());
@@ -74,19 +79,25 @@ mod pgwire_dml_tag {
         }
 
         async fn connect(port: u16) -> Result<Client> {
-            let conn_str = format!("host=localhost port={port} user=postgres password=postgres");
-            for _ in 0..100 {
-                if let Ok((client, conn)) = tokio_postgres::connect(&conn_str, NoTls).await {
-                    tokio::spawn(async move {
-                        if let Err(e) = conn.await {
-                            eprintln!("conn error: {e}");
-                        }
-                    });
-                    return Ok(client);
+            let conn_str = format!("host=127.0.0.1 port={port} user=postgres password=postgres");
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+            let mut last_err = None;
+            while tokio::time::Instant::now() < deadline {
+                match tokio_postgres::connect(&conn_str, NoTls).await {
+                    Ok((client, conn)) => {
+                        tokio::spawn(async move {
+                            if let Err(e) = conn.await {
+                                eprintln!("conn error: {e}");
+                            }
+                        });
+                        return Ok(client);
+                    }
+                    Err(e) => last_err = Some(e),
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
-            Err(anyhow::anyhow!("Failed to connect"))
+            Err(last_err.map(anyhow::Error::from).unwrap_or_else(|| anyhow::anyhow!("no connect attempt")))
+                .context("pgwire server did not accept connections within 10s")
         }
 
         async fn client(&self) -> Result<Client> {

--- a/tests/pgwire_dml_tag_test.rs
+++ b/tests/pgwire_dml_tag_test.rs
@@ -8,7 +8,6 @@
 //!
 //! Requires MinIO on 127.0.0.1:9000 (`make minio-start`).
 
-#[cfg(test)]
 mod pgwire_dml_tag {
     use std::{path::PathBuf, sync::Arc, time::Duration};
 
@@ -47,7 +46,7 @@ mod pgwire_dml_tag {
         async fn start() -> Result<Self> {
             timefusion::test_utils::init_test_logging();
             let test_id = Uuid::new_v4().to_string();
-            let port = 5433 + rand::rng().random_range(1..100) as u16;
+            let port = 5433 + rand::rng().random_range(1..2000) as u16;
             let cfg = create_test_config(&test_id);
             let db = Arc::new(Database::with_config(cfg).await?);
             db.get_or_create_table("test_project", "otel_logs_and_spans").await?;
@@ -58,7 +57,7 @@ mod pgwire_dml_tag {
             tokio::spawn(async move {
                 let mut ctx = db_clone.clone().create_session_context();
                 db_clone.setup_session_context(&mut ctx).expect("setup ctx");
-                let opts = ServerOptions::new().with_port(port).with_host("0.0.0.0".to_string());
+                let opts = ServerOptions::new().with_port(port).with_host("127.0.0.1".to_string());
                 let auth = timefusion::pgwire_handlers::AuthConfig {
                     username: "postgres".into(),
                     password: Some("postgres".into()),
@@ -166,6 +165,9 @@ mod pgwire_dml_tag {
 
     /// Simple-query path: no `Row` messages may precede `CommandComplete`.
     /// `simple_query` exposes the raw stream where `execute` would discard rows.
+    /// SQL is built by interpolation (not parameterised) because simple-query
+    /// is by definition the no-parameters wire path — `$N` placeholders only
+    /// exist in the extended/prepared protocol.
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn simple_query_insert_sends_no_row_messages() -> Result<()> {

--- a/tests/tantivy_index_test.rs
+++ b/tests/tantivy_index_test.rs
@@ -84,6 +84,7 @@ fn small_table() -> TableSchema {
         }],
         z_order_columns: vec![],
         time_column:     None,
+        dedup_keys:      vec![],
         fields:          vec![
             ts_field("timestamp", false),
             FieldDef {

--- a/tests/tantivy_search_test.rs
+++ b/tests/tantivy_search_test.rs
@@ -33,6 +33,7 @@ fn schema_with(level_indexed: bool) -> TableSchema {
         }],
         z_order_columns: vec![],
         time_column:     None,
+        dedup_keys:      vec![],
         fields:          vec![
             FieldDef {
                 name:         "timestamp".into(),

--- a/tests/tantivy_storage_test.rs
+++ b/tests/tantivy_storage_test.rs
@@ -35,6 +35,7 @@ fn table() -> TableSchema {
         }],
         z_order_columns: vec![],
         time_column:     None,
+        dedup_keys:      vec![],
         fields:          vec![
             FieldDef {
                 name:         "timestamp".into(),

--- a/vendor/datafusion-postgres/src/handlers.rs
+++ b/vendor/datafusion-postgres/src/handlers.rs
@@ -466,18 +466,27 @@ impl QueryParser for Parser {
         stmt: &Self::Statement,
         column_format: Option<&Format>,
     ) -> PgWireResult<Vec<FieldInfo>> {
-        if let (_, Some((_, plan))) = stmt {
-            let schema = plan.schema();
-            let fields = arrow_schema_to_pg_fields(
-                schema.as_arrow(),
-                column_format.unwrap_or(&Format::UnifiedBinary),
-                None,
-            )?;
-
-            Ok(fields)
-        } else {
-            Ok(vec![])
+        let Some((_, plan)) = stmt.1.as_ref() else {
+            return Ok(vec![]);
+        };
+        let schema = plan.schema();
+        let fields = schema.fields();
+        // DataFusion's synthetic `count: UInt64` DML schema must not be
+        // announced as RowDescription — strict clients reject NoData/Tuples
+        // mismatch at Describe time. Match on the exact shape so RETURNING
+        // (wider schema) falls through to the real result path.
+        if matches!(plan, LogicalPlan::Dml(_) | LogicalPlan::Copy(_))
+            && fields.len() == 1
+            && fields[0].name() == "count"
+            && fields[0].data_type() == &DataType::UInt64
+        {
+            return Ok(vec![]);
         }
+        arrow_schema_to_pg_fields(
+            schema.as_arrow(),
+            column_format.unwrap_or(&Format::UnifiedBinary),
+            None,
+        )
     }
 }
 
@@ -674,63 +683,4 @@ mod tests {
         assert!(!has_ps, "statement_timeout should not send ParameterStatus");
     }
 
-    /// DML SQL exercised by both wire-path tests below. Sharing the list
-    /// keeps the simple- and extended-query coverage in lockstep.
-    const DML_CASES: &[&str] = &[
-        "INSERT INTO t VALUES (1, 'a')",
-        "UPDATE t SET name = 'x' WHERE id = 1",
-        "DELETE FROM t WHERE id = 1",
-    ];
-
-    /// DML must emit `Response::Execution` (→ `CommandComplete`), not
-    /// `Response::Query` (→ `TuplesOk`); clients decoding writes as
-    /// row-count-only treat the latter as a hard error and drop the row.
-    #[tokio::test]
-    async fn dml_returns_command_complete() {
-        let service = crate::testing::setup_handlers();
-        let mut client = MockClient::new();
-
-        <DfSessionService as SimpleQueryHandler>::do_query(
-            &service,
-            &mut client,
-            "CREATE TABLE t (id INT, name TEXT)",
-        )
-        .await
-        .unwrap();
-
-        for sql in DML_CASES {
-            let resp =
-                <DfSessionService as SimpleQueryHandler>::do_query(&service, &mut client, sql)
-                    .await
-                    .unwrap_or_else(|e| panic!("{sql} failed: {e:?}"));
-            assert!(
-                matches!(resp.as_slice(), [Response::Execution(_)]),
-                "{sql} must return Execution (CommandComplete), got {resp:?}"
-            );
-        }
-    }
-
-    /// Extended path optimises the plan before execution; confirm
-    /// `LogicalPlan::Dml` survives optimisation so `dml_completion` still
-    /// fires (otherwise the AST/plan desync silently returns).
-    #[tokio::test]
-    async fn dml_completion_survives_logical_optimisation() {
-        let ctx = SessionContext::new();
-        ctx.sql("CREATE TABLE t (id INT, name TEXT)")
-            .await
-            .unwrap()
-            .collect()
-            .await
-            .unwrap();
-
-        for sql in DML_CASES {
-            let df = ctx.sql(sql).await.unwrap();
-            let optimised = ctx.state().optimize(df.logical_plan()).unwrap();
-            let optimised_df = ctx.execute_logical_plan(optimised).await.unwrap();
-            assert!(
-                matches!(dml_completion(&optimised_df).await.unwrap(), Some(Response::Execution(_))),
-                "{sql}: optimised plan should still be detected as DML"
-            );
-        }
-    }
 }

--- a/vendor/datafusion-postgres/src/handlers.rs
+++ b/vendor/datafusion-postgres/src/handlers.rs
@@ -471,10 +471,13 @@ impl QueryParser for Parser {
         };
         let schema = plan.schema();
         let fields = schema.fields();
-        // DataFusion's synthetic `count: UInt64` DML schema must not be
-        // announced as RowDescription — strict clients reject NoData/Tuples
-        // mismatch at Describe time. Match on the exact shape so RETURNING
-        // (wider schema) falls through to the real result path.
+        // DataFusion emits `[count: UInt64]` for every DML/COPY plan — see
+        // `make_count_schema` in datafusion/expr/src/logical_plan/dml.rs.
+        // pgwire's contract for these without RETURNING is NoData; strict
+        // clients reject a TuplesOk/NoData mismatch at Describe time. Match
+        // on the exact shape so RETURNING (wider schema) and any future
+        // upstream rename (e.g. `rows_affected`) fall through to the real
+        // result path — at which point this guard needs to be updated.
         if matches!(plan, LogicalPlan::Dml(_) | LogicalPlan::Copy(_))
             && fields.len() == 1
             && fields[0].name() == "count"
@@ -702,11 +705,19 @@ mod tests {
         .unwrap();
 
         let parser = <DfSessionService as ExtendedQueryHandler>::query_parser(&service);
+        // COPY is rejected by `state.statement_to_plan`, so `LogicalPlan::Copy`
+        // can't be reached via the prepared-statement path today — the Copy
+        // arm in the guard is defensive for if upstream ever enables it.
         let cases: &[(&str, bool)] = &[
             ("INSERT INTO t VALUES (1, 'a')", true),
             ("UPDATE t SET name = 'x' WHERE id = 1", true),
             ("DELETE FROM t WHERE id = 1", true),
             ("SELECT id, name FROM t", false),
+            // Over-match guard: a SELECT that happens to produce a single
+            // UInt64 `count` column must NOT be suppressed — only DML/COPY
+            // plans of that shape may. If the guard ever drops the
+            // `LogicalPlan::Dml | Copy` check, this case fails loudly.
+            ("SELECT COUNT(*) AS count FROM t", false),
         ];
         for (sql, expect_empty) in cases {
             let stmt = parser.parse_sql(&client, sql, &[]).await.unwrap();

--- a/vendor/datafusion-postgres/src/handlers.rs
+++ b/vendor/datafusion-postgres/src/handlers.rs
@@ -683,4 +683,39 @@ mod tests {
         assert!(!has_ps, "statement_timeout should not send ParameterStatus");
     }
 
+    /// `Describe Statement` for INSERT/UPDATE/DELETE without RETURNING must
+    /// return an empty result schema so pgwire emits `NoData`. Strict clients
+    /// (Hasql, pgjdbc, Npgsql, psycopg3, sqlx) treat a `RowDescription` here
+    /// as a `TuplesOk` protocol error and drop the write. SELECT is the
+    /// fallthrough positive control.
+    #[tokio::test]
+    async fn get_result_schema_returns_no_data_for_dml() {
+        let service = crate::testing::setup_handlers();
+        let mut client = MockClient::new();
+
+        <DfSessionService as SimpleQueryHandler>::do_query(
+            &service,
+            &mut client,
+            "CREATE TABLE t (id INT, name TEXT)",
+        )
+        .await
+        .unwrap();
+
+        let parser = <DfSessionService as ExtendedQueryHandler>::query_parser(&service);
+        let cases: &[(&str, bool)] = &[
+            ("INSERT INTO t VALUES (1, 'a')", true),
+            ("UPDATE t SET name = 'x' WHERE id = 1", true),
+            ("DELETE FROM t WHERE id = 1", true),
+            ("SELECT id, name FROM t", false),
+        ];
+        for (sql, expect_empty) in cases {
+            let stmt = parser.parse_sql(&client, sql, &[]).await.unwrap();
+            let fields = parser.get_result_schema(&stmt, None).unwrap();
+            assert_eq!(
+                fields.is_empty(),
+                *expect_empty,
+                "{sql}: expected empty={expect_empty}, got {fields:?}"
+            );
+        }
+    }
 }

--- a/vendor/datafusion-postgres/src/handlers.rs
+++ b/vendor/datafusion-postgres/src/handlers.rs
@@ -705,13 +705,14 @@ mod tests {
         .unwrap();
 
         let parser = <DfSessionService as ExtendedQueryHandler>::query_parser(&service);
-        // COPY is rejected by `state.statement_to_plan`, so `LogicalPlan::Copy`
-        // can't be reached via the prepared-statement path today — the Copy
-        // arm in the guard is defensive for if upstream ever enables it.
         let cases: &[(&str, bool)] = &[
             ("INSERT INTO t VALUES (1, 'a')", true),
             ("UPDATE t SET name = 'x' WHERE id = 1", true),
             ("DELETE FROM t WHERE id = 1", true),
+            // COPY: not tested — `state.statement_to_plan` rejects COPY as
+            // unsupported today, so `LogicalPlan::Copy` is unreachable via
+            // the prepared-statement path. The Copy arm in the guard is
+            // defensive for if upstream ever enables it.
             ("SELECT id, name FROM t", false),
             // Over-match guard: a SELECT that happens to produce a single
             // UInt64 `count` column must NOT be suppressed — only DML/COPY


### PR DESCRIPTION
## Summary

- Strict prepare-validating clients (Hasql, pgjdbc, Npgsql, psycopg3, sqlx) were dropping every prepared `INSERT`/`UPDATE`/`DELETE` against TimeFusion with `TuplesOk` errors. Root cause: datafusion-postgres' default `Describe Statement` replied with a `RowDescription{count: UInt64}` (the synthetic DML output schema) instead of `NoData`.
- The prior attempt (7d053b2) only fixed the `Execute` response via `dml_completion` and never touched `Describe` — which is where Hasql/pgjdbc actually fail, before `Bind`/`Execute` is even sent. Lenient drivers (`tokio-postgres::execute`, asyncpg) discard the spurious DataRow, which is why the bug survived two rounds of integration tests.
- Fix: in `Parser::get_result_schema`, when the plan is `LogicalPlan::Dml`/`Copy` and its schema is the well-known `[count: UInt64]` shape, return an empty `Vec<FieldInfo>` so pgwire emits `NoData`. Exact-shape guard means a future `RETURNING` plan (wider schema) falls through to the normal path.

## Test plan

- [x] `prepared_dml_describes_as_no_data` — INSERT/UPDATE/DELETE/Variant-INSERT via `tokio_postgres::Statement::columns()`
- [x] `sqlx_describe_insert_returns_no_columns` — independent strict Rust client (`sqlx::Executor::describe`)
- [x] `prepared_insert_executes_and_writes_row` — end-to-end Execute+SELECT, guards against breaking Execute while fixing Describe
- [x] `simple_query_insert_sends_no_row_messages` — simple-query path
- [x] Without the fix: 2/4 fail (the real regression guards); with the fix: 4/4 pass
- [x] No regressions in `cargo test --lib` (106) or `tests/integration_test.rs` (4)
- [x] Removed the prior vendor unit tests added in 7d053b2 — they exercised the wrong handler and gave false confidence

Vendor diff is ~10 lines, scoped to one method, upstreamable.