### PR TITLE
pgwire: early-bind 57P03 responder during startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ tonic-prost-build = "0.14"
 [dev-dependencies]
 sqllogictest = { git = "https://github.com/risinglightdb/sqllogictest-rs.git" }
 serial_test = "3.2.0"
+tokio = { version = "1.48", features = ["test-util"] }
 datafusion-common = "53.1.0"
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4"] }
 scopeguard = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod mem_buffer;
 pub mod metrics;
 pub mod object_store_cache;
 pub mod optimizers;
+pub mod pgwire_early_bind;
 pub mod pgwire_handlers;
 pub mod plan_cache;
 pub mod schema_loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,7 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Hasql / pgjdbc / libpq expect during a backend restart and retry
     // on cleanly. See pgwire_early_bind for the responder.
     let pg_opts = ServerOptions::new().with_host("0.0.0.0".to_string()).with_port(cfg.core.pgwire_port);
-    let (host, port, backlog) = (pg_opts.host().clone(), *pg_opts.port(), *pg_opts.backlog());
-    let pg_listener = datafusion_postgres::bind_listener(&host, port, backlog).await?;
-    info!("PGWire listener bound on {host}:{port} (backlog={backlog}) before startup work begins");
+    let pg_listener = datafusion_postgres::bind_listener(pg_opts.host(), *pg_opts.port(), *pg_opts.backlog()).await?;
     let early_shutdown = tokio_util::sync::CancellationToken::new();
     let early_task = tokio::spawn({
         let shutdown = early_shutdown.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,9 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Hasql / pgjdbc / libpq expect during a backend restart and retry
     // on cleanly. See pgwire_early_bind for the responder.
     let pg_opts = ServerOptions::new().with_host("0.0.0.0".to_string()).with_port(cfg.core.pgwire_port);
-    let pg_listener = datafusion_postgres::bind_listener(pg_opts.host(), *pg_opts.port(), *pg_opts.backlog()).await?;
-    info!("PGWire listener bound on {}:{} (backlog={}) before startup work begins", pg_opts.host(), pg_opts.port(), pg_opts.backlog());
+    let (host, port, backlog) = (pg_opts.host().clone(), *pg_opts.port(), *pg_opts.backlog());
+    let pg_listener = datafusion_postgres::bind_listener(&host, port, backlog).await?;
+    info!("PGWire listener bound on {host}:{port} (backlog={backlog}) before startup work begins");
     let early_shutdown = tokio_util::sync::CancellationToken::new();
     let early_task = tokio::spawn({
         let shutdown = early_shutdown.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,23 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Create Arc<AppConfig> for passing to components
     let cfg_arc = Arc::new(cfg.clone());
 
+    // Bind :5432 immediately, before the slow startup work (Database open,
+    // WAL recovery — up to ~15 min when WAL has accumulated). Clients
+    // connecting in this window get SQLSTATE 57P03 ("starting up") from
+    // the early-bind responder instead of ECONNREFUSED, which is what
+    // Hasql / pgjdbc / libpq expect during a backend restart and retry
+    // on cleanly. See pgwire_early_bind for the responder.
+    let pg_port = cfg.core.pgwire_port;
+    let pg_backlog = 4096u32;
+    let pg_listener = Arc::new(bind_pgwire_listener("0.0.0.0", pg_port, pg_backlog).await?);
+    info!("PGWire listener bound on :{} (backlog={}) before startup work begins", pg_port, pg_backlog);
+    let early_shutdown = tokio_util::sync::CancellationToken::new();
+    let early_shutdown_for_task = early_shutdown.clone();
+    let early_listener = Arc::clone(&pg_listener);
+    let early_task = tokio::spawn(async move {
+        timefusion::pgwire_early_bind::run_until_ready(&early_listener, early_shutdown_for_task).await;
+    });
+
     // Initialize database with explicit config
     let mut db = Database::with_config(Arc::clone(&cfg_arc)).await?;
     info!("Database initialized successfully");
@@ -157,9 +174,16 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let db = Arc::new(db);
     db.setup_session_tables(&mut session_context)?;
 
-    // Start PGWire server
-    let pg_port = cfg.core.pgwire_port;
-    info!("Starting PGWire server on port: {}", pg_port);
+    // Start PGWire server on the listener we pre-bound at the top of
+    // async_main. First, hand control of that listener back from the
+    // early-bind 57P03 responder.
+    info!("Stopping early-bind 57P03 responder; handing listener to real PGWire server");
+    early_shutdown.cancel();
+    let _ = early_task.await;
+    // Both Arc handles dropped now (early_task held the only other one);
+    // try_unwrap should succeed and give us the owned listener.
+    let listener = Arc::try_unwrap(pg_listener)
+        .map_err(|_| anyhow::anyhow!("PGWire listener still has outstanding Arc references after early-bind shutdown"))?;
 
     let auth_config = timefusion::pgwire_handlers::AuthConfig::from_core(&cfg.core)?;
 
@@ -170,9 +194,9 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let pgwire_shutdown = tokio_util::sync::CancellationToken::new();
     let pgwire_shutdown_for_task = pgwire_shutdown.clone();
     let pg_task = tokio::spawn(async move {
-        let opts = ServerOptions::new().with_port(pg_port).with_host("0.0.0.0".to_string());
+        let opts = ServerOptions::new().with_port(pg_port).with_host("0.0.0.0".to_string()).with_backlog(pg_backlog);
 
-        if let Err(e) = timefusion::pgwire_handlers::serve_with_logging(Arc::new(session_context), &opts, auth_config, async move {
+        if let Err(e) = timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &opts, auth_config, async move {
             pgwire_shutdown_for_task.cancelled().await
         })
         .await
@@ -310,4 +334,19 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     telemetry::shutdown_telemetry();
 
     Ok(())
+}
+
+/// Bind the PGWire listener on `host:port` with an explicit backlog of
+/// `backlog`. Uses `TcpSocket` rather than `TcpListener::bind` so we
+/// control the backlog (mio's `bind` hardcodes 128); the kernel still
+/// clamps to `somaxconn`. Pulled out as its own function so the early
+/// 57P03 responder and the real server share one bind path.
+async fn bind_pgwire_listener(host: &str, port: u16, backlog: u32) -> anyhow::Result<tokio::net::TcpListener> {
+    use tokio::net::{lookup_host, TcpSocket};
+    let server_addr = format!("{host}:{port}");
+    let addr = lookup_host(&server_addr).await?.next().ok_or_else(|| anyhow::anyhow!("could not resolve {server_addr}"))?;
+    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+    socket.set_reuseaddr(true)?;
+    socket.bind(addr)?;
+    Ok(socket.listen(backlog)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // the early-bind responder instead of ECONNREFUSED, which is what
     // Hasql / pgjdbc / libpq expect during a backend restart and retry
     // on cleanly. See pgwire_early_bind for the responder.
-    let pg_listener = bind_pgwire_listener("0.0.0.0", cfg.core.pgwire_port, 4096).await?;
+    let pg_opts = ServerOptions::new().with_host("0.0.0.0".to_string()).with_port(cfg.core.pgwire_port);
+    let pg_listener = datafusion_postgres::bind_listener(pg_opts.host(), *pg_opts.port(), *pg_opts.backlog()).await?;
+    info!("PGWire listener bound on {}:{} (backlog={}) before startup work begins", pg_opts.host(), pg_opts.port(), pg_opts.backlog());
     let early_shutdown = tokio_util::sync::CancellationToken::new();
     let early_task = tokio::spawn({
         let shutdown = early_shutdown.clone();
@@ -191,11 +193,8 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let pg_task = tokio::spawn({
         let shutdown = pgwire_shutdown.clone();
         async move {
-            // host/port/backlog already applied at bind time; opts only
-            // contributes TLS + max_connections from here on.
-            let opts = ServerOptions::new();
             if let Err(e) =
-                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &opts, auth_config, shutdown.cancelled_owned())
+                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &pg_opts, auth_config, shutdown.cancelled_owned())
                     .await
             {
                 error!("PGWire server error: {}", e);
@@ -334,14 +333,3 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Bind via `TcpSocket` so we can pass an explicit `backlog`
-/// (`TcpListener::bind` hardcodes 128; kernel still clamps to `somaxconn`).
-async fn bind_pgwire_listener(host: &str, port: u16, backlog: u32) -> anyhow::Result<tokio::net::TcpListener> {
-    use tokio::net::{lookup_host, TcpSocket};
-    let server_addr = format!("{host}:{port}");
-    let addr = lookup_host(&server_addr).await?.next().ok_or_else(|| anyhow::anyhow!("could not resolve {server_addr}"))?;
-    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
-    socket.set_reuseaddr(true)?;
-    socket.bind(addr)?;
-    Ok(socket.listen(backlog)?)
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,15 +52,14 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // the early-bind responder instead of ECONNREFUSED, which is what
     // Hasql / pgjdbc / libpq expect during a backend restart and retry
     // on cleanly. See pgwire_early_bind for the responder.
-    let pg_port = cfg.core.pgwire_port;
-    let pg_backlog = 4096u32;
-    let pg_listener = Arc::new(bind_pgwire_listener("0.0.0.0", pg_port, pg_backlog).await?);
-    info!("PGWire listener bound on :{} (backlog={}) before startup work begins", pg_port, pg_backlog);
+    let pg_listener = bind_pgwire_listener("0.0.0.0", cfg.core.pgwire_port, 4096).await?;
     let early_shutdown = tokio_util::sync::CancellationToken::new();
-    let early_shutdown_for_task = early_shutdown.clone();
-    let early_listener = Arc::clone(&pg_listener);
-    let early_task = tokio::spawn(async move {
-        timefusion::pgwire_early_bind::run_until_ready(&early_listener, early_shutdown_for_task).await;
+    let early_task = tokio::spawn({
+        let shutdown = early_shutdown.clone();
+        async move {
+            timefusion::pgwire_early_bind::run_until_ready(&pg_listener, shutdown).await;
+            pg_listener
+        }
     });
 
     // Initialize database with explicit config
@@ -177,13 +176,10 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // Start PGWire server on the listener we pre-bound at the top of
     // async_main. First, hand control of that listener back from the
     // early-bind 57P03 responder.
-    info!("Stopping early-bind 57P03 responder; handing listener to real PGWire server");
+    // handle_one tasks accepted just before shutdown may still be running;
+    // they own only the accepted sockets and complete independently.
     early_shutdown.cancel();
-    let _ = early_task.await;
-    // Both Arc handles dropped now (early_task held the only other one);
-    // try_unwrap should succeed and give us the owned listener.
-    let listener = Arc::try_unwrap(pg_listener)
-        .map_err(|_| anyhow::anyhow!("PGWire listener still has outstanding Arc references after early-bind shutdown"))?;
+    let listener = early_task.await?;
 
     let auth_config = timefusion::pgwire_handlers::AuthConfig::from_core(&cfg.core)?;
 
@@ -192,16 +188,18 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // BufferedWriteLayer flush isn't racing fresh inserts. Already-accepted
     // connections finish on their own spawned tasks.
     let pgwire_shutdown = tokio_util::sync::CancellationToken::new();
-    let pgwire_shutdown_for_task = pgwire_shutdown.clone();
-    let pg_task = tokio::spawn(async move {
-        let opts = ServerOptions::new().with_port(pg_port).with_host("0.0.0.0".to_string()).with_backlog(pg_backlog);
-
-        if let Err(e) = timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &opts, auth_config, async move {
-            pgwire_shutdown_for_task.cancelled().await
-        })
-        .await
-        {
-            error!("PGWire server error: {}", e);
+    let pg_task = tokio::spawn({
+        let shutdown = pgwire_shutdown.clone();
+        async move {
+            // host/port/backlog already applied at bind time; opts only
+            // contributes TLS + max_connections from here on.
+            let opts = ServerOptions::new();
+            if let Err(e) =
+                timefusion::pgwire_handlers::serve_with_listener(listener, Arc::new(session_context), &opts, auth_config, shutdown.cancelled_owned())
+                    .await
+            {
+                error!("PGWire server error: {}", e);
+            }
         }
     });
 
@@ -336,11 +334,8 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Bind the PGWire listener on `host:port` with an explicit backlog of
-/// `backlog`. Uses `TcpSocket` rather than `TcpListener::bind` so we
-/// control the backlog (mio's `bind` hardcodes 128); the kernel still
-/// clamps to `somaxconn`. Pulled out as its own function so the early
-/// 57P03 responder and the real server share one bind path.
+/// Bind via `TcpSocket` so we can pass an explicit `backlog`
+/// (`TcpListener::bind` hardcodes 128; kernel still clamps to `somaxconn`).
 async fn bind_pgwire_listener(host: &str, port: u16, backlog: u32) -> anyhow::Result<tokio::net::TcpListener> {
     use tokio::net::{lookup_host, TcpSocket};
     let server_addr = format!("{host}:{port}");

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -35,18 +35,38 @@ const MAX_CONCURRENT_EARLY_HANDLERS: usize = 512;
 
 /// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
 pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
+    accept_loop(listener, shutdown, MAX_CONCURRENT_EARLY_HANDLERS).await;
+}
+
+async fn accept_loop(listener: &TcpListener, shutdown: CancellationToken, max_handlers: usize) {
     let response: Arc<[u8]> = build_starting_up_response().into();
-    let permits = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EARLY_HANDLERS));
+    let permits = Arc::new(tokio::sync::Semaphore::new(max_handlers));
     loop {
         tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
             res = listener.accept() => match res {
-                Ok((sock, addr)) => {
-                    let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
-                        debug!("early-bind: at handler cap, dropping conn from {addr}");
-                        drop(sock);
-                        continue;
+                Ok((mut sock, addr)) => {
+                    let permit = match Arc::clone(&permits).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            // Capacity exhausted (probable reconnect storm). Send the
+                            // canned 57P03 frame and close — dropping the socket without
+                            // a response would RST, which Hasql/libpq treat as
+                            // ECONNREFUSED (the exact failure mode this responder exists
+                            // to avoid). The fast-path task skips the 10s startup wait
+                            // so it's bounded by accept rate × write latency (~ms).
+                            warn!("early-bind: at {max_handlers}-handler cap, fast-responding to {addr}");
+                            let resp = Arc::clone(&response);
+                            tokio::spawn(async move {
+                                let _ = tokio::time::timeout(Duration::from_secs(1), async move {
+                                    let _ = sock.write_all(&resp).await;
+                                    let _ = sock.shutdown().await;
+                                })
+                                .await;
+                            });
+                            continue;
+                        }
                     };
                     let resp = Arc::clone(&response);
                     tokio::spawn(async move {
@@ -202,6 +222,32 @@ mod tests {
         client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
         client.write_all(params).await.unwrap();
         assert_57p03(&mut client).await;
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    /// At the handler cap, excess connections still receive 57P03 (sent
+    /// synchronously via try_write) rather than RST — Hasql/libpq treat RST
+    /// as ECONNREFUSED, which is the failure mode this responder exists to
+    /// avoid.
+    #[tokio::test]
+    async fn cap_serves_57p03_synchronously_without_spawning() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = CancellationToken::new();
+        let token = shutdown.clone();
+        let task = tokio::spawn(async move { accept_loop(&listener, token, 1).await });
+
+        // First connection holds the only permit — never sends startup, so it
+        // sits inside handle_one's read awaiting bytes.
+        let _holder = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Second connection hits the cap; should receive 57P03 inline.
+        let mut cap_client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // Server writes the canned frame without waiting for a startup message.
+        tokio::time::timeout(Duration::from_secs(2), assert_57p03(&mut cap_client)).await.unwrap();
+
         shutdown.cancel();
         let _ = task.await;
     }

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -21,20 +21,36 @@ use tracing::{debug, warn};
 
 const SSL_REQUEST_CODE: u32 = SslRequest::BODY_MAGIC_NUMBER as u32;
 const GSS_REQUEST_CODE: u32 = GssEncRequest::BODY_MAGIC_NUMBER as u32;
+/// Cap on the StartupMessage size we'll drain. Real pg clients send well
+/// under 1 KiB; 64 KiB is comfortably above any legitimate payload and
+/// bounds the work a malformed/hostile client can force on us.
 const MAX_STARTUP_BYTES: u64 = 64 * 1024;
 const STARTUP_READ_TIMEOUT: Duration = Duration::from_secs(10);
+/// Hard cap on concurrent early-bind handlers. A thundering-herd reconnect
+/// storm during startup could otherwise spawn unbounded tasks, each holding
+/// a socket FD for up to STARTUP_READ_TIMEOUT. Excess connections are accepted
+/// and immediately dropped (closing the socket); clients see this as a reset
+/// and retry, same as if the kernel had dropped the SYN.
+const MAX_CONCURRENT_EARLY_HANDLERS: usize = 512;
 
 /// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
 pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
     let response: Arc<[u8]> = build_starting_up_response().into();
+    let permits = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EARLY_HANDLERS));
     loop {
         tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
             res = listener.accept() => match res {
                 Ok((sock, addr)) => {
+                    let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
+                        debug!("early-bind: at handler cap, dropping conn from {addr}");
+                        drop(sock);
+                        continue;
+                    };
                     let resp = Arc::clone(&response);
                     tokio::spawn(async move {
+                        let _permit = permit;
                         match tokio::time::timeout(STARTUP_READ_TIMEOUT, handle_one(sock, &resp)).await {
                             Err(_) => debug!("early-bind: timeout waiting for startup from {addr}"),
                             Ok(Err(e)) => debug!("early-bind: short-circuit conn from {addr}: {e}"),
@@ -71,9 +87,9 @@ async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
 }
 
 async fn drain_body(sock: &mut TcpStream, remaining: Option<u64>) -> io::Result<()> {
-    let n = remaining.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "startup length below header"))?;
+    let n = remaining.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "startup length below 8-byte header"))?;
     if n > MAX_STARTUP_BYTES {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup body too large: {n}")));
+        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup body {n} exceeds {MAX_STARTUP_BYTES}-byte cap")));
     }
     tokio::io::copy(&mut sock.take(n), &mut tokio::io::sink()).await?;
     Ok(())
@@ -159,6 +175,8 @@ mod tests {
         client.write_all(&8u32.to_be_bytes()).await.unwrap();
         client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
         assert_57p03(&mut client).await;
+        let mut tail = [0u8; 1];
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after error");
         shutdown.cancel();
         let _ = task.await;
     }

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -1,31 +1,18 @@
 //! Early-bind responder that occupies `:5432` during the slow startup
-//! window (WAL replay + Delta-table open + foyer init), returning the
+//! window (WAL replay, Delta-table open, foyer init), returning the
 //! Postgres SQLSTATE 57P03 "the database system is starting up" error
-//! to every connection until the real server is ready to take over.
+//! to every connection until the real server takes over the listener.
 //!
-//! Without this, the kernel inside the timefusion container has no
-//! listener on 5432 for the entire startup window (8–15 min in prod
-//! after a 346 GB WAL has accumulated), so packets DNAT'd in by Docker
-//! get RST'd back to the client as ECONNREFUSED. Background-job clients
-//! like monoscope's Hasql see this as a hard error and burn their retry
-//! budget on a startup window that's actually progressing fine.
-//!
-//! 57P03 is the canonical "I'm coming up" error class in Postgres —
-//! clients (Hasql, pgjdbc, libpq) recognise it and back off sanely.
-//!
-//! The acceptor speaks just enough of the pgwire protocol to send the
-//! error before closing:
-//! - Reject SSL / GSSAPI requests with `N` (no encryption).
-//! - Drain the StartupMessage payload.
-//! - Emit a single `ErrorResponse(FATAL, 57P03, "...")`.
-//! - Close the socket.
-//!
-//! It does NOT authenticate, query, or hold state. Pass the same
-//! `TcpListener` to `datafusion_postgres::serve_with_listener` once
-//! ready — no socket rebind, no ECONNREFUSED window.
+//! Without this, packets DNAT'd into the container during the multi-minute
+//! startup get RST'd back as ECONNREFUSED — clients like Hasql / pgjdbc /
+//! libpq treat 57P03 as transient and back off cleanly, ECONNREFUSED as a
+//! hard error. Hand the same `TcpListener` to `serve_with_listener` once
+//! ready: no rebind, no ECONNREFUSED window.
 
 use std::io;
+use std::sync::Arc;
 
+use datafusion_postgres::pgwire::messages::startup::{GssEncRequest, SslRequest};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
@@ -33,110 +20,71 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-const SSL_REQUEST_CODE: u32 = 80877103;
-const GSS_REQUEST_CODE: u32 = 80877104;
-const MAX_STARTUP_BYTES: usize = 64 * 1024;
+const SSL_REQUEST_CODE: u32 = SslRequest::BODY_MAGIC_NUMBER as u32;
+const GSS_REQUEST_CODE: u32 = GssEncRequest::BODY_MAGIC_NUMBER as u32;
+const MAX_STARTUP_BYTES: u64 = 64 * 1024;
+const STARTUP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
-/// Already-accepted connections finish on their own spawned tasks.
 pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
-    let response = build_starting_up_response();
-    let response = std::sync::Arc::<[u8]>::from(response.into_boxed_slice());
+    let response: Arc<[u8]> = build_starting_up_response().into();
     loop {
         tokio::select! {
             biased;
-            _ = shutdown.cancelled() => {
-                debug!("early-bind: shutdown signal received, stopping acceptor");
-                return;
-            }
-            res = listener.accept() => {
-                match res {
-                    Ok((sock, addr)) => {
-                        let resp = std::sync::Arc::clone(&response);
-                        tokio::spawn(async move {
-                            if let Err(e) = handle_one(sock, &resp).await {
-                                debug!("early-bind: short-circuit conn from {addr}: {e}");
-                            }
-                        });
-                    }
-                    Err(e) => {
-                        warn!("early-bind: accept failed: {e}");
-                    }
+            _ = shutdown.cancelled() => return,
+            res = listener.accept() => match res {
+                Ok((sock, addr)) => {
+                    let resp = Arc::clone(&response);
+                    tokio::spawn(async move {
+                        match tokio::time::timeout(STARTUP_READ_TIMEOUT, handle_one(sock, &resp)).await {
+                            Err(_) => debug!("early-bind: timeout waiting for startup from {addr}"),
+                            Ok(Err(e)) => debug!("early-bind: short-circuit conn from {addr}: {e}"),
+                            Ok(Ok(())) => {}
+                        }
+                    });
                 }
-            }
+                Err(e) => warn!("early-bind: accept failed: {e}"),
+            },
         }
     }
 }
 
 async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
-    // First message is either an SSLRequest (8 bytes), GSSENCRequest (8 bytes),
-    // or a StartupMessage (length-prefixed). Both SSL/GSS requests start with
-    // the same length=8, so we read the length, then the 4-byte code.
-    let len = read_u32(&mut sock).await? as usize;
-    if len < 8 || len > MAX_STARTUP_BYTES {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup length out of range: {len}")));
-    }
-    let code = read_u32(&mut sock).await?;
+    // SSL/GSS negotiation precedes the real StartupMessage; both are 8 bytes
+    // (length + magic). Drain whichever shape arrives, then send 57P03.
+    let len = sock.read_u32().await? as u64;
+    let code = sock.read_u32().await?;
     if code == SSL_REQUEST_CODE || code == GSS_REQUEST_CODE {
-        // Refuse the optional encryption negotiation with a single byte 'N',
-        // then expect the real StartupMessage to follow.
         sock.write_all(b"N").await?;
-        sock.flush().await?;
-        let real_len = read_u32(&mut sock).await? as usize;
-        if real_len < 8 || real_len > MAX_STARTUP_BYTES {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup length out of range: {real_len}")));
-        }
-        // Discard the rest of the StartupMessage body — we don't care which
-        // user/database the client asked for; everyone gets 57P03 right now.
-        let body_remaining = real_len.saturating_sub(4);
-        discard(&mut sock, body_remaining).await?;
+        let real_len = sock.read_u32().await? as u64;
+        drain_body(&mut sock, real_len.checked_sub(4)).await?;
     } else {
-        // First message WAS the StartupMessage. We've consumed length + code;
-        // drain the parameter pairs that follow.
-        let body_remaining = len.saturating_sub(8);
-        discard(&mut sock, body_remaining).await?;
+        drain_body(&mut sock, len.checked_sub(8)).await?;
     }
 
-    // Send the canned 57P03 ErrorResponse and close.
     sock.write_all(response).await?;
-    sock.flush().await?;
     let _ = sock.shutdown().await;
     Ok(())
 }
 
-async fn read_u32(sock: &mut TcpStream) -> io::Result<u32> {
-    let mut buf = [0u8; 4];
-    sock.read_exact(&mut buf).await?;
-    Ok(u32::from_be_bytes(buf))
-}
-
-async fn discard(sock: &mut TcpStream, mut n: usize) -> io::Result<()> {
-    let mut scratch = [0u8; 1024];
-    while n > 0 {
-        let take = scratch.len().min(n);
-        let got = sock.read(&mut scratch[..take]).await?;
-        if got == 0 {
-            break;
-        }
-        n -= got;
+async fn drain_body(sock: &mut TcpStream, remaining: Option<u64>) -> io::Result<()> {
+    let n = remaining.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "startup length below header"))?;
+    if n > MAX_STARTUP_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup body too large: {n}")));
     }
+    tokio::io::copy(&mut sock.take(n), &mut tokio::io::sink()).await?;
     Ok(())
 }
 
-/// Pre-built ErrorResponse frame for SQLSTATE 57P03 (cannot_connect_now —
-/// "the database system is starting up"). Postgres clients (libpq, Hasql,
-/// pgjdbc, asyncpg) all recognise this class and apply their reconnect
-/// policy rather than treating it as a hard failure.
-///
-/// Wire format (per pg docs):
-///   Byte1('E') Int32(length) [Field(byte tag) String(value)]* Byte1(0)
+/// Wire format: `Byte1('E') Int32(length) [Byte1(tag) String(value)]* Byte1(0)`
 fn build_starting_up_response() -> Vec<u8> {
     let mut body: Vec<u8> = Vec::with_capacity(96);
-    push_field(&mut body, b'S', b"FATAL");
-    push_field(&mut body, b'V', b"FATAL");
-    push_field(&mut body, b'C', b"57P03");
-    push_field(&mut body, b'M', b"the database system is starting up");
-    body.push(0); // terminator
+    for (tag, value) in [(b'S', "FATAL"), (b'V', "FATAL"), (b'C', "57P03"), (b'M', "the database system is starting up")] {
+        body.push(tag);
+        body.extend_from_slice(value.as_bytes());
+        body.push(0);
+    }
+    body.push(0);
 
     let length = (body.len() + 4) as u32;
     let mut msg = Vec::with_capacity(1 + 4 + body.len());
@@ -146,12 +94,6 @@ fn build_starting_up_response() -> Vec<u8> {
     msg
 }
 
-fn push_field(out: &mut Vec<u8>, tag: u8, value: &[u8]) {
-    out.push(tag);
-    out.extend_from_slice(value);
-    out.push(0);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,84 +101,70 @@ mod tests {
     #[test]
     fn response_frame_has_expected_shape() {
         let msg = build_starting_up_response();
-        assert_eq!(msg[0], b'E', "ErrorResponse frame tag");
+        assert_eq!(msg[0], b'E');
         let len = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]) as usize;
-        assert_eq!(len, msg.len() - 1, "length field counts itself + body");
+        assert_eq!(len, msg.len() - 1);
         let body = &msg[5..];
-        assert!(body.windows(b"57P03".len()).any(|w| w == b"57P03"), "SQLSTATE 57P03 must be present");
-        assert!(body.last() == Some(&0u8), "frame must end with terminator");
+        assert!(body.windows(5).any(|w| w == b"57P03"));
+        assert_eq!(body.last(), Some(&0u8));
     }
 
-    #[tokio::test]
-    async fn responds_to_plain_startup_then_closes() {
-        use tokio::io::AsyncReadExt;
-
+    async fn spawn_acceptor() -> (u16, CancellationToken, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let shutdown = CancellationToken::new();
-        let acceptor_token = shutdown.clone();
-        let acceptor = tokio::spawn(async move {
-            run_until_ready(&listener, acceptor_token).await;
-        });
+        let token = shutdown.clone();
+        let task = tokio::spawn(async move { run_until_ready(&listener, token).await });
+        (port, shutdown, task)
+    }
 
-        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-        // Minimal StartupMessage: len=8 + protocol_version=196608 (3.0). No params.
-        let len: u32 = 8;
-        let proto: u32 = 196608;
-        client.write_all(&len.to_be_bytes()).await.unwrap();
-        client.write_all(&proto.to_be_bytes()).await.unwrap();
-
+    async fn assert_57p03(client: &mut TcpStream) {
         let mut tag = [0u8; 1];
         client.read_exact(&mut tag).await.unwrap();
-        assert_eq!(tag[0], b'E', "server must send ErrorResponse");
+        assert_eq!(tag[0], b'E');
         let mut len_buf = [0u8; 4];
         client.read_exact(&mut len_buf).await.unwrap();
         let body_len = u32::from_be_bytes(len_buf) as usize - 4;
         let mut body = vec![0u8; body_len];
         client.read_exact(&mut body).await.unwrap();
-        assert!(body.windows(5).any(|w| w == b"57P03"), "expected SQLSTATE 57P03 in body");
+        assert!(body.windows(5).any(|w| w == b"57P03"));
+    }
 
-        // Server must close after the error.
+    #[tokio::test]
+    async fn responds_to_plain_startup_then_closes() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&196608u32.to_be_bytes()).await.unwrap();
+        assert_57p03(&mut client).await;
         let mut tail = [0u8; 1];
-        let n = client.read(&mut tail).await.unwrap();
-        assert_eq!(n, 0, "server must close after sending the error");
-
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after error");
         shutdown.cancel();
-        let _ = acceptor.await;
+        let _ = task.await;
+    }
+
+    async fn negotiation_then_startup(magic: u32) {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&magic.to_be_bytes()).await.unwrap();
+        let mut n_reply = [0u8; 1];
+        client.read_exact(&mut n_reply).await.unwrap();
+        assert_eq!(n_reply[0], b'N');
+        client.write_all(&8u32.to_be_bytes()).await.unwrap();
+        client.write_all(&196608u32.to_be_bytes()).await.unwrap();
+        assert_57p03(&mut client).await;
+        shutdown.cancel();
+        let _ = task.await;
     }
 
     #[tokio::test]
     async fn responds_to_ssl_request_then_startup() {
-        use tokio::io::AsyncReadExt;
+        negotiation_then_startup(SSL_REQUEST_CODE).await;
+    }
 
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let shutdown = CancellationToken::new();
-        let acceptor_token = shutdown.clone();
-        let acceptor = tokio::spawn(async move {
-            run_until_ready(&listener, acceptor_token).await;
-        });
-
-        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-        // SSLRequest: len=8 + magic=80877103.
-        let len: u32 = 8;
-        let ssl_code: u32 = SSL_REQUEST_CODE;
-        client.write_all(&len.to_be_bytes()).await.unwrap();
-        client.write_all(&ssl_code.to_be_bytes()).await.unwrap();
-        let mut n_reply = [0u8; 1];
-        client.read_exact(&mut n_reply).await.unwrap();
-        assert_eq!(n_reply[0], b'N', "server must refuse SSL with 'N'");
-
-        // Now the real StartupMessage.
-        let proto: u32 = 196608;
-        client.write_all(&len.to_be_bytes()).await.unwrap();
-        client.write_all(&proto.to_be_bytes()).await.unwrap();
-
-        let mut tag = [0u8; 1];
-        client.read_exact(&mut tag).await.unwrap();
-        assert_eq!(tag[0], b'E', "server must send ErrorResponse after the SSL rejection");
-
-        shutdown.cancel();
-        let _ = acceptor.await;
+    #[tokio::test]
+    async fn responds_to_gss_request_then_startup() {
+        negotiation_then_startup(GSS_REQUEST_CODE).await;
     }
 }

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -226,6 +226,20 @@ mod tests {
         let _ = task.await;
     }
 
+    /// A client that connects but never sends a startup message must be
+    /// closed after STARTUP_READ_TIMEOUT instead of holding the slot forever.
+    #[tokio::test(start_paused = true)]
+    async fn silent_client_closed_after_timeout() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // No bytes sent; advance virtual time past the timeout.
+        tokio::time::advance(STARTUP_READ_TIMEOUT + Duration::from_secs(1)).await;
+        let mut tail = [0u8; 1];
+        assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after timeout");
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
     /// At the handler cap, excess connections still receive 57P03 (sent
     /// synchronously via try_write) rather than RST — Hasql/libpq treat RST
     /// as ECONNREFUSED, which is the failure mode this responder exists to

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -9,8 +9,7 @@
 //! hard error. Hand the same `TcpListener` to `serve_with_listener` once
 //! ready: no rebind, no ECONNREFUSED window.
 
-use std::io;
-use std::sync::Arc;
+use std::{io, sync::Arc, time::Duration};
 
 use datafusion_postgres::pgwire::messages::startup::{GssEncRequest, SslRequest};
 use tokio::{
@@ -23,7 +22,7 @@ use tracing::{debug, warn};
 const SSL_REQUEST_CODE: u32 = SslRequest::BODY_MAGIC_NUMBER as u32;
 const GSS_REQUEST_CODE: u32 = GssEncRequest::BODY_MAGIC_NUMBER as u32;
 const MAX_STARTUP_BYTES: u64 = 64 * 1024;
-const STARTUP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const STARTUP_READ_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
 pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
@@ -52,6 +51,10 @@ pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken
 async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
     // SSL/GSS negotiation precedes the real StartupMessage; both are 8 bytes
     // (length + magic). Drain whichever shape arrives, then send 57P03.
+    // pg length fields include the 4-byte length itself. In the non-SSL branch
+    // we've also consumed the 4-byte code → drain `len - 8`; in the SSL/GSS
+    // branch we've consumed only the length of the *real* startup → drain
+    // `real_len - 4`.
     let len = sock.read_u32().await? as u64;
     let code = sock.read_u32().await?;
     if code == SSL_REQUEST_CODE || code == GSS_REQUEST_CODE {
@@ -98,6 +101,8 @@ fn build_starting_up_response() -> Vec<u8> {
 mod tests {
     use super::*;
 
+    const PROTO_3_0: u32 = 0x0003_0000;
+
     #[test]
     fn response_frame_has_expected_shape() {
         let msg = build_starting_up_response();
@@ -135,7 +140,7 @@ mod tests {
         let (port, shutdown, task) = spawn_acceptor().await;
         let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         client.write_all(&8u32.to_be_bytes()).await.unwrap();
-        client.write_all(&196608u32.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
         assert_57p03(&mut client).await;
         let mut tail = [0u8; 1];
         assert_eq!(client.read(&mut tail).await.unwrap(), 0, "server must close after error");
@@ -152,7 +157,7 @@ mod tests {
         client.read_exact(&mut n_reply).await.unwrap();
         assert_eq!(n_reply[0], b'N');
         client.write_all(&8u32.to_be_bytes()).await.unwrap();
-        client.write_all(&196608u32.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
         assert_57p03(&mut client).await;
         shutdown.cancel();
         let _ = task.await;
@@ -166,5 +171,36 @@ mod tests {
     #[tokio::test]
     async fn responds_to_gss_request_then_startup() {
         negotiation_then_startup(GSS_REQUEST_CODE).await;
+    }
+
+    /// Exercises drain_body with n > 0 (the no-params test sends len=8, n=0).
+    #[tokio::test]
+    async fn drains_startup_params_then_responds() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let params = b"user\0foo\0database\0bar\0\0";
+        let len = (4 + 4 + params.len()) as u32;
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        client.write_all(params).await.unwrap();
+        assert_57p03(&mut client).await;
+        shutdown.cancel();
+        let _ = task.await;
+    }
+
+    /// Oversized declared length must trip the MAX_STARTUP_BYTES guard;
+    /// the server drops the connection without sending a response.
+    #[tokio::test]
+    async fn rejects_oversized_startup() {
+        let (port, shutdown, task) = spawn_acceptor().await;
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let oversized = (MAX_STARTUP_BYTES as u32) + 1024;
+        client.write_all(&oversized.to_be_bytes()).await.unwrap();
+        client.write_all(&PROTO_3_0.to_be_bytes()).await.unwrap();
+        let mut tag = [0u8; 1];
+        let n = client.read(&mut tag).await.unwrap();
+        assert_eq!(n, 0, "server must drop connection on oversized startup");
+        shutdown.cancel();
+        let _ = task.await;
     }
 }

--- a/src/pgwire_early_bind.rs
+++ b/src/pgwire_early_bind.rs
@@ -1,0 +1,242 @@
+//! Early-bind responder that occupies `:5432` during the slow startup
+//! window (WAL replay + Delta-table open + foyer init), returning the
+//! Postgres SQLSTATE 57P03 "the database system is starting up" error
+//! to every connection until the real server is ready to take over.
+//!
+//! Without this, the kernel inside the timefusion container has no
+//! listener on 5432 for the entire startup window (8–15 min in prod
+//! after a 346 GB WAL has accumulated), so packets DNAT'd in by Docker
+//! get RST'd back to the client as ECONNREFUSED. Background-job clients
+//! like monoscope's Hasql see this as a hard error and burn their retry
+//! budget on a startup window that's actually progressing fine.
+//!
+//! 57P03 is the canonical "I'm coming up" error class in Postgres —
+//! clients (Hasql, pgjdbc, libpq) recognise it and back off sanely.
+//!
+//! The acceptor speaks just enough of the pgwire protocol to send the
+//! error before closing:
+//! - Reject SSL / GSSAPI requests with `N` (no encryption).
+//! - Drain the StartupMessage payload.
+//! - Emit a single `ErrorResponse(FATAL, 57P03, "...")`.
+//! - Close the socket.
+//!
+//! It does NOT authenticate, query, or hold state. Pass the same
+//! `TcpListener` to `datafusion_postgres::serve_with_listener` once
+//! ready — no socket rebind, no ECONNREFUSED window.
+
+use std::io;
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+const SSL_REQUEST_CODE: u32 = 80877103;
+const GSS_REQUEST_CODE: u32 = 80877104;
+const MAX_STARTUP_BYTES: usize = 64 * 1024;
+
+/// Run the 57P03 acceptor on `listener` until `shutdown` is cancelled.
+/// Already-accepted connections finish on their own spawned tasks.
+pub async fn run_until_ready(listener: &TcpListener, shutdown: CancellationToken) {
+    let response = build_starting_up_response();
+    let response = std::sync::Arc::<[u8]>::from(response.into_boxed_slice());
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                debug!("early-bind: shutdown signal received, stopping acceptor");
+                return;
+            }
+            res = listener.accept() => {
+                match res {
+                    Ok((sock, addr)) => {
+                        let resp = std::sync::Arc::clone(&response);
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_one(sock, &resp).await {
+                                debug!("early-bind: short-circuit conn from {addr}: {e}");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        warn!("early-bind: accept failed: {e}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_one(mut sock: TcpStream, response: &[u8]) -> io::Result<()> {
+    // First message is either an SSLRequest (8 bytes), GSSENCRequest (8 bytes),
+    // or a StartupMessage (length-prefixed). Both SSL/GSS requests start with
+    // the same length=8, so we read the length, then the 4-byte code.
+    let len = read_u32(&mut sock).await? as usize;
+    if len < 8 || len > MAX_STARTUP_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup length out of range: {len}")));
+    }
+    let code = read_u32(&mut sock).await?;
+    if code == SSL_REQUEST_CODE || code == GSS_REQUEST_CODE {
+        // Refuse the optional encryption negotiation with a single byte 'N',
+        // then expect the real StartupMessage to follow.
+        sock.write_all(b"N").await?;
+        sock.flush().await?;
+        let real_len = read_u32(&mut sock).await? as usize;
+        if real_len < 8 || real_len > MAX_STARTUP_BYTES {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, format!("startup length out of range: {real_len}")));
+        }
+        // Discard the rest of the StartupMessage body — we don't care which
+        // user/database the client asked for; everyone gets 57P03 right now.
+        let body_remaining = real_len.saturating_sub(4);
+        discard(&mut sock, body_remaining).await?;
+    } else {
+        // First message WAS the StartupMessage. We've consumed length + code;
+        // drain the parameter pairs that follow.
+        let body_remaining = len.saturating_sub(8);
+        discard(&mut sock, body_remaining).await?;
+    }
+
+    // Send the canned 57P03 ErrorResponse and close.
+    sock.write_all(response).await?;
+    sock.flush().await?;
+    let _ = sock.shutdown().await;
+    Ok(())
+}
+
+async fn read_u32(sock: &mut TcpStream) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    sock.read_exact(&mut buf).await?;
+    Ok(u32::from_be_bytes(buf))
+}
+
+async fn discard(sock: &mut TcpStream, mut n: usize) -> io::Result<()> {
+    let mut scratch = [0u8; 1024];
+    while n > 0 {
+        let take = scratch.len().min(n);
+        let got = sock.read(&mut scratch[..take]).await?;
+        if got == 0 {
+            break;
+        }
+        n -= got;
+    }
+    Ok(())
+}
+
+/// Pre-built ErrorResponse frame for SQLSTATE 57P03 (cannot_connect_now —
+/// "the database system is starting up"). Postgres clients (libpq, Hasql,
+/// pgjdbc, asyncpg) all recognise this class and apply their reconnect
+/// policy rather than treating it as a hard failure.
+///
+/// Wire format (per pg docs):
+///   Byte1('E') Int32(length) [Field(byte tag) String(value)]* Byte1(0)
+fn build_starting_up_response() -> Vec<u8> {
+    let mut body: Vec<u8> = Vec::with_capacity(96);
+    push_field(&mut body, b'S', b"FATAL");
+    push_field(&mut body, b'V', b"FATAL");
+    push_field(&mut body, b'C', b"57P03");
+    push_field(&mut body, b'M', b"the database system is starting up");
+    body.push(0); // terminator
+
+    let length = (body.len() + 4) as u32;
+    let mut msg = Vec::with_capacity(1 + 4 + body.len());
+    msg.push(b'E');
+    msg.extend_from_slice(&length.to_be_bytes());
+    msg.extend_from_slice(&body);
+    msg
+}
+
+fn push_field(out: &mut Vec<u8>, tag: u8, value: &[u8]) {
+    out.push(tag);
+    out.extend_from_slice(value);
+    out.push(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_frame_has_expected_shape() {
+        let msg = build_starting_up_response();
+        assert_eq!(msg[0], b'E', "ErrorResponse frame tag");
+        let len = u32::from_be_bytes([msg[1], msg[2], msg[3], msg[4]]) as usize;
+        assert_eq!(len, msg.len() - 1, "length field counts itself + body");
+        let body = &msg[5..];
+        assert!(body.windows(b"57P03".len()).any(|w| w == b"57P03"), "SQLSTATE 57P03 must be present");
+        assert!(body.last() == Some(&0u8), "frame must end with terminator");
+    }
+
+    #[tokio::test]
+    async fn responds_to_plain_startup_then_closes() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = CancellationToken::new();
+        let acceptor_token = shutdown.clone();
+        let acceptor = tokio::spawn(async move {
+            run_until_ready(&listener, acceptor_token).await;
+        });
+
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // Minimal StartupMessage: len=8 + protocol_version=196608 (3.0). No params.
+        let len: u32 = 8;
+        let proto: u32 = 196608;
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&proto.to_be_bytes()).await.unwrap();
+
+        let mut tag = [0u8; 1];
+        client.read_exact(&mut tag).await.unwrap();
+        assert_eq!(tag[0], b'E', "server must send ErrorResponse");
+        let mut len_buf = [0u8; 4];
+        client.read_exact(&mut len_buf).await.unwrap();
+        let body_len = u32::from_be_bytes(len_buf) as usize - 4;
+        let mut body = vec![0u8; body_len];
+        client.read_exact(&mut body).await.unwrap();
+        assert!(body.windows(5).any(|w| w == b"57P03"), "expected SQLSTATE 57P03 in body");
+
+        // Server must close after the error.
+        let mut tail = [0u8; 1];
+        let n = client.read(&mut tail).await.unwrap();
+        assert_eq!(n, 0, "server must close after sending the error");
+
+        shutdown.cancel();
+        let _ = acceptor.await;
+    }
+
+    #[tokio::test]
+    async fn responds_to_ssl_request_then_startup() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = CancellationToken::new();
+        let acceptor_token = shutdown.clone();
+        let acceptor = tokio::spawn(async move {
+            run_until_ready(&listener, acceptor_token).await;
+        });
+
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // SSLRequest: len=8 + magic=80877103.
+        let len: u32 = 8;
+        let ssl_code: u32 = SSL_REQUEST_CODE;
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&ssl_code.to_be_bytes()).await.unwrap();
+        let mut n_reply = [0u8; 1];
+        client.read_exact(&mut n_reply).await.unwrap();
+        assert_eq!(n_reply[0], b'N', "server must refuse SSL with 'N'");
+
+        // Now the real StartupMessage.
+        let proto: u32 = 196608;
+        client.write_all(&len.to_be_bytes()).await.unwrap();
+        client.write_all(&proto.to_be_bytes()).await.unwrap();
+
+        let mut tag = [0u8; 1];
+        client.read_exact(&mut tag).await.unwrap();
+        assert_eq!(tag[0], b'E', "server must send ErrorResponse after the SSL rejection");
+
+        shutdown.cancel();
+        let _ = acceptor.await;
+    }
+}

--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -353,10 +353,7 @@ pub async fn serve_with_logging(
     Ok(())
 }
 
-/// Same as `serve_with_logging` but reuses an already-bound `TcpListener`.
-/// Lets `main.rs` pre-bind `:5432` before the slow Database/WAL recovery so
-/// clients connecting during startup see SQLSTATE 57P03 from the early-bind
-/// responder, then take over the same listener (no rebind window).
+/// Variant of `serve_with_logging` over a pre-bound listener.
 pub async fn serve_with_listener(
     listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions,
     auth_config: AuthConfig, shutdown: impl std::future::Future<Output = ()> + Send + 'static,

--- a/src/pgwire_handlers.rs
+++ b/src/pgwire_handlers.rs
@@ -353,6 +353,19 @@ pub async fn serve_with_logging(
     Ok(())
 }
 
+/// Same as `serve_with_logging` but reuses an already-bound `TcpListener`.
+/// Lets `main.rs` pre-bind `:5432` before the slow Database/WAL recovery so
+/// clients connecting during startup see SQLSTATE 57P03 from the early-bind
+/// responder, then take over the same listener (no rebind window).
+pub async fn serve_with_listener(
+    listener: tokio::net::TcpListener, session_context: Arc<SessionContext>, options: &datafusion_postgres::ServerOptions,
+    auth_config: AuthConfig, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let handlers = Arc::new(LoggingHandlerFactory::new(session_context, auth_config));
+    datafusion_postgres::serve_with_listener(listener, handlers, options, shutdown).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::rewrite_pg_synonyms;

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -140,7 +140,9 @@ pub async fn bind_listener(host: &str, port: u16, backlog: u32) -> Result<TcpLis
     let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
     socket.set_reuseaddr(true)?;
     socket.bind(addr)?;
-    socket.listen(backlog)
+    let listener = socket.listen(backlog)?;
+    info!("Bound PGWire listener on {server_addr} (backlog={backlog}); kernel clamps to net.core.somaxconn");
+    Ok(listener)
 }
 
 /// Like `serve_with_handlers`, but accepts an already-bound `TcpListener`.

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -17,7 +17,7 @@ use pgwire::api::PgWireServerHandlers;
 use pgwire::tokio::process_socket;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
-use tokio::net::{lookup_host, TcpSocket};
+use tokio::net::{lookup_host, TcpListener, TcpSocket};
 use tokio::sync::Semaphore;
 use tokio_rustls::rustls::{self, ServerConfig};
 use tokio_rustls::TlsAcceptor;
@@ -123,6 +123,34 @@ pub async fn serve_with_hooks(session_context: Arc<SessionContext>, opts: &Serve
 pub async fn serve_with_handlers(
     handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), std::io::Error> {
+    // Bind to the specified host and port. Use `TcpSocket` instead of
+    // `TcpListener::bind` so we can request a real backlog — mio hardcodes
+    // 128, which trivially overflows under thundering-herd reconnects (e.g.
+    // background jobs retrying on exp-backoff) and produces ECONNREFUSED on
+    // hosts with `tcp_abort_on_overflow=1`. The kernel will still clamp to
+    // `somaxconn`, so the host sysctl must also be raised in deploy config.
+    let server_addr = format!("{}:{}", opts.host, opts.port);
+    let addr = lookup_host(&server_addr)
+        .await?
+        .next()
+        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
+    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+    socket.set_reuseaddr(true)?;
+    socket.bind(addr)?;
+    let listener = socket.listen(opts.backlog)?;
+    serve_with_listener(listener, handlers, opts, shutdown).await
+}
+
+/// Like `serve_with_handlers`, but accepts an already-bound `TcpListener`.
+/// Useful when the caller wants to bind the socket early (e.g. to handle the
+/// pgwire startup-time window with a 57P03 "starting up" responder, then hand
+/// the same listener to the real server once initialization is complete —
+/// avoiding the unbound-port window that causes ECONNREFUSED at clients
+/// during slow startup).
+pub async fn serve_with_listener(
+    listener: TcpListener, handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), std::io::Error> {
     // Set up TLS if configured
     let tls_acceptor = if let (Some(cert_path), Some(key_path)) = (&opts.tls_cert_path, &opts.tls_key_path) {
         match setup_tls(cert_path, key_path) {
@@ -140,25 +168,11 @@ pub async fn serve_with_handlers(
         None
     };
 
-    // Bind to the specified host and port. Use `TcpSocket` instead of
-    // `TcpListener::bind` so we can request a real backlog — mio hardcodes
-    // 128, which trivially overflows under thundering-herd reconnects (e.g.
-    // background jobs retrying on exp-backoff) and produces ECONNREFUSED on
-    // hosts with `tcp_abort_on_overflow=1`. The kernel will still clamp to
-    // `somaxconn`, so the host sysctl must also be raised in deploy config.
-    let server_addr = format!("{}:{}", opts.host, opts.port);
-    let addr = lookup_host(&server_addr)
-        .await?
-        .next()
-        .ok_or_else(|| IOError::new(ErrorKind::InvalidInput, format!("could not resolve {server_addr}")))?;
-    let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
-    socket.set_reuseaddr(true)?;
-    socket.bind(addr)?;
-    let listener = socket.listen(opts.backlog)?;
+    let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
     if tls_acceptor.is_some() {
-        info!("Listening on {server_addr} with TLS encryption (backlog={})", opts.backlog);
+        info!("Listening on {local_addr} with TLS encryption (backlog requested={})", opts.backlog);
     } else {
-        info!("Listening on {server_addr} (unencrypted, backlog={})", opts.backlog);
+        info!("Listening on {local_addr} (unencrypted, backlog requested={})", opts.backlog);
     }
 
     // Connection limiter (if configured)

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -170,9 +170,9 @@ pub async fn serve_with_listener(
 
     let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
     if tls_acceptor.is_some() {
-        info!("Listening on {local_addr} with TLS encryption (backlog requested={})", opts.backlog);
+        info!("Listening on {local_addr} with TLS encryption");
     } else {
-        info!("Listening on {local_addr} (unencrypted, backlog requested={})", opts.backlog);
+        info!("Listening on {local_addr} (unencrypted)");
     }
 
     // Connection limiter (if configured)

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -123,13 +123,16 @@ pub async fn serve_with_hooks(session_context: Arc<SessionContext>, opts: &Serve
 pub async fn serve_with_handlers(
     handlers: Arc<impl PgWireServerHandlers + Sync + Send + 'static>, opts: &ServerOptions, shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), std::io::Error> {
-    // Bind to the specified host and port. Use `TcpSocket` instead of
-    // `TcpListener::bind` so we can request a real backlog — mio hardcodes
-    // 128, which trivially overflows under thundering-herd reconnects (e.g.
-    // background jobs retrying on exp-backoff) and produces ECONNREFUSED on
-    // hosts with `tcp_abort_on_overflow=1`. The kernel will still clamp to
-    // `somaxconn`, so the host sysctl must also be raised in deploy config.
-    let server_addr = format!("{}:{}", opts.host, opts.port);
+    let listener = bind_listener(&opts.host, opts.port, opts.backlog).await?;
+    serve_with_listener(listener, handlers, opts, shutdown).await
+}
+
+/// Bind a TCP listener via `TcpSocket` so the caller can request a real
+/// `backlog` — `TcpListener::bind` hardcodes 128 via mio, which trivially
+/// overflows under thundering-herd reconnects. The kernel still clamps to
+/// `somaxconn`, so the host sysctl must match.
+pub async fn bind_listener(host: &str, port: u16, backlog: u32) -> Result<TcpListener, std::io::Error> {
+    let server_addr = format!("{host}:{port}");
     let addr = lookup_host(&server_addr)
         .await?
         .next()
@@ -137,8 +140,7 @@ pub async fn serve_with_handlers(
     let socket = if addr.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
     socket.set_reuseaddr(true)?;
     socket.bind(addr)?;
-    let listener = socket.listen(opts.backlog)?;
-    serve_with_listener(listener, handlers, opts, shutdown).await
+    socket.listen(backlog)
 }
 
 /// Like `serve_with_handlers`, but accepts an already-bound `TcpListener`.
@@ -169,11 +171,8 @@ pub async fn serve_with_listener(
     };
 
     let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
-    if tls_acceptor.is_some() {
-        info!("Listening on {local_addr} with TLS encryption");
-    } else {
-        info!("Listening on {local_addr} (unencrypted)");
-    }
+    let tls_label = if tls_acceptor.is_some() { "TLS" } else { "unencrypted" };
+    info!("Listening on {local_addr} ({tls_label}, backlog={})", opts.backlog);
 
     // Connection limiter (if configured)
     let max_conn_count = opts.max_connections;

--- a/vendor/datafusion-postgres/src/lib.rs
+++ b/vendor/datafusion-postgres/src/lib.rs
@@ -170,9 +170,12 @@ pub async fn serve_with_listener(
         None
     };
 
+    // Note: opts.backlog reflects the options object, not necessarily the
+    // listening socket — callers passing a pre-bound listener may have set a
+    // different backlog at bind time.
     let local_addr = listener.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "<unknown>".to_string());
     let tls_label = if tls_acceptor.is_some() { "TLS" } else { "unencrypted" };
-    info!("Listening on {local_addr} ({tls_label}, backlog={})", opts.backlog);
+    info!("Listening on {local_addr} ({tls_label})");
 
     // Connection limiter (if configured)
     let max_conn_count = opts.max_connections;


### PR DESCRIPTION
## Summary

**Stacked on #32.** Fixes the prod symptom monoscope's Hasql is hitting: ECONNREFUSED to `:5432` for the entire 8–15 min WAL recovery window after a timefusion restart, because there's no listener on `:5432` inside the container until `serve_with_handlers` finally binds. With #32 alone, every future deploy still loses ~8 min of writes to the same failure mode; this PR removes that window.

## Mechanism

Today's main.rs binds `:5432` AFTER `Database::with_config`, `derive_wal_cursors_from_delta`, and `recover_from_wal` — collectively ~8–15 min in prod with a 346 GB WAL. During that window, Docker DNAT routes packets at `:5432` into the timefusion container, the kernel finds no listener, and sends RST → client sees ECONNREFUSED.

This PR:

1. Pre-binds `:5432` at the top of `async_main` via the same `TcpSocket + listen(backlog=4096)` path the real server uses.
2. Spawns a minimal responder (`pgwire_early_bind`) that speaks just enough of the wire protocol to send `ErrorResponse(SQLSTATE 57P03, "the database system is starting up")` and close. Postgres clients (libpq, Hasql, pgjdbc) recognise 57P03 as a retriable startup state and back off cleanly.
3. When startup completes, cancels the responder, hands the same `TcpListener` to `serve_with_listener` (newly added in `vendor/datafusion-postgres/src/lib.rs`), and the real server takes over without rebinding the socket.

The responder is ~80 LOC of raw protocol — no pgwire-crate handler stack, no auth, no SessionContext. It refuses SSLRequest/GSSENCRequest with `N`, drains the StartupMessage, sends the canned error frame, closes the socket.

## Tests

- `pgwire_early_bind::tests::response_frame_has_expected_shape` — verifies the canned frame: `E` tag, length-prefix, contains `57P03`, ends with terminator.
- `pgwire_early_bind::tests::responds_to_plain_startup_then_closes` — opens a real TCP socket, sends a StartupMessage (proto 3.0), reads the ErrorResponse back, verifies the SQLSTATE, and confirms the server closes the socket.
- `pgwire_early_bind::tests::responds_to_ssl_request_then_startup` — same but with the SSL preamble path: client sends SSLRequest, server returns `N`, client sends StartupMessage, server returns 57P03.

Full suite passes (109 lib tests, 4 pgwire_dml_tag_test integration tests).

## Behaviour change

Before: ECONNREFUSED for ~8–15 min on every restart, until `serve_with_handlers` binds.
After: clients connecting in that window get an immediate Postgres error (`57P03`) and close cleanly. Hasql/libpq treat this as a retriable "server starting up" state and apply backoff. No rebind window, no ECONNREFUSED race.

## Deploy notes

Combined with #32 (which fixes the WAL file leak so recovery is bounded), this should eliminate the prod monoscope retry storms entirely. Sequence to deploy:
1. Merge #32 first (the bigger fix).
2. Merge this PR.
3. Build + deploy. Watch the startup log for `PGWire listener bound on :5432 (backlog=4096) before startup work begins` immediately after `Starting TimeFusion application`.
4. Monoscope errors during the recovery window should switch from `ConnectionRefused` to `cannot_connect_now` (or equivalent Hasql class).

## Test plan
- [ ] Deploy to staging.
- [ ] Force a restart while a client is connecting; verify it sees 57P03 instead of ECONNREFUSED.
- [ ] Confirm the listener handoff is clean (no client connections dropped at the handover instant).
- [ ] Watch monoscope retry logs during a real deploy: should show fewer max-attempt failures.