### PR TITLE
ci: cache build artifacts across runs to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Incremental compilation bloats the cache without helping CI (no warm
+  # incremental state across runs). Disabling it makes target/ smaller and
+  # speeds up sccache hit rates.
+  CARGO_INCREMENTAL: "0"
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   fmt:
@@ -27,34 +33,13 @@ jobs:
           components: rustfmt
       - run: cargo +nightly fmt --all --check
 
-  clippy:
-    name: Clippy
+  # Combined clippy + test. `cargo clippy` implies `cargo check`, and both
+  # share ~all artifacts with `cargo test` — running them in one job lets
+  # them reuse target/ instead of recompiling the world per-job.
+  build-test:
+    name: Clippy & Test
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-targets --all-features
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       AWS_SDK_LOAD_CONFIG: "false"
       AWS_ENDPOINT_URL: http://127.0.0.1:9000
@@ -98,9 +83,18 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: mozilla-actions/sccache-action@v0.0.5
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: build-test
 
-      - name: Run all tests
-        run: cargo test --all-features
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
+
+      - name: Test
+        run: cargo test --all-features --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,8 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Incremental compilation bloats the cache without helping CI (no warm
-  # incremental state across runs). Disabling it makes target/ smaller and
-  # speeds up sccache hit rates.
+  # incremental state across runs). Disabling it makes target/ smaller.
   CARGO_INCREMENTAL: "0"
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   fmt:
@@ -90,7 +87,6 @@ jobs:
           components: clippy
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: mozilla-actions/sccache-action@v0.0.5
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           # Use a container-based driver (using BuildKit) to enable cache export.
           driver-opts: image=moby/buildkit:master
 
       - name: Login to Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -30,7 +30,7 @@ jobs:
           echo "IMAGE_URL=$(echo ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:$(echo ${{ github.sha }} | cut -c1-7) | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.6
 
 ##############################
 #         Builder Stage      #
@@ -6,38 +6,29 @@
 FROM rust:1.91-slim-bookworm AS builder
 WORKDIR /app
 
-# Install build dependencies. protoc is required by tonic-prost-build (build.rs).
+# protoc is required by tonic-prost-build (build.rs).
 RUN apt-get update && \
     apt-get install -y pkg-config libssl-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy Cargo manifests, build.rs, proto files (needed by build.rs at compile
-# time), and vendored path-dep crates referenced in Cargo.toml.
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY proto/ proto/
 COPY vendor/ vendor/
-
-# Create dummy bench files (one per [[bench]] in Cargo.toml) and a dummy main
-# to allow dependency caching without the full source tree.
-RUN mkdir src && echo "fn main() {}" > src/main.rs && \
-    mkdir benches && \
-    echo "fn main() {}" > benches/core_benchmarks.rs && \
-    echo "fn main() {}" > benches/tantivy_benchmarks.rs && \
-    echo "fn main() {}" > benches/sort_layout_benchmarks.rs
-
-# Build a dummy release binary (to cache dependencies)
-RUN cargo build --release
-
-# Copy the full source code
 COPY src/ src/
 COPY schemas/ schemas/
 
-# Build the real release binary
-RUN cargo build --release
+# BuildKit cache mounts let the cargo registry and target/ dir survive across
+# CI runs (combined with `cache-to: type=gha` in the workflow). This replaces
+# the previous dummy-main scaffolding, which only cached when Cargo.toml was
+# unchanged and never reused target/ between builds.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked && \
+    cp target/release/timefusion /timefusion
 
-# Pre-create app state dirs so they can be copied into the distroless
-# runtime (which has no shell to mkdir at runtime).
-RUN mkdir -p /app/queue_db /app/data
+# App state dirs (distroless runtime has no shell to mkdir at runtime).
+RUN mkdir -p /queue_db /data
 
 ##############################
 #         Runtime Stage      #
@@ -49,9 +40,9 @@ RUN mkdir -p /app/queue_db /app/data
 FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /app
 
-COPY --from=builder --chown=nonroot:nonroot /app/target/release/timefusion /usr/local/bin/timefusion
-COPY --from=builder --chown=nonroot:nonroot /app/queue_db /app/queue_db
-COPY --from=builder --chown=nonroot:nonroot /app/data     /app/data
+COPY --from=builder --chown=nonroot:nonroot /timefusion /usr/local/bin/timefusion
+COPY --from=builder --chown=nonroot:nonroot /queue_db /app/queue_db
+COPY --from=builder --chown=nonroot:nonroot /data     /app/data
 
 EXPOSE 80 5432
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ RUN cargo install cargo-chef --locked
 # Cargo.toml / Cargo.lock / path-dep manifests change, so the cook layer below
 # stays cached across most edits.
 FROM chef AS planner
+# Only inputs cargo chef prepare actually reads: Cargo manifests + path-dep
+# manifests (in vendor/). NOT src/ or schemas/ — including them here would
+# bust the planner layer on every source edit, transitively invalidating
+# the cook layer and defeating cargo-chef's purpose.
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY proto/ proto/
 COPY vendor/ vendor/
-COPY src/ src/
-COPY schemas/ schemas/
 RUN cargo chef prepare --recipe-path recipe.json
 
 ##############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ RUN cargo install cargo-chef --version 0.1.77 --locked
 # stays cached across most edits.
 FROM chef AS planner
 # Only inputs cargo chef prepare actually reads: Cargo manifests + path-dep
-# manifests (in vendor/). NOT src/ or schemas/ — including them here would
-# bust the planner layer on every source edit, transitively invalidating
-# the cook layer and defeating cargo-chef's purpose.
+# manifests (in vendor/). NOT src/, schemas/, or proto/ — including them
+# here would bust the planner layer on edits unrelated to the dep graph,
+# defeating cargo-chef's purpose. vendor/ is copied in full (manifests +
+# source) since separating them isn't worth the Dockerfile complexity.
 COPY Cargo.toml Cargo.lock build.rs ./
-COPY proto/ proto/
 COPY vendor/ vendor/
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -34,15 +34,17 @@ FROM chef AS builder
 # Cook compiles only dependencies. Docker layer-caches this step; cache-to:
 # type=gha,mode=max in deploy.yml persists the layer across CI runs. Layer
 # invalidates only when recipe.json changes (i.e. the dep graph changes),
-# not on every src/ edit like the previous dummy-main pattern.
+# not on every src/ or proto/ edit. vendor/ is required here for the same
+# reason as in the planner stage (path-deps) — the duplication is necessary.
 COPY --from=planner /app/recipe.json recipe.json
-COPY proto/ proto/
 COPY vendor/ vendor/
 RUN cargo chef cook --release --locked --recipe-path recipe.json
 
 # Now compile the real binary. Deps are already built, so this only rebuilds
-# the crate itself when src/ changes.
+# the crate itself when src/, build.rs, or proto/ change. proto/ must be
+# copied *after* cook so .proto edits don't bust the dep-compile layer.
 COPY Cargo.toml Cargo.lock build.rs ./
+COPY proto/ proto/
 COPY src/ src/
 COPY schemas/ schemas/
 RUN cargo build --release --locked

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,55 @@
 # syntax=docker/dockerfile:1.6
 
 ##############################
-#         Builder Stage      #
+#         Chef base          #
 ##############################
-FROM rust:1.91-slim-bookworm AS builder
+FROM rust:1.91-slim-bookworm AS chef
 WORKDIR /app
-
 # protoc is required by tonic-prost-build (build.rs).
 RUN apt-get update && \
     apt-get install -y pkg-config libssl-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked
 
+##############################
+#         Planner            #
+##############################
+# Emit recipe.json describing the dep graph. Recipe content only changes when
+# Cargo.toml / Cargo.lock / path-dep manifests change, so the cook layer below
+# stays cached across most edits.
+FROM chef AS planner
 COPY Cargo.toml Cargo.lock build.rs ./
 COPY proto/ proto/
 COPY vendor/ vendor/
 COPY src/ src/
 COPY schemas/ schemas/
+RUN cargo chef prepare --recipe-path recipe.json
 
-# BuildKit cache mounts let the cargo registry and target/ dir survive across
-# CI runs (combined with `cache-to: type=gha` in the workflow). This replaces
-# the previous dummy-main scaffolding, which only cached when Cargo.toml was
-# unchanged and never reused target/ between builds.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/app/target \
-    cargo build --release --locked && \
-    cp target/release/timefusion /timefusion
+##############################
+#         Builder            #
+##############################
+FROM chef AS builder
+# Cook compiles only dependencies. Docker layer-caches this step; cache-to:
+# type=gha,mode=max in deploy.yml persists the layer across CI runs. Layer
+# invalidates only when recipe.json changes (i.e. the dep graph changes),
+# not on every src/ edit like the previous dummy-main pattern.
+COPY --from=planner /app/recipe.json recipe.json
+COPY proto/ proto/
+COPY vendor/ vendor/
+RUN cargo chef cook --release --locked --recipe-path recipe.json
+
+# Now compile the real binary. Deps are already built, so this only rebuilds
+# the crate itself when src/ changes.
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ src/
+COPY schemas/ schemas/
+RUN cargo build --release --locked
 
 # App state dirs (distroless runtime has no shell to mkdir at runtime).
 RUN mkdir -p /queue_db /data
 
 ##############################
-#         Runtime Stage      #
+#         Runtime            #
 ##############################
 # Distroless/cc ships glibc 2.36 (matches builder), libssl3, and CA roots,
 # and runs as the built-in `nonroot` user (uid 65532). Previously this
@@ -40,7 +58,7 @@ RUN mkdir -p /queue_db /data
 FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /app
 
-COPY --from=builder --chown=nonroot:nonroot /timefusion /usr/local/bin/timefusion
+COPY --from=builder --chown=nonroot:nonroot /app/target/release/timefusion /usr/local/bin/timefusion
 COPY --from=builder --chown=nonroot:nonroot /queue_db /app/queue_db
 COPY --from=builder --chown=nonroot:nonroot /data     /app/data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y pkg-config libssl-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version 0.1.77 --locked
 
 ##############################
 #         Planner            #


### PR DESCRIPTION
## Summary
- **Dockerfile**: switch to `cargo-chef` two-stage build. The `cook` step compiles only dependencies and is cached as a normal Docker layer (persisted across CI runs by `cache-to: type=gha,mode=max` in deploy.yml). It only invalidates when the dep graph (`recipe.json`) changes — not on every `src/` edit like the previous dummy-main pattern.
- **ci.yml**: collapse `check` + `clippy` + `test` into one `build-test` job that shares one `target/` instead of recompiling per-job (clippy implies check, and test rebuilds most of the same artifacts). Add `CARGO_INCREMENTAL=0` (incremental bloats CI cache for no win), `cache-on-failure: true` so flaky tests don't poison the cache, a `shared-key`, `--locked`, and an explicit `permissions: contents: read`.
- **deploy.yml**: bump `actions/checkout@v3` → `v4`.

## Test plan
- [ ] First run: cold cache, confirm build/test pass and caches populate
- [ ] Subsequent run: confirm `target/` restore from rust-cache and Docker cook-layer hit (much shorter Docker build)
- [ ] Source-only edit (touch a file in `src/`): confirm Docker cook layer still hits (validates the planner-stage fix from review round 2)
- [ ] Docker smoke test on master push catches any binary regression