### PR TITLE
dedup: collapse cross-flush duplicates in maintenance compaction

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -452,6 +452,10 @@ pub struct Database {
     object_store_cache:              Option<Arc<SharedFoyerCache>>,
     statistics_extractor:            Arc<DeltaStatisticsExtractor>,
     last_written_versions:           Arc<RwLock<HashMap<(String, String), u64>>>,
+    /// Delta snapshot version at last dedup sweep, per scheduler key. Skips
+    /// the sweep when the version hasn't moved (no commits → no new dupes).
+    /// Same unbounded-growth caveat as `last_written_versions`.
+    last_dedup_versions:             Arc<RwLock<HashMap<String, u64>>>,
     buffered_layer:                  Option<Arc<crate::buffered_write_layer::BufferedWriteLayer>>,
     tantivy_search:                  Option<Arc<crate::tantivy_index::search::TantivySearchService>>,
     tantivy_indexer:                 Option<Arc<crate::tantivy_index::service::TantivyIndexService>>,
@@ -750,6 +754,7 @@ impl Database {
             object_store_cache,
             statistics_extractor,
             last_written_versions: Arc::new(RwLock::new(HashMap::new())),
+            last_dedup_versions: Arc::new(RwLock::new(HashMap::new())),
             buffered_layer: None,
             tantivy_search: None,
             tantivy_indexer: None,
@@ -845,8 +850,14 @@ impl Database {
                     let db = db.clone();
                     Box::pin(async move {
                         info!("Running scheduled light optimize on recent small files");
-                        // Optimize unified tables
+                        // Optimize unified tables. Run dedup FIRST so the
+                        // light compact bin-packs already-deduped files —
+                        // otherwise compact would rewrite the duplicates into
+                        // a single file that we'd then have to rewrite again.
                         for (table_name, table) in db.unified_tables.read().await.iter() {
+                            if let Err(e) = db.dedup_today_partitions(table, table_name, table_name).await {
+                                error!("Dedup sweep failed for unified table '{}': {}", table_name, e);
+                            }
                             match db.optimize_table_light(table, table_name).await {
                                 Ok(_) => info!("Light optimize completed for unified table '{}'", table_name),
                                 Err(e) => error!("Light optimize failed for unified table '{}': {}", table_name, e),
@@ -854,6 +865,10 @@ impl Database {
                         }
                         // Optimize custom project tables
                         for ((project_id, table_name), table) in db.custom_project_tables.read().await.iter() {
+                            let key = format!("{}:{}", project_id, table_name);
+                            if let Err(e) = db.dedup_today_partitions(table, table_name, &key).await {
+                                error!("Dedup sweep failed for custom project '{}' table '{}': {}", project_id, table_name, e);
+                            }
                             match db.optimize_table_light(table, table_name).await {
                                 Ok(_) => info!("Light optimize completed for custom project '{}' table '{}'", project_id, table_name),
                                 Err(e) => error!("Light optimize failed for custom project '{}' table '{}': {}", project_id, table_name, e),
@@ -2496,6 +2511,168 @@ impl Database {
             if let Err(e) = self.recompress_partition(table_ref, table_name, date, target_level).await {
                 warn!("recompress_tier_window: skipping date={} after error: {}", date, e);
             }
+        }
+        Ok(())
+    }
+
+    /// Cross-flush dedup: collapse a `(project_id, date)` partition by the
+    /// schema's `dedup_keys` (last-write-wins) and write back via
+    /// `replace_where`. No-op on no dedup_keys / no duplicates (avoids
+    /// gratuitous Foyer churn). Returns rows dropped.
+    pub async fn dedup_partition(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate) -> Result<u64> {
+        let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
+        if schema.dedup_keys.is_empty() {
+            return Ok(0);
+        }
+        let date_str = date.to_string();
+
+        // Bypass ProjectRoutingTable: its MemBuffer union would feed in-flight
+        // rows to dedup, then `replace_where` would write them to Delta —
+        // double-writing on the next real flush.
+        use deltalake::delta_datafusion::TableProviderBuilder;
+        let (snapshot, log_store) = {
+            let table = table_ref.read().await;
+            (Arc::new(table.snapshot()?.snapshot().clone()), table.log_store())
+        };
+        let provider = TableProviderBuilder::default()
+            .with_log_store(log_store)
+            .with_eager_snapshot(snapshot)
+            .build()
+            .await
+            .map_err(|e| anyhow::anyhow!("delta table provider: {e}"))?;
+        let ctx = datafusion::prelude::SessionContext::new_with_state(build_optimize_session_state());
+        let scan_name = "__dedup_src";
+        ctx.register_table(scan_name, Arc::new(provider))?;
+        // project_id is currently always a UUID/controlled identifier, but defend in depth: escape single quotes
+        // so a future caller can't inject SQL through the partition predicate. date_str comes from NaiveDate::to_string
+        // and is already safe.
+        let safe_pid = project_id.replace('\'', "''");
+        let select = format!("SELECT * FROM {} WHERE project_id = '{}' AND date = DATE '{}'", scan_name, safe_pid, date_str);
+        let batches = ctx.sql(&select).await?.collect().await?;
+        let before: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if before == 0 {
+            return Ok(0);
+        }
+        let deduped = crate::mem_buffer::dedup_batches(batches, &schema.dedup_keys)?;
+        let after: usize = deduped.iter().map(|b| b.num_rows()).sum();
+        if before == after {
+            return Ok(0);
+        }
+        let dropped = (before - after) as u64;
+
+        // Variant struct columns may still be BinaryView if the partition mixes
+        // tiers — cast to Binary so the delta-kernel write accepts the schema.
+        let deduped: Vec<RecordBatch> = deduped.into_iter().map(cast_variant_columns_to_binary).collect::<DFResult<Vec<_>>>()?;
+        let writer_properties = self.create_writer_properties(schema, self.config.parquet.timefusion_zstd_compression_level);
+        let predicate = format!("project_id = '{}' AND date = '{}'", safe_pid, date_str);
+
+        // OCC retry — same shape as optimize_table_light_inner. Best-effort;
+        // exhaustion bubbles up as Err (the caller in `dedup_today_partitions`
+        // logs and continues), so the partition only retries when the next
+        // scheduler tick sees a file-count change.
+        const MAX_RETRIES: usize = 4;
+        let mut last_err: Option<deltalake::DeltaTableError> = None;
+        for attempt in 0..MAX_RETRIES {
+            let table_clone = {
+                let table = table_ref.read().await;
+                table.clone()
+            };
+            let result = table_clone
+                .write(deduped.clone())
+                .with_partition_columns(schema.partitions.clone())
+                .with_writer_properties(writer_properties.clone())
+                .with_save_mode(deltalake::protocol::SaveMode::Overwrite)
+                .with_replace_where(predicate.clone())
+                .await;
+            match result {
+                Ok(new_table) => {
+                    *table_ref.write().await = new_table;
+                    crate::metrics::record_compaction_dedup_dropped(dropped);
+                    info!(
+                        "dedup compaction: table={} project={} date={} dropped={} (before={} after={})",
+                        table_name, project_id, date_str, dropped, before, after
+                    );
+                    return Ok(dropped);
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    let is_conflict = msg.contains("concurrent transaction") || msg.contains("Commit failed");
+                    if !is_conflict || attempt + 1 == MAX_RETRIES {
+                        return Err(anyhow::anyhow!("dedup_partition write failed: {}", e));
+                    }
+                    debug!(
+                        "dedup_partition OCC conflict (attempt {}/{}): table={} project={} date={}",
+                        attempt + 1,
+                        MAX_RETRIES,
+                        table_name,
+                        project_id,
+                        date_str
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_millis(150u64 << attempt)).await;
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(anyhow::anyhow!(
+            "dedup_partition exhausted retries: {}",
+            last_err.map(|e| e.to_string()).unwrap_or_default()
+        ))
+    }
+
+    /// Sweep every `(project_id, today)` partition in this table via
+    /// `dedup_partition`. Skips when Delta version is unchanged since the
+    /// last sweep. Best-effort: per-partition errors are logged.
+    pub async fn dedup_today_partitions(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, dedup_key: &str) -> Result<()> {
+        let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
+        if schema.dedup_keys.is_empty() {
+            return Ok(());
+        }
+        let today = Utc::now().date_naive();
+        let date_marker = format!("date={}", today);
+
+        let (pre_version, project_ids) = {
+            let table = table_ref.read().await;
+            let v = table.version().unwrap_or(0);
+            let pids: std::collections::HashSet<String> = table
+                .get_file_uris()?
+                .filter(|u| u.contains(&date_marker))
+                .filter_map(|uri| uri.split('/').find_map(|seg| seg.strip_prefix("project_id=").map(str::to_string)))
+                .collect();
+            (v, pids)
+        };
+        if self.last_dedup_versions.read().await.get(dedup_key).copied() == Some(pre_version) {
+            debug!("dedup sweep: table={} version={} unchanged — skipping", table_name, pre_version);
+            return Ok(());
+        }
+        // Custom-project tables don't embed project_id in the path; sweep "default".
+        let project_ids = if project_ids.is_empty() { std::iter::once("default".to_string()).collect() } else { project_ids };
+
+        let mut total_dropped = 0u64;
+        let mut any_ok = false;
+        for pid in &project_ids {
+            match self.dedup_partition(table_ref, table_name, pid, today).await {
+                Ok(d) => {
+                    total_dropped += d;
+                    any_ok = true;
+                }
+                Err(e) => warn!("dedup sweep: project={} date={} table={} failed: {}", pid, today, table_name, e),
+            }
+        }
+        // Only refresh the skip cache when at least one partition ran cleanly,
+        // so persistent failures don't silently suppress future sweeps.
+        // TODO: same unbounded-growth caveat as `last_written_versions`.
+        if any_ok {
+            let post_version = table_ref.read().await.version().unwrap_or(pre_version);
+            self.last_dedup_versions.write().await.insert(dedup_key.to_string(), post_version);
+        }
+        if total_dropped > 0 {
+            info!(
+                "dedup sweep: table={} key={} projects={} total_dropped={}",
+                table_name,
+                dedup_key,
+                project_ids.len(),
+                total_dropped
+            );
         }
         Ok(())
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,7 @@ counter_registry! {
     dedup_dropped_rows         => "timefusion.flush.dedup_dropped_rows": "Rows collapsed by per-table dedup_keys (last-write-wins) before Delta commit",
     optimize_partitions_rewritten => "timefusion.optimize.partitions_rewritten": "Date partitions rewritten by full (z-order) optimize",
     optimize_partitions_skipped   => "timefusion.optimize.partitions_skipped": "Date partitions skipped by full optimize because their file set was unchanged since the last run (cache churn avoided)",
+    compaction_dedup_dropped_rows => "timefusion.compaction.dedup_dropped_rows": "Rows collapsed by Delta-vs-Delta dedup compaction (cross-flush duplicates)",
 }
 
 pub fn registry() -> Option<&'static MetricsRegistry> {
@@ -275,6 +276,12 @@ simple_recorders! {
 pub fn record_dedup_dropped(rows: u64) {
     if let Some(m) = METRICS.get() {
         m.dedup_dropped_rows.add(rows, &[]);
+    }
+}
+
+pub fn record_compaction_dedup_dropped(rows: u64) {
+    if let Some(m) = METRICS.get() {
+        m.compaction_dedup_dropped_rows.add(rows, &[]);
     }
 }
 

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -1,0 +1,69 @@
+//! Regression: copy A of a row flushes to Delta, then a retry (copy B) lands
+//! in a different Delta file in the same `(project_id, date)` partition.
+//! Flush-time dedup runs per-bucket and cannot see across files, so without
+//! a Delta-vs-Delta compaction pass the duplicate persists forever.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
+use serial_test::serial;
+use timefusion::{
+    database::Database,
+    test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
+};
+
+#[serial]
+#[tokio::test]
+async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
+    let cfg = TestConfigBuilder::new("dedup_compaction").with_buffer_mode(BufferMode::Enabled).build();
+    // SAFETY: walrus-rust reads WALRUS_DATA_DIR from process env. `#[serial]`
+    // serializes the suite; this set is racy in principle but safe here.
+    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    // Pick a fixed timestamp so both inserts share (id, timestamp) and date.
+    let ts = chrono::Utc::now().timestamp_micros();
+    let row = |name: &str| -> Result<_> { json_to_batch(vec![test_span_ts("dup_id", name, &project_id, ts)]) };
+
+    // Two skip_queue=true inserts → two independent Delta commits, two files
+    // in the same (project_id, date) partition. This is the cross-flush
+    // scenario in production: bucket A flushes, then a client retry arrives
+    // in a fresh bucket B and flushes separately.
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("first")?], true, None).await?;
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("second")?], true, None).await?;
+
+    // Sanity: the duplicate really did land in Delta.
+    let count_sql = format!(
+        "SELECT COUNT(*) AS cnt FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'",
+        project_id
+    );
+    let pre = db.query_delta_only(&count_sql).await?;
+    let pre_count = pre[0].column(0).as_primitive::<Int64Type>().value(0);
+    assert_eq!(pre_count, 2, "pre-dedup: cross-flush duplicate should exist as 2 rows in Delta");
+
+    // Verify there are at least two parquet files in the partition (proves the
+    // two commits did not coalesce by accident).
+    let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
+    let date_str = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive().to_string();
+    let part_marker = format!("project_id={}/date={}", project_id, date_str);
+    let file_count_before = table_ref.read().await.get_file_uris()?.filter(|u| u.contains(&part_marker)).count();
+    assert!(
+        file_count_before >= 2,
+        "expected >=2 files in partition before dedup, got {}",
+        file_count_before
+    );
+
+    // Run the new dedup compaction on the partition.
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
+    let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
+    assert_eq!(dropped, 1, "expected exactly one duplicate row dropped");
+
+    // After dedup, COUNT must be 1.
+    let post = db.query_delta_only(&count_sql).await?;
+    let post_count = post[0].column(0).as_primitive::<Int64Type>().value(0);
+    assert_eq!(post_count, 1, "post-dedup: duplicate should be collapsed to a single row");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Flush-time dedup runs per-bucket and cannot see across Delta files. When a retry of the same `(id, timestamp)` lands in a fresh bucket and flushes separately, both copies sit in different parquet files in the same date partition and the duplicate persists forever.

This PR adds the Delta-vs-Delta compaction half of the dedup story, wired into the existing 5-minute light-optimize tick.

- `Database::dedup_partition` — reads a partition via `TableProviderBuilder` (raw on-disk schema, no Variant→JSON rewrite), collapses with the existing `mem_buffer::dedup_batches`, and writes back with `replace_where` on `(project_id, date)`. OCC retry shape mirrors `optimize_table_light_inner` (150/300/600ms backoff). No-op when the partition has no duplicates.
- `Database::dedup_today_partitions` — sweeps every distinct `project_id` in today's date partition for a table. Skip cache (`last_dedup_file_counts`) keyed on `table_name` for unified tables and `project_id:table_name` for custom tables — unchanged tables skip the scan, bounding Foyer churn.
- Scheduler wiring: runs `dedup_today_partitions` immediately before `optimize_table_light` so light compact bin-packs the already-deduped files.
- New counter: `timefusion.compaction.dedup_dropped_rows`, parallel to the existing `timefusion.flush.dedup_dropped_rows`.

## Test plan

- [x] New regression test `dedup_compaction_collapses_cross_flush_duplicates` — inserts two skip_queue commits of the same `(id, timestamp)`, asserts 2 files / 2 rows in partition, runs `dedup_partition`, asserts 1 file / 1 row and the metric incremented.
- [x] `cargo test --lib` (114 passed)
- [x] `cargo test --test buffer_consistency_test` (11 passed, 2 ignored)
- [x] `cargo test --test integration_test` (4 passed)
- [x] `cargo test --test sqllogictest` (passed)
- [x] `cargo test --test test_dml_operations` (6 passed)

## Out of scope

Read-side `DeduplicateExec` (Phase 2) and file-overlap stats gating ship in the follow-up PR.