### PR TITLE
wal: fix WAL file leak by checkpointing sealed blocks on cursor fast-forward

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ tonic-prost-build = "0.14"
 [dev-dependencies]
 sqllogictest = { git = "https://github.com/risinglightdb/sqllogictest-rs.git" }
 serial_test = "3.2.0"
+tokio = { version = "1.48", features = ["test-util"] }
 datafusion-common = "53.1.0"
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4"] }
 scopeguard = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mem_buffer;
 pub mod metrics;
 pub mod object_store_cache;
 pub mod optimizers;
+pub mod pgwire_early_bind;
 pub mod pgwire_handlers;
 pub mod plan_cache;
 pub mod schema_loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,13 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Start PGWire server on the listener we pre-bound at the top of
     // async_main. First, hand control of that listener back from the
     // early-bind 57P03 responder.
+    //
+    // Ownership handoff: the listener was moved into early_task and is
+    // returned as its final value, so `early_task.await?` hands back the
+    // owned TcpListener — no Arc, no rebind, no ECONNREFUSED window.
     // handle_one tasks accepted just before shutdown may still be running;
     // they own only the accepted sockets and complete independently.
+    info!("startup complete, transferring :5432 from early-bind 57P03 responder to real PGWire server");
     early_shutdown.cancel();
     let listener = early_task.await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,23 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Create Arc<AppConfig> for passing to components
     let cfg_arc = Arc::new(cfg.clone());
 
+    // Bind :5432 immediately, before the slow startup work (Database open,
+    // WAL recovery — up to ~15 min when WAL has accumulated). Clients
+    // connecting in this window get SQLSTATE 57P03 ("starting up") from
+    // the early-bind responder instead of ECONNREFUSED, which is what
+    // Hasql / pgjdbc / libpq expect during a backend restart and retry
+    // on cleanly. See pgwire_early_bind for the responder.
+    let pg_opts = ServerOptions::new().with_host("0.0.0.0".to_string()).with_port(cfg.core.pgwire_port);
+    let pg_listener = datafusion_postgres::bind_listener(pg_opts.host(), *pg_opts.port(), *pg_opts.backlog()).await?;
+    let early_shutdown = tokio_util::sync::CancellationToken::new();
+    let early_task = tokio::spawn({
+        let shutdown = early_shutdown.clone();
+        async move {
+            timefusion::pgwire_early_bind::run_until_ready(&pg_listener, shutdown).await;
+            pg_listener
+        }
+    });
+
     // Initialize database with explicit config
     let mut db = Database::with_config(Arc::clone(&cfg_arc)).await?;
     info!("Database initialized successfully");
@@ -157,9 +174,13 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let db = Arc::new(db);
     db.setup_session_tables(&mut session_context)?;
 
-    // Start PGWire server
-    let pg_port = cfg.core.pgwire_port;
-    info!("Starting PGWire server on port: {}", pg_port);
+    // Start PGWire server on the listener we pre-bound at the top of
+    // async_main. First, hand control of that listener back from the
+    // early-bind 57P03 responder.
+    // handle_one tasks accepted just before shutdown may still be running;
+    // they own only the accepted sockets and complete independently.
+    early_shutdown.cancel();
+    let listener = early_task.await?;
 
     let auth_config = timefusion::pgwire_handlers::AuthConfig::from_core(&cfg.core)?;
 
@@ -168,16 +189,15 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // BufferedWriteLayer flush isn't racing fresh inserts. Already-accepted
     // connections finish on their own spawned tasks.
     let pgwire_shutdown = tokio_util::sync::CancellationToken::new();
-    let pgwire_shutdown_for_task = pgwire_shutdown.clone();
-    let pg_task = tokio::spawn(async move {
-        let opts = ServerOptions::new().with_port(pg_port).with_host("0.0.0.0".to_string());
-
-        if let Err(e) = timefusion::pgwire_handlers::serve_with_logging(Arc::new(session_context), &opts, auth_config, async move {
-            pgwire_shutdown_for_task.cancelled().await
-        })
-        .await
-        {
-            error!("PGWire server error: {}", e);
+    let pg_task = tokio::spawn({
+        let shutdown = pgwire_shutdown.clone();
+        async move {
+            if let Err(e) =
+                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &pg_opts, auth_config, shutdown.cancelled_owned())
+                    .await
+            {
+                error!("PGWire server error: {}", e);
+            }
         }
     });
 
@@ -311,3 +331,4 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
 
     Ok(())
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,8 +193,7 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
         let shutdown = pgwire_shutdown.clone();
         async move {
             if let Err(e) =
-                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &pg_opts, auth_config, shutdown.cancelled_owned())
-                    .await
+                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &pg_opts, auth_config, shutdown.cancelled_owned()).await
             {
                 error!("PGWire server error: {}", e);
             }
@@ -331,4 +330,3 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
 
     Ok(())
 }
-

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -258,12 +258,20 @@ mod tests {
         // First connection holds the only permit — never sends startup, so it
         // sits inside handle_one's read awaiting bytes.
         let _holder = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Second connection hits the cap; should receive 57P03 inline.
-        let mut cap_client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-        // Server writes the canned frame without waiting for a startup message.
-        tokio::time::timeout(Duration::from_secs(2), assert_57p03(&mut cap_client)).await.unwrap();
+        // Poll for cap behaviour rather than sleeping a fixed amount: open
+        // probes until one comes back with the canned 57P03 frame, confirming
+        // the holder has the permit and the cap fast-path is firing.
+        // Robust on loaded CI runners.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let mut probe = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+            if tokio::time::timeout(Duration::from_millis(200), assert_57p03(&mut probe)).await.is_ok() {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "cap fast-path never observed");
+            tokio::task::yield_now().await;
+        }
 
         shutdown.cancel();
         let _ = task.await;

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -1,0 +1,284 @@
+//! Early-bind responder that occupies `:5432` during the slow startup
+//! window (WAL replay, Delta-table open, foyer init), returning the
+//! Postgres SQLSTATE 57P03 "the database system is starting up" error
+//! to every connection until the real server takes over the listener.
+//!
+//! Without this, packets DNAT'd into the container during the multi-minute
+//! startup get RST'd back as ECONNREFUSED — clients like Hasql / pgjdbc /
+//! libpq treat 57P03 as transient and back off cleanly, ECONNREFUSED as a
+//! hard error. Hand the same `TcpListener` to `serve_with_listener` once
+//! ready: no rebind, no ECONNREFUSED window.
+
+use std::{io, sync::Arc, time::Duration};
+
+use datafusion_postgres::pgwire::messages::startup::{GssEncRequest, SslRequest};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+const SSL_REQUEST_CODE: u32 = SslRequest::BODY_MAGIC_NUMBER as u32;
+const GSS_REQUEST_CODE: u32 = GssEncRequest::BODY_MAGIC_NUMBER as u32;
+/// Cap on the StartupMessage size we'll drain. Real pg clients send well
+/// under 1 KiB; 64 KiB is comfortably above any legitimate payload and
+/// bounds the work a malformed/hostile client can force on us.
+const MAX_STARTUP_BYTES: u64 = 64 * 1024;
+const STARTUP_READ_TIMEOUT: Duration = Duration::from_secs(10);
+/// Hard cap on concurrent early-bind handlers. A thundering-herd reconnect
+/// storm during startup could otherwise spawn unbounded tasks, each holding
+/// a socket FD for up to STARTUP_READ_TIMEOUT. Excess connections are accepted
+/// and immediately dropped (closing the socket); clients see this as a reset
+/// and retry, same as if the kernel had dropped the SYN.
+const MAX_CONCURRENT_EARLY_HANDLERS: usize = 512;
+
+/// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
+pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
+    accept_loop(listener, shutdown, MAX_CONCURRENT_EARLY_HANDLERS).await;
+}
+
+async fn accept_loop(listener: &TcpListener, shutdown: CancellationToken, max_handlers: usize) {
+    let response: Arc<[u8]> = build_starting_up_response().into();
+    let permits = Arc::new(tokio::sync::Semaphore::new(max_handlers));
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            res = listener.accept() => match res {
+                Ok((mut sock, addr)) => {
+                    let permit = match Arc::clone(&permits).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            // Capacity exhausted (probable reconnect storm). Send the
+                            // canned 57P03 frame and close — dropping the socket without
+                            // a response would RST, which Hasql/libpq treat as
+                            // ECONNREFUSED (the exact failure mode this responder exists
+                            // to avoid). The fast-path task skips the 10s startup wait
+                            // so it's bounded by accept rate × write latency (~ms).
+                            warn!("early-bind: at {max_handlers}-handler cap, fast-responding to {addr}");
+                            let resp = Arc::clone(&response);
+                            tokio::spawn(async move {
+                                let _ = tokio::time::timeout(Duration::from_secs(1), async move {
+                                    let _ = sock.write_all(&resp).await;
+                                    let _ = sock.shutdown().await;
+                                })
+                                .await;
+                            });
+                            continue;
+                        }
+                    };
+                    let resp = Arc::clone(&response);
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        match tokio::time::timeout(STARTUP_READ_TIMEOUT, handle_one(sock, &resp)).await {
+                            Err(_) => debug!("early-bind: timeout waiting for startup from {addr}"),
+                            Ok(Err(e)) => debug!("early-bind: short-circuit conn from {addr}: {e}"),
+                            Ok(Ok(())) => {}
+                        }
+                    });
+                }
+                Err(e) => warn!("early-bind: accept failed: {e}"),
+            },
+        }
+    }
+}
+
+async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
+    // SSL/GSS negotiation precedes the real StartupMessage; both are 8 bytes
+    // (length + magic). Drain whichever shape arrives, then send 57P03.
+    // pg length fields include the 4-byte length itself. In the non-SSL branch
+    // we've also consumed the 4-byte code → drain `len - 8`; in the SSL/GSS
+    // branch we've consumed only the length of the *real* startup → drain
+    // `real_len - 4`.
+    let len = sock.read_u32().await? as u64;
+    let code = sock.read_u32().await?;
+    if code == SSL_REQUEST_CODE || code == GSS_REQUEST_CODE {
+        sock.write_all(b"N").await?;
+        let real_len = sock.read_u32().await? as u64;
+        drain_body(&mut sock, real_len.checked_sub(4)).await?;
+    } else {
+        drain_body(&mut sock, len.checked_sub(8)).await?;
+    }
+
+    sock.write_all(response).await?;
+    let _ = sock.shutdown().await;
+    Ok(())
+}
+
+async fn drain_body(sock: &mut TcpStream, remaining: Option<u64>) -> io::Result<()> {
+    let n = remaining.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "startup length below 8-byte header"))?;
+    if n > MAX_STARTUP_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup body {n} exceeds {MAX_STARTUP_BYTES}-byte cap")));
+    }
+    tokio::io::copy(&mut sock.take(n), &mut tokio::io::sink()).await?;
+    Ok(())
+}
+
+/// Wire format: `Byte1('E') Int32(length) [Byte1(tag) String(value)]* Byte1(0)`
+fn build_starting_up_response() -> Vec<u8> {
+    let mut body: Vec<u8> = Vec::with_capacity(96);
+    for (tag, value) in [(b'S', "FATAL"), (b'V', "FATAL"), (b'C', "57P03"), (b'M', "the database system is starting up")] {
+        body.push(tag);
+        body.extend_from_slice(value.as_bytes());
+        body.push(0);
+    }
+    body.push(0);
+
+    let length = (body.len() + 4) as u32;
+    let mut msg = Vec::with_capacity(1 + 4 + body.len());
+    msg.push(b'E');
+    msg.extend_from_slice(&length.to_be_bytes());
+    msg.extend_from_slice(&body);
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROTO_3_0: u32 = 0x0003_0000;
+
+    #[test]
+    fn response_frame_has_expected_shape() {
+        let msg = build_starting_up_response();
+        assert_eq!(msg[0], b'E');
+        let len = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]) as usize;
+        assert_eq!(len, msg.len() - 1);
+        let body = &msg[5..];
+        assert!(body.windows(5).any(|w| w == b"57P03"));
+        assert_eq!(body.last(), Some(&0u8));
+    }
+
+    async fn spawn_acceptor() -> (u16, CancellationToken, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = CancellationToken::new();
+        let token = shutdown.clone();
+        let task = tokio::spawn(async move { run_until_ready(&listener, token).await });
+        (port, shutdown, task)
+    }
+
+    async fn assert_57p03(client: &mut TcpStream) {
+        let mut tag = [0u8; 1];
+        client.read_exact(&mut tag).await.unwrap();
+        assert_eq!(tag[0], b'E');
+        let mut len_buf = [0u8; 4];
+        client.read_exact(&mut len_buf).await.unwrap();
+        let body_len = u32::from_be_bytes(len_buf) as usize - 4;
+        let mut body = vec![0u8; body_len];
+        client.read_exact(&mut body).await.unwrap();
+        assert!(body.windows(5).any(|w| w == b"57P03"));
+    }
+
+    #[tokio::test]
+    async fn responds_to_plain_startup_then_closes() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        assert_57p03(&mut client).await;
+        let mut tail = [0u8; 1];
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after error");
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    async fn negotiation_then_startup(magic: u32) {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&magic.to_be_bytes()).await.unwrap();
+        let mut n_reply = [0u8; 1];
+        client.read_exact(&mut n_reply).await.unwrap();
+        assert_eq!(n_reply[0], b'N');
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        assert_57p03(&mut client).await;
+        let mut tail = [0u8; 1];
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after error");
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    #[tokio::test]
+    async fn responds_to_ssl_request_then_startup() {
+        negotiation_then_startup(SSL_REQUEST_CODE).await;
+    }
+
+    #[tokio::test]
+    async fn responds_to_gss_request_then_startup() {
+        negotiation_then_startup(GSS_REQUEST_CODE).await;
+    }
+
+    /// Exercises drain_body with n > 0 (the no-params test sends len=8, n=0).
+    #[tokio::test]
+    async fn drains_startup_params_then_responds() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let params = b"user\0foo\0database\0bar\0\0";
+        let len = (4 + 4 + params.len()) as u32;
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        client.write_all(params).await.unwrap();
+        assert_57p03(&mut client).await;
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    /// A client that connects but never sends a startup message must be
+    /// closed after STARTUP_READ_TIMEOUT instead of holding the slot forever.
+    #[tokio::test(start_paused = true)]
+    async fn silent_client_closed_after_timeout() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // No bytes sent; advance virtual time past the timeout.
+        tokio::time::advance(STARTUP_READ_TIMEOUT + Duration::from_secs(1)).await;
+        let mut tail = [0u8; 1];
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after timeout");
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    /// At the handler cap, excess connections still receive 57P03 (sent
+    /// synchronously via try_write) rather than RST — Hasql/libpq treat RST
+    /// as ECONNREFUSED, which is the failure mode this responder exists to
+    /// avoid.
+    #[tokio::test]
+    async fn cap_serves_57p03_synchronously_without_spawning() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = CancellationToken::new();
+        let token = shutdown.clone();
+        let task = tokio::spawn(async move { accept_loop(&listener, token, 1).await });
+
+        // First connection holds the only permit — never sends startup, so it
+        // sits inside handle_one's read awaiting bytes.
+        let _holder = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Second connection hits the cap; should receive 57P03 inline.
+        let mut cap_client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // Server writes the canned frame without waiting for a startup message.
+        tokio::time::timeout(Duration::from_secs(2), assert_57p03(&mut cap_client)).await.unwrap();
+
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    /// Oversized declared length must trip the MAX_STARTUP_BYTES guard;
+    /// the server drops the connection without sending a response.
+    #[tokio::test]
+    async fn rejects_oversized_startup() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let oversized = (MAX_STARTUP_BYTES as u32) + 1024;
+        client.write_all(&oversized.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        let mut tag = [0u8; 1];
+        let n = client.read(&mut tag).await.unwrap();
+        assert_eq!(n, 0, "server must drop connection on oversized startup");
+        shutdown.cancel();
+        let _ = task.await;
+    }
+}

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -109,7 +109,10 @@ async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
 async fn drain_body(sock: &mut TcpStream, remaining: Option<u64>) -> io::Result<()> {
     let n = remaining.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "startup length below 8-byte header"))?;
     if n > MAX_STARTUP_BYTES {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup body {n} exceeds {MAX_STARTUP_BYTES}-byte cap")));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("startup body {n} exceeds {MAX_STARTUP_BYTES}-byte cap"),
+        ));
     }
     tokio::io::copy(&mut sock.take(n), &mut tokio::io::sink()).await?;
     Ok(())

--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -355,8 +355,8 @@ pub async fn serve_with_logging(
 
 /// Variant of `serve_with_logging` over a pre-bound listener.
 pub async fn serve_with_listener(
-    listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions,
-    auth_config: AuthConfig, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+    listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions, auth_config: AuthConfig,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let handlers = Arc::new(LoggingHandlerFactory::new(session_context, auth_config));
     datafusion_postgres::serve_with_listener(listener, handlers, options, shutdown).await?;

--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -353,7 +353,9 @@ pub async fn serve_with_logging(
     Ok(())
 }
 
-/// Variant of `serve_with_logging` over a pre-bound listener.
+/// Variant of `serve_with_logging` over a pre-bound listener. The listener's
+/// host/port/backlog were set at bind time; `options` here contributes only
+/// TLS config and connection-limit settings.
 pub async fn serve_with_listener(
     listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions, auth_config: AuthConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,

--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -353,6 +353,16 @@ pub async fn serve_with_logging(
     Ok(())
 }
 
+/// Variant of `serve_with_logging` over a pre-bound listener.
+pub async fn serve_with_listener(
+    listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions,
+    auth_config: AuthConfig, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let handlers = Arc::new(LoggingHandlerFactory::new(session_context, auth_config));
+    datafusion_postgres::serve_with_listener(listener, handlers, options, shutdown).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::rewrite_pg_synonyms;

--- a/tests/listen_backlog_test.rs
+++ b/tests/listen_backlog_test.rs
@@ -185,6 +185,9 @@ async fn larger_backlog_eliminates_overflow_under_same_burst() {
         );
     }
 
+    // Assertion is Linux-only: on macOS, kern.ipc.somaxconn often clamps below
+    // BACKLOG, so we can't enforce a strict ok==BURST contract. The eprintln!
+    // above surfaces the macOS case as a diagnostic.
     #[cfg(target_os = "linux")]
     assert_eq!(
         ok, BURST,
@@ -228,19 +231,12 @@ async fn worker_starvation_causes_backlog_overflow_under_burst() {
         }
     });
 
-    // Saturate every worker with a CPU-bound spin. This is the bit that
-    // mimics heavy query execution starving the accept task.
-    let hogs: Vec<_> = (0..2)
-        .map(|_| {
-            tokio::task::spawn_blocking(move || {
-                // spawn_blocking would NOT starve the runtime — use a normal
-                // tokio::spawn with a CPU-bound loop instead so it occupies
-                // a runtime worker.
-            })
-        })
-        .collect();
-    drop(hogs);
-
+    // Saturate every worker with a CPU-bound spin. This mimics heavy query
+    // execution starving the accept task.
+    //
+    // NOTE: tokio::task::spawn_blocking does NOT starve the runtime — it runs
+    // on a dedicated blocking pool. Use tokio::spawn with a tight CPU-bound
+    // loop (no .await points) so the work actually pins a runtime worker.
     let hogs: Vec<_> = (0..2)
         .map(|i| {
             tokio::spawn(async move {

--- a/tests/listen_backlog_test.rs
+++ b/tests/listen_backlog_test.rs
@@ -108,6 +108,11 @@ async fn listen_backlog_overflows_at_128_when_accept_stalls() {
     //    fails, either the OS isn't enforcing the backlog (unlikely) or the
     //    fix has landed (raise the burst, or delete this test as obsolete).
     let failed = refused + timed_out;
+    // Strict assertion is Linux-only: some kernels (e.g. macOS dev hosts)
+    // silently queue beyond the requested backlog, which would produce
+    // spurious failures here. The eprintln! below still surfaces the
+    // observed counts on every platform.
+    #[cfg(target_os = "linux")]
     assert!(
         failed > 0,
         "expected backlog overflow to refuse/timeout some of {BURST} connects, \

--- a/tests/listen_backlog_test.rs
+++ b/tests/listen_backlog_test.rs
@@ -72,6 +72,13 @@ async fn burst_connect(port: u16, n: usize, connect_timeout: Duration) -> (usize
     (ok, refused, timed_out, other)
 }
 
+// Skipped on CI: GitHub Actions runners silently queue SYNs beyond the
+// requested 128 backlog (kernel/network-namespace behaviour we don't control),
+// so the "some connects must fail" assertion fires `ok=300 refused=0 timed_out=0`
+// and the test fails deterministically. Kept as a manual reproducer — run with
+// `cargo test --test listen_backlog_test -- --ignored` on a host where
+// `tcp_abort_on_overflow=1` and the kernel enforces the backlog.
+#[ignore = "kernel-level backlog enforcement not reliable on CI runners"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn listen_backlog_overflows_at_128_when_accept_stalls() {
     // Burst well past the kernel accept-queue depth.

--- a/tests/listen_backlog_test.rs
+++ b/tests/listen_backlog_test.rs
@@ -1,0 +1,333 @@
+//! Reproduces the production "Connection refused" symptom that monoscope's
+//! bulk insert jobs hit against `timefusion.s.past3.tech:5432`.
+//!
+//! Root cause: tokio's `TcpListener::bind` (via mio) hardcodes the listen
+//! backlog to **128** on Linux/macOS. When monoscope's parallel retry loops
+//! converge into a burst of >128 concurrent SYNs faster than the accept loop
+//! drains the queue, the kernel either drops the SYN (default Linux,
+//! manifests as client connect-timeout) or RSTs it (Linux with
+//! `tcp_abort_on_overflow=1`, manifests as `ECONNREFUSED`). The server logs
+//! show nothing because the rejection happens in the kernel, not in
+//! application code.
+//!
+//! This test pins the mechanism by binding a stock `TcpListener` (backlog=128),
+//! stalling the accept loop, and demonstrating that the 129th+ concurrent
+//! connect attempt fails. The fix is to bind via `socket2`/`TcpSocket` with
+//! an explicit larger backlog (e.g. 4096) — see follow-up.
+//!
+//! Run with `RUST_LOG=info` for per-connection diagnostics. Run on Linux with
+//! `sudo sysctl net.ipv4.tcp_abort_on_overflow=1` to surface the exact prod
+//! `ECONNREFUSED` error class; otherwise observed failures are timeouts (same
+//! root cause, different kernel response).
+
+use std::{io, sync::Arc, time::Duration};
+
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Notify,
+    time::timeout,
+};
+
+/// Bind a stock tokio TcpListener (backlog=128 from mio) and DO NOT accept
+/// until `release` is notified. This simulates a wedged accept loop —
+/// equivalent to what monoscope sees when the prod accept loop falls behind
+/// during a thundering-herd retry burst.
+async fn stalled_listener() -> (u16, Arc<Notify>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    let release = Arc::new(Notify::new());
+    let release_clone = release.clone();
+
+    tokio::spawn(async move {
+        // Hold the listener, do nothing. Kernel keeps queueing SYNs into the
+        // 128-deep accept queue until it overflows.
+        release_clone.notified().await;
+        // Drain any queued connections so the test exits cleanly.
+        while let Ok((_, _)) = listener.accept().await {}
+    });
+
+    (port, release)
+}
+
+/// Fire N concurrent TCP connect attempts at the given port, with a per-connect
+/// timeout. Returns (successes, refused_count, timeout_count, other_errors).
+async fn burst_connect(port: u16, n: usize, connect_timeout: Duration) -> (usize, usize, usize, Vec<String>) {
+    let handles: Vec<_> = (0..n)
+        .map(|_| tokio::spawn(async move { timeout(connect_timeout, TcpStream::connect(("127.0.0.1", port))).await }))
+        .collect();
+
+    let mut ok = 0;
+    let mut refused = 0;
+    let mut timed_out = 0;
+    let mut other = Vec::new();
+
+    for h in handles {
+        match h.await.expect("join") {
+            Ok(Ok(_stream)) => ok += 1,
+            Ok(Err(e)) if e.kind() == io::ErrorKind::ConnectionRefused => refused += 1,
+            Ok(Err(e)) => other.push(format!("{} ({:?})", e, e.kind())),
+            Err(_elapsed) => timed_out += 1,
+        }
+    }
+    (ok, refused, timed_out, other)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn listen_backlog_overflows_at_128_when_accept_stalls() {
+    // Burst well past the kernel accept-queue depth.
+    const BURST: usize = 300;
+    const CONNECT_TIMEOUT_MS: u64 = 500;
+
+    let (port, release) = stalled_listener().await;
+    // Give the listener a moment to be polled into the runtime.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (ok, refused, timed_out, other) = burst_connect(port, BURST, Duration::from_millis(CONNECT_TIMEOUT_MS)).await;
+
+    release.notify_one();
+
+    eprintln!("burst={BURST} ok={ok} refused={refused} timed_out={timed_out} other={}", other.len());
+    if !other.is_empty() {
+        eprintln!("other errors:");
+        for e in other.iter().take(5) {
+            eprintln!("  - {e}");
+        }
+    }
+
+    // The contract we're asserting:
+    //
+    // 1. The accept queue is finite (128 by default), so SOME connects must
+    //    fail when we burst 300 SYNs at a stalled acceptor. If this assertion
+    //    fails, either the OS isn't enforcing the backlog (unlikely) or the
+    //    fix has landed (raise the burst, or delete this test as obsolete).
+    let failed = refused + timed_out;
+    assert!(
+        failed > 0,
+        "expected backlog overflow to refuse/timeout some of {BURST} connects, \
+         but all {ok} succeeded. Either the listen backlog has been raised \
+         above {BURST}, the OS isn't enforcing it, or you're on a kernel that \
+         silently queues beyond the requested backlog."
+    );
+
+    // 2. On Linux with `tcp_abort_on_overflow=1`, failures appear as
+    //    ECONNREFUSED — the same error class monoscope's Hasql logs print.
+    //    On macOS and stock Linux, failures appear as connect timeouts.
+    //    Both indicate the same root cause: kernel-level backlog overflow.
+    eprintln!(
+        "Mechanism reproduced: {} of {BURST} connects failed (refused={refused}, timed_out={timed_out}).",
+        failed
+    );
+    if cfg!(target_os = "linux") && refused > 0 {
+        eprintln!("ECONNREFUSED observed -> host has tcp_abort_on_overflow=1, matches prod.");
+    } else if refused == 0 && timed_out > 0 {
+        eprintln!("Timeouts (no ECONNREFUSED) -> default kernel behavior; same root cause.");
+    }
+}
+
+/// The fix: bind via `TcpSocket` with an explicit larger backlog (e.g. 4096
+/// or whatever `net.core.somaxconn` allows). With a deeper accept queue,
+/// the same stalled-acceptor burst no longer refuses connections — the
+/// kernel happily queues all 300 SYNs until the acceptor wakes up.
+///
+/// This is the test that should fail before the production fix lands and
+/// pass after. The fix is to either:
+///   1. Patch `datafusion-postgres::serve_with_handlers` to bind with
+///      `TcpSocket::new_v4()? + bind + listen(4096)` instead of
+///      `TcpListener::bind(...)`, or
+///   2. Pre-bind in main.rs and pass a `TcpListener::from_std(...)` into
+///      `serve_with_handlers` (would need a small API addition).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn larger_backlog_eliminates_overflow_under_same_burst() {
+    use tokio::net::TcpSocket;
+
+    const BURST: usize = 300;
+    const BACKLOG: u32 = 4096;
+
+    let socket = TcpSocket::new_v4().expect("socket");
+    socket.bind("127.0.0.1:0".parse().unwrap()).expect("bind");
+    let addr = socket.local_addr().expect("local_addr");
+    let port = addr.port();
+    let listener = socket.listen(BACKLOG).expect("listen");
+    let release = Arc::new(Notify::new());
+    let release_clone = release.clone();
+
+    tokio::spawn(async move {
+        release_clone.notified().await;
+        while let Ok((_, _)) = listener.accept().await {}
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let (ok, refused, timed_out, other) = burst_connect(port, BURST, Duration::from_millis(500)).await;
+    release.notify_one();
+
+    eprintln!(
+        "explicit-backlog={BACKLOG} burst={BURST} ok={ok} refused={refused} timed_out={timed_out} other={}",
+        other.len()
+    );
+
+    // CRITICAL FINDING: this assertion may fail even after the app-level fix
+    // because the OS clamps the requested backlog to `somaxconn`:
+    //   - macOS:   kern.ipc.somaxconn  (default 128)
+    //   - Linux:   net.core.somaxconn  (modern default 4096; older 128)
+    // So the prod fix is two-part:
+    //   (a) app-level: bind via TcpSocket and request a large backlog (4096+)
+    //   (b) host-level: ensure somaxconn >= the requested backlog
+    // If (b) is below the burst size, the same overflow occurs and clients
+    // see ECONNREFUSED (when tcp_abort_on_overflow=1) or connect timeouts.
+    //
+    // On macOS this test is informational only (somaxconn=128 by default).
+    // On Linux it should pass with the default 4096 somaxconn.
+    if ok < BURST {
+        eprintln!(
+            "Backlog clamped by host somaxconn — requested {BACKLOG}, got effective ~{ok}. \
+             Raise somaxconn (Linux: sysctl -w net.core.somaxconn=4096; \
+             macOS: sysctl -w kern.ipc.somaxconn=4096) for the app-level fix to take effect."
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        ok, BURST,
+        "On Linux with default somaxconn=4096, backlog={BACKLOG} should queue all {BURST}, \
+         but got ok={ok} refused={refused} timed_out={timed_out}. \
+         Either somaxconn is set below {BURST} on this host or the fix is incomplete."
+    );
+}
+
+/// Reproduces the **realistic** prod scenario: a fast accept loop that
+/// nonetheless falls behind because the tokio runtime workers are saturated
+/// with CPU-bound query work. The accept task is just another task — when
+/// all workers are spinning on `std::hint::black_box(..)` loops, the
+/// accept future doesn't get polled for tens to hundreds of milliseconds,
+/// and the 128-deep accept queue overflows during a burst.
+///
+/// This is closer to what monoscope sees: timefusion is "up", *some*
+/// connections succeed, and others get refused / time out, because the
+/// accept loop is being starved.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn worker_starvation_causes_backlog_overflow_under_burst() {
+    const BURST: usize = 300;
+    const HOG_DURATION_MS: u64 = 800;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let stop = Arc::new(Notify::new());
+    let stop_clone = stop.clone();
+
+    let accepter = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = stop_clone.notified() => break,
+                res = listener.accept() => {
+                    match res {
+                        Ok((s, _)) => { drop(s); }
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+    });
+
+    // Saturate every worker with a CPU-bound spin. This is the bit that
+    // mimics heavy query execution starving the accept task.
+    let hogs: Vec<_> = (0..2)
+        .map(|_| {
+            tokio::task::spawn_blocking(move || {
+                // spawn_blocking would NOT starve the runtime — use a normal
+                // tokio::spawn with a CPU-bound loop instead so it occupies
+                // a runtime worker.
+            })
+        })
+        .collect();
+    drop(hogs);
+
+    let hogs: Vec<_> = (0..2)
+        .map(|i| {
+            tokio::spawn(async move {
+                let deadline = std::time::Instant::now() + Duration::from_millis(HOG_DURATION_MS);
+                let mut x: u64 = i as u64;
+                while std::time::Instant::now() < deadline {
+                    // Cooperative yield budget exhausts after ~128 polls in tokio,
+                    // but a tight loop with no .await points blocks the worker
+                    // entirely. That's the realistic case: a heavy synchronous
+                    // routine inside a handler (e.g. arrow compute) holding the
+                    // worker thread.
+                    for _ in 0..1_000_000 {
+                        x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                    }
+                    std::hint::black_box(x);
+                }
+            })
+        })
+        .collect();
+
+    // Tiny pause so the hogs are actually scheduled and start spinning.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let (ok, refused, timed_out, other) = burst_connect(port, BURST, Duration::from_millis(400)).await;
+
+    for h in hogs {
+        let _ = h.await;
+    }
+    stop.notify_one();
+    let _ = accepter.await;
+
+    eprintln!("worker-starved burst: ok={ok} refused={refused} timed_out={timed_out} other={}", other.len());
+
+    // Under worker starvation, the accept task can't drain 128+ SYNs fast
+    // enough during the burst. We expect SOME failures even though the
+    // accept loop itself is "correct" (spawn-immediately pattern).
+    let failed = refused + timed_out;
+    if failed == 0 {
+        eprintln!(
+            "WARNING: worker starvation did not produce backlog overflow on this host. \
+             Either the runtime preempted the hogs, the kernel queued beyond 128, or the \
+             burst rate was insufficient. This test is a probabilistic indicator, not a hard \
+             contract — but a 'pass with 0 failures' here means we should investigate prod \
+             more carefully."
+        );
+    } else {
+        eprintln!(
+            "Reproduced: {} of {BURST} connects failed because the accept task was starved \
+             by CPU-bound workers (refused={refused}, timed_out={timed_out}). On a Linux host \
+             with tcp_abort_on_overflow=1, the timeouts here would appear as ECONNREFUSED \
+             at the client — matching monoscope's prod logs.",
+            failed
+        );
+    }
+}
+
+/// Sanity check: with a fast acceptor, the same burst should succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_overflow_when_acceptor_drains_promptly() {
+    const BURST: usize = 300;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let stop = Arc::new(Notify::new());
+    let stop_clone = stop.clone();
+
+    let accepter = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = stop_clone.notified() => break,
+                res = listener.accept() => {
+                    if res.is_err() { break; }
+                }
+            }
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let (ok, refused, timed_out, other) = burst_connect(port, BURST, Duration::from_millis(2000)).await;
+
+    stop.notify_one();
+    let _ = accepter.await;
+
+    eprintln!("fast-acceptor burst: ok={ok} refused={refused} timed_out={timed_out} other={}", other.len());
+    // With a tight accept loop draining the queue, all 300 should land.
+    assert_eq!(
+        ok, BURST,
+        "fast acceptor should drain all {BURST} connects (got ok={ok}, refused={refused}, timed_out={timed_out})"
+    );
+}

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -17,7 +17,7 @@ use pgwire::api::PgWireServerHandlers;
 use pgwire::tokio::process_socket;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
-use tokio::net::{lookup_host, TcpSocket};
+use tokio::net::{lookup_host, TcpListener, TcpSocket};
 use tokio::sync::Semaphore;
 use tokio_rustls::rustls::{self, ServerConfig};
 use tokio_rustls::TlsAcceptor;
@@ -123,6 +123,38 @@ pub async fn serve_with_hooks(session_context: Arc<SessionContext>, opts: &Serve
 pub async fn serve_with_handlers(
     handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), std::io::Error> {
+    let listener = bind_listener(&opts.host, opts.port, opts.backlog).await?;
+    serve_with_listener(listener, handlers, opts, shutdown).await
+}
+
+/// Bind a TCP listener via `TcpSocket` so the caller can request a real
+/// `backlog` — `TcpListener::bind` hardcodes 128 via mio, which trivially
+/// overflows under thundering-herd reconnects. The kernel still clamps to
+/// `somaxconn`, so the host sysctl must match.
+pub async fn bind_listener(host: &str, port: u16, backlog: u32) -> Result<TcpListener, std::io::Error> {
+    let server_addr = format!("{host}:{port}");
+    let addr = lookup_host(&server_addr)
+        .await?
+        .next()
+        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
+    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+    socket.set_reuseaddr(true)?;
+    socket.bind(addr)?;
+    let listener = socket.listen(backlog)?;
+    info!("Bound PGWire listener on {server_addr} (backlog={backlog}); kernel clamps to net.core.somaxconn");
+    Ok(listener)
+}
+
+/// Like `serve_with_handlers`, but accepts an already-bound `TcpListener`.
+/// Useful when the caller wants to bind the socket early (e.g. to handle the
+/// pgwire startup-time window with a 57P03 "starting up" responder, then hand
+/// the same listener to the real server once initialization is complete —
+/// avoiding the unbound-port window that causes ECONNREFUSED at clients
+/// during slow startup).
+pub async fn serve_with_listener(
+    listener: TcpListener, handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), std::io::Error> {
     // Set up TLS if configured
     let tls_acceptor = if let (Some(cert_path), Some(key_path)) = (&opts.tls_cert_path, &opts.tls_key_path) {
         match setup_tls(cert_path, key_path) {
@@ -140,26 +172,12 @@ pub async fn serve_with_handlers(
         None
     };
 
-    // Bind to the specified host and port. Use `TcpSocket` instead of
-    // `TcpListener::bind` so we can request a real backlog — mio hardcodes
-    // 128, which trivially overflows under thundering-herd reconnects (e.g.
-    // background jobs retrying on exp-backoff) and produces ECONNREFUSED on
-    // hosts with `tcp_abort_on_overflow=1`. The kernel will still clamp to
-    // `somaxconn`, so the host sysctl must also be raised in deploy config.
-    let server_addr = format!("{}:{}", opts.host, opts.port);
-    let addr = lookup_host(&server_addr)
-        .await?
-        .next()
-        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
-    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
-    socket.set_reuseaddr(true)?;
-    socket.bind(addr)?;
-    let listener = socket.listen(opts.backlog)?;
-    if tls_acceptor.is_some() {
-        info!("Listening on {server_addr} with TLS encryption (backlog={})", opts.backlog);
-    } else {
-        info!("Listening on {server_addr} (unencrypted, backlog={})", opts.backlog);
-    }
+    // Note: opts.backlog reflects the options object, not necessarily the
+    // listening socket — callers passing a pre-bound listener may have set a
+    // different backlog at bind time.
+    let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
+    let tls_label = if tls_acceptor.is_some() { "TLS" } else { "unencrypted" };
+    info!("Listening on {local_addr} ({tls_label})");
 
     // Connection limiter (if configured)
     let max_conn_count = opts.max_connections;

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -8,6 +8,7 @@ pub mod testing;
 
 use std::fs::File;
 use std::io::{BufReader, Error as IOError, ErrorKind};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use datafusion::prelude::SessionContext;
@@ -133,10 +134,15 @@ pub async fn serve_with_handlers(
 /// `somaxconn`, so the host sysctl must match.
 pub async fn bind_listener(host: &str, port: u16, backlog: u32) -> Result<TcpListener, std::io::Error> {
     let server_addr = format!("{host}:{port}");
-    let addr = lookup_host(&server_addr)
-        .await?
-        .next()
-        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
+    // Skip the async resolver round-trip when host parses as a literal IP
+    // (the common 0.0.0.0 / :: case). lookup_host is only needed for names.
+    let addr = match server_addr.parse::<SocketAddr>() {
+        Ok(a) => a,
+        Err(_) => lookup_host(&server_addr)
+            .await?
+            .next()
+            .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?,
+    };
     let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
     socket.set_reuseaddr(true)?;
     socket.bind(addr)?;

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -17,7 +17,7 @@ use pgwire::api::PgWireServerHandlers;
 use pgwire::tokio::process_socket;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
-use tokio::net::TcpListener;
+use tokio::net::{lookup_host, TcpSocket};
 use tokio::sync::Semaphore;
 use tokio_rustls::rustls::{self, ServerConfig};
 use tokio_rustls::TlsAcceptor;
@@ -39,6 +39,11 @@ pub struct ServerOptions {
     tls_cert_path: Option<String>,
     tls_key_path: Option<String>,
     max_connections: usize,
+    /// Listen backlog passed to `listen(2)`. Default 4096 — well above mio's
+    /// hardcoded 128 in `TcpListener::bind`. The OS will clamp to
+    /// `net.core.somaxconn` (Linux) / `kern.ipc.somaxconn` (macOS), so
+    /// raising both is required for the larger queue to take effect.
+    backlog: u32,
 }
 
 impl ServerOptions {
@@ -55,6 +60,7 @@ impl Default for ServerOptions {
             tls_cert_path: None,
             tls_key_path: None,
             max_connections: 0, // 0 = no limit
+            backlog: 4096,
         }
     }
 }
@@ -64,8 +70,7 @@ fn setup_tls(cert_path: &str, key_path: &str) -> Result<TlsAcceptor, IOError> {
     // Install ring crypto provider for rustls
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let cert = certs(&mut BufReader::new(File::open(cert_path)?))
-        .collect::<Result<Vec<CertificateDer>, IOError>>()?;
+    let cert = certs(&mut BufReader::new(File::open(cert_path)?)).collect::<Result<Vec<CertificateDer>, IOError>>()?;
 
     let key = pkcs8_private_keys(&mut BufReader::new(File::open(key_path)?))
         .map(|key| key.map(PrivateKeyDer::from))
@@ -83,10 +88,7 @@ fn setup_tls(cert_path: &str, key_path: &str) -> Result<TlsAcceptor, IOError> {
 }
 
 /// Serve the Datafusion `SessionContext` with Postgres protocol.
-pub async fn serve(
-    session_context: Arc<SessionContext>,
-    opts: &ServerOptions,
-) -> Result<(), std::io::Error> {
+pub async fn serve(session_context: Arc<SessionContext>, opts: &ServerOptions) -> Result<(), std::io::Error> {
     #[cfg(feature = "postgis")]
     geodatafusion::register(&session_context);
 
@@ -98,11 +100,7 @@ pub async fn serve(
 
 /// Serve the Datafusion `SessionContext` with Postgres protocol, using custom
 /// query processing hooks.
-pub async fn serve_with_hooks(
-    session_context: Arc<SessionContext>,
-    opts: &ServerOptions,
-    hooks: Vec<Arc<dyn QueryHook>>,
-) -> Result<(), std::io::Error> {
+pub async fn serve_with_hooks(session_context: Arc<SessionContext>, opts: &ServerOptions, hooks: Vec<Arc<dyn QueryHook>>) -> Result<(), std::io::Error> {
     #[cfg(feature = "postgis")]
     geodatafusion::register(&session_context);
 
@@ -123,44 +121,49 @@ pub async fn serve_with_hooks(
 /// listener just stops minting new ones. Pass `std::future::pending()` (or
 /// equivalent never-firing future) if you don't need shutdown signalling.
 pub async fn serve_with_handlers(
-    handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>,
-    opts: &ServerOptions,
-    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+    handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), std::io::Error> {
     // Set up TLS if configured
-    let tls_acceptor =
-        if let (Some(cert_path), Some(key_path)) = (&opts.tls_cert_path, &opts.tls_key_path) {
-            match setup_tls(cert_path, key_path) {
-                Ok(acceptor) => {
-                    info!("TLS enabled using cert: {cert_path} and key: {key_path}");
-                    Some(acceptor)
-                }
-                Err(e) => {
-                    warn!("Failed to setup TLS: {e}. Running without encryption.");
-                    None
-                }
+    let tls_acceptor = if let (Some(cert_path), Some(key_path)) = (&opts.tls_cert_path, &opts.tls_key_path) {
+        match setup_tls(cert_path, key_path) {
+            Ok(acceptor) => {
+                info!("TLS enabled using cert: {cert_path} and key: {key_path}");
+                Some(acceptor)
             }
-        } else {
-            info!("TLS not configured. Running without encryption.");
-            None
-        };
-
-    // Bind to the specified host and port
-    let server_addr = format!("{}:{}", opts.host, opts.port);
-    let listener = TcpListener::bind(&server_addr).await?;
-    if tls_acceptor.is_some() {
-        info!("Listening on {server_addr} with TLS encryption");
+            Err(e) => {
+                warn!("Failed to setup TLS: {e}. Running without encryption.");
+                None
+            }
+        }
     } else {
-        info!("Listening on {server_addr} (unencrypted)");
+        info!("TLS not configured. Running without encryption.");
+        None
+    };
+
+    // Bind to the specified host and port. Use `TcpSocket` instead of
+    // `TcpListener::bind` so we can request a real backlog — mio hardcodes
+    // 128, which trivially overflows under thundering-herd reconnects (e.g.
+    // background jobs retrying on exp-backoff) and produces ECONNREFUSED on
+    // hosts with `tcp_abort_on_overflow=1`. The kernel will still clamp to
+    // `somaxconn`, so the host sysctl must also be raised in deploy config.
+    let server_addr = format!("{}:{}", opts.host, opts.port);
+    let addr = lookup_host(&server_addr)
+        .await?
+        .next()
+        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
+    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+    socket.set_reuseaddr(true)?;
+    socket.bind(addr)?;
+    let listener = socket.listen(opts.backlog)?;
+    if tls_acceptor.is_some() {
+        info!("Listening on {server_addr} with TLS encryption (backlog={})", opts.backlog);
+    } else {
+        info!("Listening on {server_addr} (unencrypted, backlog={})", opts.backlog);
     }
 
     // Connection limiter (if configured)
     let max_conn_count = opts.max_connections;
-    let connection_limiter = if max_conn_count > 0 {
-        Some(Arc::new(Semaphore::new(max_conn_count)))
-    } else {
-        None
-    };
+    let connection_limiter = if max_conn_count > 0 { Some(Arc::new(Semaphore::new(max_conn_count))) } else { None };
 
     // Accept incoming connections until `shutdown` resolves. Existing
     // connections keep going on their spawned tasks — they're not cancelled

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -144,6 +144,10 @@ pub async fn bind_listener(host: &str, port: u16, backlog: u32) -> Result<TcpLis
             .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?,
     };
     let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+    // SO_REUSEADDR on Linux/macOS only governs TIME_WAIT reuse. On Windows it
+    // additionally allows another process to steal the port — so skip it
+    // there to keep the dev experience safe.
+    #[cfg(not(windows))]
     socket.set_reuseaddr(true)?;
     socket.bind(addr)?;
     let listener = socket.listen(backlog)?;
@@ -178,9 +182,10 @@ pub async fn serve_with_listener(
         None
     };
 
-    // Note: opts.backlog reflects the options object, not necessarily the
-    // listening socket — callers passing a pre-bound listener may have set a
-    // different backlog at bind time.
+    // Note: opts.host / opts.port / opts.backlog reflect the options object,
+    // not necessarily the listening socket — callers passing a pre-bound
+    // listener may have used different values at bind time. Only TLS config
+    // and connection-limit fields from opts affect behaviour from here on.
     let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
     let tls_label = if tls_acceptor.is_some() { "TLS" } else { "unencrypted" };
     info!("Listening on {local_addr} ({tls_label})");

--- a/vendor/walrus-rust/src/wal/runtime/allocator.rs
+++ b/vendor/walrus-rust/src/wal/runtime/allocator.rs
@@ -17,8 +17,8 @@ use crate::wal::{
 
 pub(super) struct BlockAllocator {
     next_block: UnsafeCell<Block>,
-    lock: AtomicBool,
-    paths: Arc<WalPathManager>,
+    lock:       AtomicBool,
+    paths:      Arc<WalPathManager>,
 }
 
 impl BlockAllocator {
@@ -113,12 +113,12 @@ impl BlockAllocator {
             debug_print!("[alloc] file rollover for sized alloc -> {}", data.file_path);
         }
         let ret = Block {
-            id: data.id,
+            id:        data.id,
             file_path: data.file_path.clone(),
-            offset: data.offset,
-            limit: alloc_size,
-            mmap: data.mmap.clone(),
-            used: 0,
+            offset:    data.offset,
+            limit:     alloc_size,
+            mmap:      data.mmap.clone(),
+            used:      0,
         };
         // register the new block before handing it out
         BlockStateTracker::register_block(ret.id as usize, &ret.file_path);
@@ -175,7 +175,7 @@ pub(super) fn flush_check(file_path: String) {
 
 struct BlockState {
     is_checkpointed: AtomicBool,
-    file_path: String,
+    file_path:       String,
 }
 
 pub(super) struct BlockStateTracker {}
@@ -191,7 +191,7 @@ impl BlockStateTracker {
         if let Ok(mut w) = map.write() {
             w.entry(block_id).or_insert_with(|| BlockState {
                 is_checkpointed: AtomicBool::new(false),
-                file_path: file_path.to_string(),
+                file_path:       file_path.to_string(),
             });
         }
     }
@@ -235,10 +235,10 @@ impl BlockStateTracker {
 }
 
 struct FileState {
-    locked_block_ctr: AtomicU16,
+    locked_block_ctr:     AtomicU16,
     checkpoint_block_ctr: AtomicU16,
-    total_blocks: AtomicU16,
-    is_fully_allocated: AtomicBool,
+    total_blocks:         AtomicU16,
+    is_fully_allocated:   AtomicBool,
 }
 
 pub(super) struct FileStateTracker {}
@@ -253,10 +253,10 @@ impl FileStateTracker {
         let map = Self::map();
         let mut w = map.write().expect("file state map write lock poisoned");
         w.entry(file_path.to_string()).or_insert_with(|| FileState {
-            locked_block_ctr: AtomicU16::new(0),
+            locked_block_ctr:     AtomicU16::new(0),
             checkpoint_block_ctr: AtomicU16::new(0),
-            total_blocks: AtomicU16::new(0),
-            is_fully_allocated: AtomicBool::new(false),
+            total_blocks:         AtomicU16::new(0),
+            is_fully_allocated:   AtomicBool::new(false),
         });
     }
 

--- a/vendor/walrus-rust/src/wal/runtime/allocator.rs
+++ b/vendor/walrus-rust/src/wal/runtime/allocator.rs
@@ -17,8 +17,8 @@ use crate::wal::{
 
 pub(super) struct BlockAllocator {
     next_block: UnsafeCell<Block>,
-    lock:       AtomicBool,
-    paths:      Arc<WalPathManager>,
+    lock: AtomicBool,
+    paths: Arc<WalPathManager>,
 }
 
 impl BlockAllocator {
@@ -113,12 +113,12 @@ impl BlockAllocator {
             debug_print!("[alloc] file rollover for sized alloc -> {}", data.file_path);
         }
         let ret = Block {
-            id:        data.id,
+            id: data.id,
             file_path: data.file_path.clone(),
-            offset:    data.offset,
-            limit:     alloc_size,
-            mmap:      data.mmap.clone(),
-            used:      0,
+            offset: data.offset,
+            limit: alloc_size,
+            mmap: data.mmap.clone(),
+            used: 0,
         };
         // register the new block before handing it out
         BlockStateTracker::register_block(ret.id as usize, &ret.file_path);
@@ -175,7 +175,7 @@ pub(super) fn flush_check(file_path: String) {
 
 struct BlockState {
     is_checkpointed: AtomicBool,
-    file_path:       String,
+    file_path: String,
 }
 
 pub(super) struct BlockStateTracker {}
@@ -191,7 +191,7 @@ impl BlockStateTracker {
         if let Ok(mut w) = map.write() {
             w.entry(block_id).or_insert_with(|| BlockState {
                 is_checkpointed: AtomicBool::new(false),
-                file_path:       file_path.to_string(),
+                file_path: file_path.to_string(),
             });
         }
     }
@@ -203,32 +203,42 @@ impl BlockStateTracker {
     }
 
     pub(super) fn set_checkpointed_true(block_id: usize) {
-        let path_opt = {
+        // Idempotent: only increment the file's checkpoint counter on the
+        // false→true transition. Prior to this, repeated calls would
+        // double-increment `checkpoint_block_ctr` (cursor rebases across
+        // chain resets, or the new fast-forward path in
+        // `set_persisted_read_position`), potentially overshooting `total`
+        // without ever clearing — and on the other side of the comparison,
+        // legitimately-checkpointed blocks could fail the `>= total` check
+        // if a parallel duplicate consumed the increment "budget" earlier.
+        let (path_opt, transitioned) = {
             let map = Self::map();
             if let Ok(r) = map.read() {
                 if let Some(b) = r.get(&block_id) {
-                    b.is_checkpointed.store(true, Ordering::Release);
-                    Some(b.file_path.clone())
+                    let prev = b.is_checkpointed.swap(true, Ordering::AcqRel);
+                    (Some(b.file_path.clone()), !prev)
                 } else {
-                    None
+                    (None, false)
                 }
             } else {
-                None
+                (None, false)
             }
         };
 
         if let Some(path) = path_opt {
-            FileStateTracker::inc_checkpoint_for_file(&path);
+            if transitioned {
+                FileStateTracker::inc_checkpoint_for_file(&path);
+            }
             flush_check(path);
         }
     }
 }
 
 struct FileState {
-    locked_block_ctr:     AtomicU16,
+    locked_block_ctr: AtomicU16,
     checkpoint_block_ctr: AtomicU16,
-    total_blocks:         AtomicU16,
-    is_fully_allocated:   AtomicBool,
+    total_blocks: AtomicU16,
+    is_fully_allocated: AtomicBool,
 }
 
 pub(super) struct FileStateTracker {}
@@ -243,10 +253,10 @@ impl FileStateTracker {
         let map = Self::map();
         let mut w = map.write().expect("file state map write lock poisoned");
         w.entry(file_path.to_string()).or_insert_with(|| FileState {
-            locked_block_ctr:     AtomicU16::new(0),
+            locked_block_ctr: AtomicU16::new(0),
             checkpoint_block_ctr: AtomicU16::new(0),
-            total_blocks:         AtomicU16::new(0),
-            is_fully_allocated:   AtomicBool::new(false),
+            total_blocks: AtomicU16::new(0),
+            is_fully_allocated: AtomicBool::new(false),
         });
     }
 

--- a/vendor/walrus-rust/src/wal/runtime/allocator.rs
+++ b/vendor/walrus-rust/src/wal/runtime/allocator.rs
@@ -229,6 +229,10 @@ impl BlockStateTracker {
             if transitioned {
                 FileStateTracker::inc_checkpoint_for_file(&path);
             }
+            // Deliberate: call flush_check even when no transition happened.
+            // It acts as a retry for files whose previous checkpoint observation
+            // raced `set_fully_allocated` and didn't reclaim — replays of the
+            // same block_id can still close out the file.
             flush_check(path);
         }
     }

--- a/vendor/walrus-rust/src/wal/runtime/allocator.rs
+++ b/vendor/walrus-rust/src/wal/runtime/allocator.rs
@@ -232,7 +232,9 @@ impl BlockStateTracker {
             // Deliberate: call flush_check even when no transition happened.
             // It acts as a retry for files whose previous checkpoint observation
             // raced `set_fully_allocated` and didn't reclaim — replays of the
-            // same block_id can still close out the file.
+            // same block_id can still close out the file. Tradeoff: a slightly
+            // hotter DELETION_TX channel (one extra send per duplicate call)
+            // in exchange for correctness against racing observers.
             flush_check(path);
         }
     }

--- a/vendor/walrus-rust/src/wal/runtime/position.rs
+++ b/vendor/walrus-rust/src/wal/runtime/position.rs
@@ -10,7 +10,10 @@
 
 use std::io;
 
-use super::Walrus;
+use super::{
+    Walrus,
+    allocator::{BlockStateTracker, FileStateTracker},
+};
 
 const TAIL_FLAG: u64 = 1u64 << 63;
 
@@ -24,7 +27,7 @@ const TAIL_FLAG: u64 = 1u64 << 63;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WalPosition {
     pub block_id: u64,
-    pub offset:   u64,
+    pub offset: u64,
 }
 
 impl WalPosition {
@@ -50,7 +53,7 @@ impl Walrus {
                 let (block, written) = w.snapshot_block()?;
                 return Ok(WalPosition {
                     block_id: block.id,
-                    offset:   written,
+                    offset: written,
                 });
             }
         }
@@ -64,7 +67,7 @@ impl Walrus {
                     if let Some(last) = info.chain.last() {
                         return Ok(WalPosition {
                             block_id: last.id,
-                            offset:   last.used,
+                            offset: last.used,
                         });
                     }
                 }
@@ -111,14 +114,14 @@ impl Walrus {
         if chain_idx < info.chain.len() {
             Ok(Some(WalPosition {
                 block_id: info.chain[chain_idx].id,
-                offset:   pos.cur_block_offset,
+                offset: pos.cur_block_offset,
             }))
         } else if chain_idx == info.chain.len() && !info.chain.is_empty() {
             // Past the last sealed block; use the last block's tail.
             let last = info.chain.last().unwrap();
             Ok(Some(WalPosition {
                 block_id: last.id,
-                offset:   last.used,
+                offset: last.used,
             }))
         } else {
             Ok(None)
@@ -154,8 +157,46 @@ impl Walrus {
         }
         drop(idx_guard);
 
+        // Mark every sealed block strictly before `pos` as checkpointed. The
+        // normal advance path (`read_next`) does this lazily as the cursor
+        // walks past each block; a Delta-derived fast-forward (TimeFusion's
+        // `derive_wal_cursor_for_table`) bypasses `read_next` entirely, so
+        // without this loop the skipped-over blocks stay uncheckpointed
+        // forever and their containing files never become eligible for
+        // deletion (`flush_check` requires `checkpointed >= total`).
+        //
+        // We checkpoint a block when its id is strictly less than the target
+        // block_id, OR equal-id with the cursor having consumed past the
+        // block's `used` bytes (the same condition `read_next` uses).
+        self.checkpoint_blocks_before(col_name, pos);
+
         self.invalidate_hydration(col_name);
         Ok(())
+    }
+
+    /// Test/diagnostic accessor: per-block file accounting for the file
+    /// owning `block_id`. Returns `(checkpointed, total)` block counts on
+    /// that file — file becomes eligible for deletion when
+    /// `checkpointed >= total` (and unlocked, fully allocated). Useful for
+    /// regression tests covering the cursor fast-forward → file-reclaim
+    /// path; not part of normal runtime use.
+    #[doc(hidden)]
+    pub fn block_file_checkpoint_state(block_id: u64) -> Option<(u16, u16)> {
+        let path = BlockStateTracker::get_file_path_for_block(block_id as usize)?;
+        FileStateTracker::get_state_snapshot(&path).map(|(_l, c, t, _f)| (c, t))
+    }
+
+    fn checkpoint_blocks_before(&self, col_name: &str, pos: WalPosition) {
+        let Ok(map) = self.reader.data.read() else { return };
+        let Some(info_arc) = map.get(col_name).cloned() else { return };
+        drop(map);
+        let Ok(info) = info_arc.read() else { return };
+        for block in info.chain.iter() {
+            let past_block = block.id < pos.block_id || (block.id == pos.block_id && pos.offset >= block.used);
+            if past_block {
+                BlockStateTracker::set_checkpointed_true(block.id as usize);
+            }
+        }
     }
 
     fn find_chain_position(&self, col_name: &str, pos: WalPosition) -> Option<(u64, u64)> {

--- a/vendor/walrus-rust/src/wal/runtime/position.rs
+++ b/vendor/walrus-rust/src/wal/runtime/position.rs
@@ -189,11 +189,23 @@ impl Walrus {
     }
 
     fn checkpoint_blocks_before(&self, col_name: &str, pos: WalPosition) {
+        // Lock sequence: (1) reader.data read → clone info_arc → drop,
+        // (2) info_arc read held while iterating chain,
+        // (3) per-block: BlockStateTracker::map read inside set_checkpointed_true,
+        //     then a channel send via flush_check. All three are distinct locks
+        //     so the nested acquisition order is fixed → no deadlock potential.
         let Ok(map) = self.reader.data.read() else { return };
         let Some(info_arc) = map.get(col_name).cloned() else { return };
         drop(map);
         let Ok(info) = info_arc.read() else { return };
         for block in info.chain.iter() {
+            // Matches read_next's "past block" predicate. If pos lands exactly
+            // at the active head (block.id == pos.block_id, pos.offset == used)
+            // the block is sealed as far as the cursor is concerned — the
+            // writer can still append, but those future bytes belong to the
+            // *next* logical chunk for this reader. A concurrent append only
+            // grows `block.used`; it never invalidates an already-observed
+            // (id, used) tuple, so no race with appends.
             let past_block = block.id < pos.block_id || (block.id == pos.block_id && pos.offset >= block.used);
             if past_block {
                 BlockStateTracker::set_checkpointed_true(block.id as usize);

--- a/vendor/walrus-rust/src/wal/runtime/position.rs
+++ b/vendor/walrus-rust/src/wal/runtime/position.rs
@@ -180,6 +180,8 @@ impl Walrus {
     /// `checkpointed >= total` (and unlocked, fully allocated). Useful for
     /// regression tests covering the cursor fast-forward → file-reclaim
     /// path; not part of normal runtime use.
+    // test-only: kept `pub` so cross-crate regression tests in tests/position.rs
+    // can probe file-level checkpoint counts after fast-forward.
     #[doc(hidden)]
     pub fn block_file_checkpoint_state(block_id: u64) -> Option<(u16, u16)> {
         let path = BlockStateTracker::get_file_path_for_block(block_id as usize)?;

--- a/vendor/walrus-rust/src/wal/runtime/position.rs
+++ b/vendor/walrus-rust/src/wal/runtime/position.rs
@@ -27,7 +27,7 @@ const TAIL_FLAG: u64 = 1u64 << 63;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WalPosition {
     pub block_id: u64,
-    pub offset: u64,
+    pub offset:   u64,
 }
 
 impl WalPosition {
@@ -53,7 +53,7 @@ impl Walrus {
                 let (block, written) = w.snapshot_block()?;
                 return Ok(WalPosition {
                     block_id: block.id,
-                    offset: written,
+                    offset:   written,
                 });
             }
         }
@@ -67,7 +67,7 @@ impl Walrus {
                     if let Some(last) = info.chain.last() {
                         return Ok(WalPosition {
                             block_id: last.id,
-                            offset: last.used,
+                            offset:   last.used,
                         });
                     }
                 }
@@ -114,14 +114,14 @@ impl Walrus {
         if chain_idx < info.chain.len() {
             Ok(Some(WalPosition {
                 block_id: info.chain[chain_idx].id,
-                offset: pos.cur_block_offset,
+                offset:   pos.cur_block_offset,
             }))
         } else if chain_idx == info.chain.len() && !info.chain.is_empty() {
             // Past the last sealed block; use the last block's tail.
             let last = info.chain.last().unwrap();
             Ok(Some(WalPosition {
                 block_id: last.id,
-                offset: last.used,
+                offset:   last.used,
             }))
         } else {
             Ok(None)

--- a/vendor/walrus-rust/tests/position.rs
+++ b/vendor/walrus-rust/tests/position.rs
@@ -83,6 +83,98 @@ fn set_position_to_origin_replays_from_start() {
     assert_eq!(second.data, b"y");
 }
 
+/// Regression: a Delta-derived cursor fast-forward (TimeFusion's
+/// `derive_wal_cursor_for_table`) used to bypass the normal block-checkpoint
+/// accounting that `read_next` performs lazily. With the bypass, blocks the
+/// cursor skipped stayed `is_checkpointed=false` forever, so their
+/// containing files never satisfied `checkpointed >= total` and were never
+/// reclaimed. This produced the prod symptom of ever-growing WAL files
+/// (346 GB stuck at 347 files on the timefusion node).
+/// Fill > 1 default block (10 MiB) so the first block gets sealed and
+/// pushed into the reader chain — the precondition for both regression
+/// tests below.
+fn fill_two_blocks(wal: &Walrus, topic: &str) -> WalPosition {
+    // Slightly larger than DEFAULT_BLOCK_SIZE so the second append spills
+    // into a new block, sealing the first one.
+    let big = vec![0xAB; 11 * 1024 * 1024];
+    wal.append_for_topic(topic, &big).unwrap();
+    wal.append_for_topic(topic, b"tail-marker").unwrap();
+    wal.current_position(topic).unwrap()
+}
+
+/// Regression: a Delta-derived cursor fast-forward (TimeFusion's
+/// `derive_wal_cursor_for_table`) used to bypass the normal block-checkpoint
+/// accounting that `read_next` performs lazily. With the bypass, sealed
+/// blocks the cursor skipped stayed `is_checkpointed=false` forever, so
+/// their containing files never satisfied `checkpointed >= total` and
+/// were never reclaimed. This produced the prod symptom of ever-growing
+/// WAL files (346 GB stuck at 347 files on the timefusion node).
+#[test]
+fn set_persisted_read_position_checkpoints_skipped_blocks() {
+    let _env = setup();
+    let wal = Walrus::new().unwrap();
+    let topic = "fastforward-checkpoints";
+
+    // Force at least one block to seal so we have a chain entry the fix
+    // can actually checkpoint.
+    let watermark = fill_two_blocks(&wal, topic);
+    assert!(!watermark.is_origin(), "watermark must point past origin");
+
+    // The sealed block has id < watermark.block_id (the watermark is in
+    // the *active* block). Look up its file state before the fast-forward:
+    // checkpointed must be 0 because we haven't read anything yet.
+    let sealed_block_id = watermark.block_id - 1;
+    let before = Walrus::block_file_checkpoint_state(sealed_block_id).expect("sealed block must have a file state entry");
+    assert_eq!(before.0, 0, "sealed block must start un-checkpointed (before={:?})", before);
+
+    // Fast-forward the cursor directly to the watermark — the path
+    // TimeFusion uses when Delta is ahead of walrus's locally-fsynced
+    // cursor.
+    wal.set_persisted_read_position(topic, watermark).unwrap();
+
+    // The sealed block MUST be marked checkpointed now so its file
+    // becomes reclaimable. Prior to the fix this stayed 0.
+    let after = Walrus::block_file_checkpoint_state(sealed_block_id).expect("sealed block must still resolve");
+    assert!(
+        after.0 >= 1,
+        "fast-forward must checkpoint sealed blocks behind the cursor — \
+         before=(checkpointed={}, total={}), after=(checkpointed={}, total={})",
+        before.0,
+        before.1,
+        after.0,
+        after.1
+    );
+
+    // And the cursor itself is past tail — confirms behavior wasn't
+    // regressed.
+    assert!(wal.read_next(topic, true).unwrap().is_none(), "cursor must be at tail");
+}
+
+#[test]
+fn set_checkpointed_true_is_idempotent_per_block() {
+    let _env = setup();
+    let wal = Walrus::new().unwrap();
+    let topic = "checkpoint-idempotent";
+
+    let watermark = fill_two_blocks(&wal, topic);
+    let sealed_block_id = watermark.block_id - 1;
+
+    // Fast-forward twice. Without the idempotence fix the second call
+    // would double-increment `checkpoint_block_ctr` past `total`, masking
+    // latent accounting drift; with the fix the counter is stable.
+    wal.set_persisted_read_position(topic, watermark).unwrap();
+    let after_first = Walrus::block_file_checkpoint_state(sealed_block_id).unwrap().0;
+    wal.set_persisted_read_position(topic, watermark).unwrap();
+    let after_second = Walrus::block_file_checkpoint_state(sealed_block_id).unwrap().0;
+
+    assert!(after_first >= 1, "first fast-forward must checkpoint the sealed block");
+    assert_eq!(
+        after_first, after_second,
+        "second fast-forward must not double-increment (after_first={}, after_second={})",
+        after_first, after_second
+    );
+}
+
 #[test]
 fn position_snapshot_then_set_recreates_cursor() {
     let _env = setup();


### PR DESCRIPTION
## Summary

Two independent fixes surfaced while investigating a prod incident where monoscope's bulk-insert background jobs were repeatedly getting `Connection refused` and `Usage chunk submission FAILED` against `timefusion.s.past3.tech:5432`. The investigation rabbit-holed through a few hypotheses before landing on the real root cause; full thread in the linked PR description below.

### 1. WAL file leak (the prod-impacting one)

`walrus::set_persisted_read_position` — the API TimeFusion uses to fast-forward the WAL cursor when Delta is ahead of walrus's locally-fsynced cursor on startup — wrote the cursor but never called `set_checkpointed_true` on the sealed blocks it skipped over. Without that call, blocks stayed `is_checkpointed=false` forever, so the file's `checkpointed_block_ctr < total_blocks` invariant was never reached and `flush_check` never enqueued the file for deletion. Prod symptom: **346 GB stuck across 347 WAL files**, with the emergency-flush warning firing every 10 minutes for hours without any change:

```
WAL stats: 347 files, 346000MB
WAL file count 347 exceeds threshold 200, triggering emergency flush
```

(Flushes themselves were working — Delta commits were succeeding the whole time. The bug was in WAL *truncation* after successful flush.)

Also fixed: `set_checkpointed_true` was non-idempotent — duplicate calls would double-increment `checkpoint_block_ctr`, masking accounting drift. Made it `swap`-based.

Two regression tests in `vendor/walrus-rust/tests/position.rs` force a real block seal (>10 MiB write) so the fix path is actually exercised, then verify (a) the sealed block is checkpointed after the fast-forward and (b) repeat fast-forwards are no-ops on the file counter.

### 2. pgwire listen backlog (defense-in-depth)

`TcpListener::bind` goes through mio, which hardcodes the listen backlog to **128** on Linux/macOS. Under a thundering-herd reconnect (e.g. background jobs converging on a retry tick), accept queue overflow → kernel drops SYN or, with `tcp_abort_on_overflow=1`, sends RST → `ECONNREFUSED` at the client with no application-level trace.

Rebinds via `tokio::net::TcpSocket` so we control the backlog (default 4096, configurable via `ServerOptions::with_backlog`). OS still clamps to `somaxconn`, so the prod host config matters too.

Prod was already on `somaxconn=4096` so this wasn't the proximate cause there, but the hardcoded 128 is a footgun the moment anyone runs on a tighter host. Test in `tests/listen_backlog_test.rs` pins the mechanism: backlog=128 + stalled acceptor + 300 connects → exactly 128 land.

## Verification

- `cargo test -p walrus-rust --test position` — 7/7 pass (5 existing + 2 new regressions).
- `cargo build` — clean.
- `cargo test --lib` — 106/106 pass.
- `cargo test --test pgwire_dml_tag_test` — 4/4 pass (real server start/bind/accept/serve).
- `cargo test --test listen_backlog_test` — 3/3 pass.

## Deploy notes

Critical: **don't restart prod without this fix in place** — every restart so far has been creating new orphaned blocks. After deploy + restart:

1. `startup_chore` re-scans the WAL dir, re-registers files and blocks, and checkpoints blocks behind the persisted cursor (existing behaviour at `walrus.rs:274-279`).
2. `derive_wal_cursor_for_table` then advances the cursor further to the Delta watermark; with this fix, the gap is also checkpointed.
3. Background deletion task drains the queue.

Expected effect: `WAL stats: N files, M MB` line should drop sharply within minutes of `BufferedWriteLayer background tasks started`. If it doesn't, walrus's persisted-read cursor is *behind* the on-disk blocks for some topic, meaning recovery still has to walk them — that's a P1 follow-up (early `:5432` bind + background recovery so monoscope doesn't see another 15-minute `ECONNREFUSED` window during the startup).

## Also in this PR

- **Early bind 57P03 responder** — `:5432` is bound before `BufferedWriteLayer::recover_from_wal` so clients connecting during the 8–15 min recovery window get SQLSTATE `57P03` ("the database system is starting up") instead of `ECONNREFUSED`. Postgres clients (Hasql, pgjdbc, libpq) recognise 57P03 and back off cleanly. See `src/pgwire_early_bind.rs` and the wiring in `src/main.rs`.
- **Listener backlog raised to 4096** — `vendor/datafusion-postgres::bind_listener` now uses `TcpSocket::new_v* + listen(backlog)` instead of `TcpListener::bind` (which mio hardcodes to 128). Kernel still clamps to `somaxconn`, so the deploy must also raise `net.core.somaxconn`.

## What's next (not in this PR)

- **WAL GC sweep** — opportunistic background scan that re-checks `flush_check` on all known files, so any stragglers from edge cases get reaped.

## Test plan

- [ ] Deploy to staging, ingest some workload, force a restart, verify `WAL stats` drops post-recovery.
- [ ] Confirm `ss -ltn '( sport = :5432 )'` shows `Send-Q=4096` after deploy.
- [ ] Watch `ListenOverflows` counter for absence of new entries.
