### PR TITLE
dedup: read-side DeduplicateExec hides cross-file duplicates on the query path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,8 @@ Client SELECT
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. PGWire parses SQL                                            │
 │ 2. DataFusion analyzes query                                    │
-│    └── VariantSelectRewriter wraps Variant→variant_to_json()    │
+│    ├── VariantTableScanSchemaPatch restores Variant types       │
+│    └── VariantPgwireRootWrap → variant_to_json() (pgwire only)  │
 │ 3. VariantAwareExprPlanner handles -> and ->> operators         │
 │ 4. Physical planning                                            │
 └─────────────────────────────────────────────────────────────────┘
@@ -247,11 +248,17 @@ AppConfig {
    - Wraps Utf8/Utf8View literals with `json_to_variant()` UDF
    - Applies recursively to Values and Projection nodes
 
-2. **VariantSelectRewriter** (`src/optimizers/variant_select_rewriter.rs`)
-   - Intercepts `LogicalPlan::Projection`
-   - Checks if expression result type is Variant (via `is_variant_type()`)
-   - Wraps with `variant_to_json()` for PostgreSQL wire protocol
-   - Preserves column aliases
+2. **VariantTableScanSchemaPatch** (`src/optimizers/variant_select_rewriter.rs`, always-on)
+   - Bottom-up `transform_up` over `LogicalPlan::TableScan`
+   - Replaces `Utf8View` columns the routing-table lying-schema returned with
+     real Variant types so downstream UDFs receive `Struct{Binary,Binary}`
+   - Recomputes parent schemas so the type propagates through cached DFSchemas
+
+3. **VariantPgwireRootWrap** (same file, pgwire sessions only)
+   - Wraps the outermost Projection's Variant exprs with `variant_to_json()`
+   - Peels Sort/Limit/Distinct/SubqueryAlias/Filter to find the wire-output Projection
+   - Internal SQL contexts (`Database::create_internal_session_context`) omit
+     this rule and receive binary Variant end-to-end
 
 ### Physical Planner
 

--- a/docs/VARIANT_TYPE_SYSTEM.md
+++ b/docs/VARIANT_TYPE_SYSTEM.md
@@ -74,7 +74,7 @@ The rewriter:
 
 ### SELECT: Automatic Variant → JSON Conversion
 
-When selecting Variant columns, the `VariantSelectRewriter` wraps them with `variant_to_json()` for PostgreSQL wire protocol compatibility:
+When selecting Variant columns over pgwire, `VariantPgwireRootWrap` wraps them with `variant_to_json()` for wire-protocol compatibility (companion to `VariantTableScanSchemaPatch`, which restores the real Variant type on the scan side). Internal SQL contexts skip the wrap and receive binary Variant end-to-end.
 
 **Before rewrite:**
 ```sql

--- a/src/database.rs
+++ b/src/database.rs
@@ -422,6 +422,11 @@ pub struct Database {
     object_store_cache:              Option<Arc<SharedFoyerCache>>,
     statistics_extractor:            Arc<DeltaStatisticsExtractor>,
     last_written_versions:           Arc<RwLock<HashMap<(String, String), u64>>>,
+    /// Per-table file count at last dedup sweep. Used to skip the partition
+    /// scan when no Delta commits have landed since — bounds Foyer churn.
+    /// Key is `table_name` for unified tables and `project_id:table_name`
+    /// for custom-project tables (matches scheduler keying).
+    last_dedup_file_counts:          Arc<RwLock<HashMap<String, usize>>>,
     buffered_layer:                  Option<Arc<crate::buffered_write_layer::BufferedWriteLayer>>,
     tantivy_search:                  Option<Arc<crate::tantivy_index::search::TantivySearchService>>,
     tantivy_indexer:                 Option<Arc<crate::tantivy_index::service::TantivyIndexService>>,
@@ -711,6 +716,7 @@ impl Database {
             object_store_cache,
             statistics_extractor,
             last_written_versions: Arc::new(RwLock::new(HashMap::new())),
+            last_dedup_file_counts: Arc::new(RwLock::new(HashMap::new())),
             buffered_layer: None,
             tantivy_search: None,
             tantivy_indexer: None,
@@ -805,8 +811,14 @@ impl Database {
                     let db = db.clone();
                     Box::pin(async move {
                         info!("Running scheduled light optimize on recent small files");
-                        // Optimize unified tables
+                        // Optimize unified tables. Run dedup FIRST so the
+                        // light compact bin-packs already-deduped files —
+                        // otherwise compact would rewrite the duplicates into
+                        // a single file that we'd then have to rewrite again.
                         for (table_name, table) in db.unified_tables.read().await.iter() {
+                            if let Err(e) = db.dedup_today_partitions(table, table_name, table_name).await {
+                                error!("Dedup sweep failed for unified table '{}': {}", table_name, e);
+                            }
                             match db.optimize_table_light(table, table_name).await {
                                 Ok(_) => info!("Light optimize completed for unified table '{}'", table_name),
                                 Err(e) => error!("Light optimize failed for unified table '{}': {}", table_name, e),
@@ -814,6 +826,10 @@ impl Database {
                         }
                         // Optimize custom project tables
                         for ((project_id, table_name), table) in db.custom_project_tables.read().await.iter() {
+                            let key = format!("{}:{}", project_id, table_name);
+                            if let Err(e) = db.dedup_today_partitions(table, table_name, &key).await {
+                                error!("Dedup sweep failed for custom project '{}' table '{}': {}", project_id, table_name, e);
+                            }
                             match db.optimize_table_light(table, table_name).await {
                                 Ok(_) => info!("Light optimize completed for custom project '{}' table '{}'", project_id, table_name),
                                 Err(e) => error!("Light optimize failed for custom project '{}' table '{}': {}", project_id, table_name, e),
@@ -1014,8 +1030,23 @@ impl Database {
         Ok(self)
     }
 
-    /// Create and configure a SessionContext with DataFusion settings
+    /// Create a SessionContext for the pgwire endpoint. Includes
+    /// `VariantPgwireRootWrap`, which serializes Variant SELECT outputs to
+    /// JSON text for the pg wire protocol.
     pub fn create_session_context(self: Arc<Self>) -> SessionContext {
+        self.create_session_context_inner(true)
+    }
+
+    /// Create a SessionContext for internal SQL (no wire format coupled).
+    /// Omits `VariantPgwireRootWrap` so Variant columns flow through as
+    /// `Struct{Binary, Binary}` — what Arrow IPC, delta-kernel writes, and
+    /// downstream Variant UDFs consume natively. Use this when the result
+    /// won't be encoded into pgwire text.
+    pub fn create_internal_session_context(self: Arc<Self>) -> SessionContext {
+        self.create_session_context_inner(false)
+    }
+
+    fn create_session_context_inner(self: Arc<Self>, include_pgwire_wrap: bool) -> SessionContext {
         use std::sync::Arc;
 
         use datafusion::{
@@ -1112,10 +1143,15 @@ impl Database {
             options: tracing_options,
         );
 
-        // Create session state with tracing rule and DML support
-        // Rule ordering: VariantInsertRewriter runs BEFORE TypeCoercion (rewrites string->json_to_variant)
-        //                VariantSelectRewriter runs AFTER TypeCoercion (wraps Variant cols with variant_to_json)
-        let analyzer_rules: Vec<Arc<dyn datafusion::optimizer::AnalyzerRule + Send + Sync>> = vec![
+        // Create session state with tracing rule and DML support.
+        // Rule ordering:
+        //   VariantInsertRewriter           BEFORE TypeCoercion (rewrites Utf8 → json_to_variant)
+        //   VariantTableScanSchemaPatch     AFTER  TypeCoercion (un-lies ProjectRoutingTable's Utf8View schema → real Variant)
+        //   VariantPgwireRootWrap           AFTER  VariantTableScanSchemaPatch (wraps root Variant projections with variant_to_json for pgwire text format)
+        // The wire-wrap rule is registered here because this context drives
+        // pgwire. Non-pgwire callers use `create_internal_session_context`,
+        // which excludes the wrap rule so SELECTs return binary Variant.
+        let mut analyzer_rules: Vec<Arc<dyn datafusion::optimizer::AnalyzerRule + Send + Sync>> = vec![
             Arc::new(datafusion::optimizer::analyzer::resolve_grouping_function::ResolveGroupingFunction::new()),
             Arc::new(crate::optimizers::VariantInsertRewriter),
             // Tantivy predicate rewriter runs BEFORE TypeCoercion so the
@@ -1123,8 +1159,11 @@ impl Database {
             // other UDF args (Utf8 vs Utf8View etc).
             Arc::new(crate::optimizers::TantivyPredicateRewriter),
             Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
-            Arc::new(crate::optimizers::VariantSelectRewriter),
+            Arc::new(crate::optimizers::VariantTableScanSchemaPatch),
         ];
+        if include_pgwire_wrap {
+            analyzer_rules.push(Arc::new(crate::optimizers::VariantPgwireRootWrap));
+        }
 
         let session_state = SessionStateBuilder::new()
             .with_config(options.into())
@@ -2196,6 +2235,186 @@ impl Database {
         Ok(())
     }
 
+    /// Cross-flush dedup compaction: reads a partition's current Delta rows,
+    /// collapses duplicates by the schema's `dedup_keys` (last-write-wins),
+    /// and writes the result back with `replace_where` on the partition.
+    /// No-op when the schema has no `dedup_keys` or no duplicates are found
+    /// (avoids gratuitous rewrites + Foyer cache churn).
+    ///
+    /// `project_id`/`date` form the partition predicate. For unified tables
+    /// these are both partition columns; for custom-project tables (`date`-
+    /// only) the `project_id` filter is still a valid row predicate.
+    ///
+    /// Returns the number of rows dropped (0 = nothing to do).
+    pub async fn dedup_partition(
+        &self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate,
+    ) -> Result<u64> {
+        let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
+        if schema.dedup_keys.is_empty() {
+            return Ok(0);
+        }
+        let date_str = date.to_string();
+
+        // Read the partition directly from the DeltaTable as a TableProvider
+        // in a fresh, minimal session. The only load-bearing reason to bypass
+        // ProjectRoutingTable is the MemBuffer union: dedup rewrites the
+        // partition via `replace_where`, so including MemBuffer rows would
+        // flush them prematurely and double-write on the next real flush.
+        // To reuse ProjectRoutingTable here, it would need an opt-in
+        // delta-only scan mode (skip the MemBuffer union) — a feature, not a
+        // cleanup. Other concerns are already neutral: both the main and the
+        // `build_optimize_session_state` sessions set
+        // `schema_force_view_types=false` (delta-kernel's `unshredded_variant()`
+        // requires Binary, not BinaryView), and the JSON wire wrap lives only
+        // on the pgwire context (`create_internal_session_context` omits it),
+        // so neither would fire on the routing path even if it were used.
+        use deltalake::delta_datafusion::TableProviderBuilder;
+        let (snapshot, log_store) = {
+            let table = table_ref.read().await;
+            (Arc::new(table.snapshot()?.snapshot().clone()), table.log_store())
+        };
+        let provider = TableProviderBuilder::default()
+            .with_log_store(log_store)
+            .with_eager_snapshot(snapshot)
+            .build()
+            .await
+            .map_err(|e| anyhow::anyhow!("delta table provider: {e}"))?;
+        let ctx = datafusion::prelude::SessionContext::new_with_state(build_optimize_session_state());
+        let scan_name = "__dedup_src";
+        ctx.register_table(scan_name, Arc::new(provider))?;
+        let select = format!(
+            "SELECT * FROM {} WHERE project_id = '{}' AND date = DATE '{}'",
+            scan_name, project_id, date_str
+        );
+        let batches = ctx.sql(&select).await?.collect().await?;
+        let before: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if before == 0 {
+            return Ok(0);
+        }
+        let deduped = crate::mem_buffer::dedup_batches(batches, &schema.dedup_keys)?;
+        let after: usize = deduped.iter().map(|b| b.num_rows()).sum();
+        if before == after {
+            return Ok(0);
+        }
+        let dropped = (before - after) as u64;
+
+        // Variant struct columns may still be BinaryView if the partition mixes
+        // tiers — cast to Binary so the delta-kernel write accepts the schema.
+        let deduped: Vec<RecordBatch> = deduped.into_iter().map(cast_variant_columns_to_binary).collect::<DFResult<Vec<_>>>()?;
+        let writer_properties = self.create_writer_properties(schema, self.config.parquet.timefusion_zstd_compression_level);
+        let predicate = format!("project_id = '{}' AND date = '{}'", project_id, date_str);
+
+        // OCC retry — same shape as optimize_table_light_inner. Best-effort;
+        // if we give up after retries, the next scheduler tick will retry.
+        const MAX_RETRIES: usize = 4;
+        let mut last_err: Option<deltalake::DeltaTableError> = None;
+        for attempt in 0..MAX_RETRIES {
+            let table_clone = {
+                let table = table_ref.read().await;
+                table.clone()
+            };
+            let result = table_clone
+                .write(deduped.clone())
+                .with_partition_columns(schema.partitions.clone())
+                .with_writer_properties(writer_properties.clone())
+                .with_save_mode(deltalake::protocol::SaveMode::Overwrite)
+                .with_replace_where(predicate.clone())
+                .await;
+            match result {
+                Ok(new_table) => {
+                    *table_ref.write().await = new_table;
+                    crate::metrics::record_compaction_dedup_dropped(dropped);
+                    info!(
+                        "dedup compaction: table={} project={} date={} dropped={} (before={} after={})",
+                        table_name, project_id, date_str, dropped, before, after
+                    );
+                    return Ok(dropped);
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    let is_conflict = msg.contains("concurrent transaction") || msg.contains("Commit failed");
+                    if is_conflict && attempt + 1 < MAX_RETRIES {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(150u64 << attempt)).await;
+                        last_err = Some(e);
+                        continue;
+                    }
+                    return Err(anyhow::anyhow!("dedup_partition write failed: {}", e));
+                }
+            }
+        }
+        Err(anyhow::anyhow!(
+            "dedup_partition exhausted retries: {}",
+            last_err.map(|e| e.to_string()).unwrap_or_default()
+        ))
+    }
+
+    /// Run `dedup_partition` for every `(project_id, today)` pair that has
+    /// data in this table. Skips entirely when the table's file count hasn't
+    /// changed since the last sweep (no commits = no new dupes). Best-effort:
+    /// per-partition errors are logged and the sweep continues.
+    ///
+    /// `dedup_key` matches the scheduler's keying so unified and custom-
+    /// project tables don't collide in the dedup-skip cache.
+    pub async fn dedup_today_partitions(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, dedup_key: &str) -> Result<()> {
+        let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
+        if schema.dedup_keys.is_empty() {
+            return Ok(());
+        }
+        let today = Utc::now().date_naive();
+        let date_marker = format!("date={}", today);
+
+        // Collect file URIs matching today's date and extract project_id from
+        // the path. Holds the read lock only briefly.
+        let uris: Vec<String> = {
+            let table = table_ref.read().await;
+            table.get_file_uris()?.filter(|u| u.contains(&date_marker)).collect()
+        };
+        // Skip the scan if no commits have landed since last sweep.
+        {
+            let last = self.last_dedup_file_counts.read().await;
+            if last.get(dedup_key).copied() == Some(uris.len()) {
+                debug!("dedup sweep: table={} unchanged ({} files) — skipping", table_name, uris.len());
+                return Ok(());
+            }
+        }
+
+        // Extract distinct project_ids from `project_id={...}/date=...` segments.
+        // Unified tables embed it; custom-project tables don't and we fall back
+        // to a single sweep with project_id = "default".
+        let mut project_ids: std::collections::BTreeSet<String> = uris
+            .iter()
+            .filter_map(|uri| {
+                uri.split('/')
+                    .find_map(|seg| seg.strip_prefix("project_id=").map(|s| s.to_string()))
+            })
+            .collect();
+        if project_ids.is_empty() {
+            project_ids.insert("default".to_string());
+        }
+
+        let mut total_dropped = 0u64;
+        for pid in &project_ids {
+            match self.dedup_partition(table_ref, table_name, pid, today).await {
+                Ok(d) => total_dropped += d,
+                Err(e) => warn!("dedup sweep: project={} date={} table={} failed: {}", pid, today, table_name, e),
+            }
+        }
+        // Refresh cached file count *after* any rewrites so the next tick
+        // compares against the post-dedup state.
+        let post_count = table_ref.read().await.get_file_uris()?.filter(|u| u.contains(&date_marker)).count();
+        self.last_dedup_file_counts.write().await.insert(dedup_key.to_string(), post_count);
+        if total_dropped > 0 {
+            info!(
+                "dedup sweep: table={} key={} projects={} total_dropped={}",
+                table_name,
+                dedup_key,
+                project_ids.len(),
+                total_dropped
+            );
+        }
+        Ok(())
+    }
+
     pub async fn optimize_table_light(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str) -> Result<()> {
         let start_time = std::time::Instant::now();
         let today = Utc::now().date_naive();
@@ -3036,8 +3255,10 @@ impl TableProvider for ProjectRoutingTable {
         }
 
         // Variant binary flows through scans untouched; downstream nodes
-        // (variant_get, ->, ->>) consume it directly. JSON serialization
-        // happens only at the root projection via VariantSelectRewriter.
+        // (variant_get, ->, ->>) consume it directly. For pgwire SELECTs,
+        // JSON serialization happens only at the root projection via
+        // VariantPgwireRootWrap; internal SQL contexts skip that rule and
+        // keep Variant binary end-to-end.
         let wrap_result = |plan: Arc<dyn ExecutionPlan>| -> DFResult<Arc<dyn ExecutionPlan>> { Ok(plan) };
 
         // Check if buffered layer is configured

--- a/src/database.rs
+++ b/src/database.rs
@@ -2857,6 +2857,32 @@ impl ProjectRoutingTable {
     async fn scan_delta_table(
         &self, table: &DeltaTable, state: &dyn Session, projection: Option<&Vec<usize>>, filters: &[Expr], limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // Dedup wrapping needs the dedup_key columns in the scan output even
+        // when the caller didn't request them (e.g. `SELECT name WHERE id=…`).
+        // Resolve the gating decision up-front so we can augment `projection`
+        // before delegating, then strip the extra columns at the end.
+        let table_schema = crate::schema_loader::get_schema(&self.table_name);
+        let dedup_keys: Vec<String> = table_schema.map(|s| s.dedup_keys.clone()).unwrap_or_default();
+        let need_dedup = !dedup_keys.is_empty()
+            && crate::dedup_exec::table_has_any_overlap(table, &dedup_keys)
+                .map_err(|e| DataFusionError::External(format!("overlap check failed: {e}").into()))?;
+        let original_projection = projection;
+        let augmented_projection: Option<Vec<usize>> = if need_dedup {
+            // Append any dedup_key indices missing from the caller's projection.
+            let mut proj: Vec<usize> = projection.cloned().unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+            for key in &dedup_keys {
+                if let Some(idx) = self.schema.fields().iter().position(|f| f.name() == key)
+                    && !proj.contains(&idx)
+                {
+                    proj.push(idx);
+                }
+            }
+            Some(proj)
+        } else {
+            projection.cloned()
+        };
+        let projection = augmented_projection.as_ref();
+
         table.update_datafusion_session(state).map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         // Build the delta-rs table provider with our session so its scan
@@ -2904,7 +2930,89 @@ impl ProjectRoutingTable {
             None => self.schema.clone(),
         };
 
-        Self::coerce_plan_to_schema(delta_plan, &target_schema)
+        let coerced = Self::coerce_plan_to_schema(delta_plan, &target_schema)?;
+        if !need_dedup {
+            return Ok(coerced);
+        }
+        let wrapped = Self::wrap_with_read_dedup(coerced, &dedup_keys)?;
+
+        // If we augmented the projection (added dedup_keys not requested by
+        // the caller), strip them with a final ProjectionExec so downstream
+        // sees the original projected schema.
+        let augmented = augmented_projection.as_ref().unwrap();
+        let original_len = original_projection.map(|p| p.len()).unwrap_or(self.schema.fields().len());
+        if augmented.len() == original_len {
+            return Ok(wrapped);
+        }
+        let wrapped_schema = wrapped.schema();
+        let project_exprs: Vec<(Arc<dyn datafusion::physical_expr::PhysicalExpr>, String)> = (0..original_len)
+            .map(|i| {
+                let field = wrapped_schema.field(i);
+                let col: Arc<dyn datafusion::physical_expr::PhysicalExpr> = Arc::new(PhysicalColumn::new(field.name(), i));
+                (col, field.name().clone())
+            })
+            .collect();
+        Ok(Arc::new(datafusion::physical_plan::projection::ProjectionExec::try_new(project_exprs, wrapped)?))
+    }
+
+    /// Sort by `dedup_keys` ASC + `timestamp` DESC, then collapse duplicates
+    /// in a streaming DeduplicateExec. The DESC tiebreaker on `timestamp`
+    /// is harmless when `timestamp` is already in `dedup_keys` (the next
+    /// sort column is ignored). For schemas where it isn't, picking the
+    /// most-recent `timestamp` matches the last-write-wins intent.
+    fn wrap_with_read_dedup(plan: Arc<dyn ExecutionPlan>, dedup_keys: &[String]) -> DFResult<Arc<dyn ExecutionPlan>> {
+        use datafusion::{
+            arrow::compute::SortOptions,
+            physical_expr::{LexOrdering, PhysicalSortExpr, expressions::Column as PhysCol},
+            physical_plan::{
+                Partitioning, repartition::RepartitionExec, sorts::sort_preserving_merge::SortPreservingMergeExec, sorts::sort::SortExec,
+            },
+        };
+
+        let schema = plan.schema();
+        // Map dedup_key names to projection indices; missing column = drop the
+        // wrapper rather than crash (read still correct, just not deduped).
+        let mut key_idx: Vec<usize> = Vec::with_capacity(dedup_keys.len());
+        for k in dedup_keys {
+            let Some(i) = schema.fields().iter().position(|f| f.name() == k) else {
+                return Ok(plan);
+            };
+            key_idx.push(i);
+        }
+
+        // Sort key: dedup_keys ASC, then timestamp DESC as tiebreaker so the
+        // newest row in a duplicate group is emitted first (and DeduplicateExec
+        // keeps the first per key tuple).
+        let mut sort_exprs: Vec<PhysicalSortExpr> = key_idx
+            .iter()
+            .map(|&i| PhysicalSortExpr::new(Arc::new(PhysCol::new(schema.field(i).name(), i)), SortOptions { descending: false, nulls_first: true }))
+            .collect();
+        if let Some(ts_idx) = schema.fields().iter().position(|f| f.name() == "timestamp")
+            && !key_idx.contains(&ts_idx)
+        {
+            sort_exprs.push(PhysicalSortExpr::new(
+                Arc::new(PhysCol::new(schema.field(ts_idx).name(), ts_idx)),
+                SortOptions { descending: true, nulls_first: false },
+            ));
+        }
+        let ordering = LexOrdering::new(sort_exprs).ok_or_else(|| DataFusionError::Internal("empty dedup sort ordering".into()))?;
+
+        // DeduplicateExec demands SinglePartition; multi-partition Delta scans
+        // funnel through SortPreservingMergeExec, single-partition scans use
+        // SortExec directly.
+        let parts = plan.properties().partitioning.partition_count();
+        let sorted: Arc<dyn ExecutionPlan> = if parts <= 1 {
+            Arc::new(SortExec::new(ordering, plan))
+        } else {
+            // Sort each partition independently, then merge into one stream.
+            let per_part = Arc::new(SortExec::new(ordering.clone(), plan));
+            let merged = Arc::new(SortPreservingMergeExec::new(ordering, per_part));
+            // SortPreservingMergeExec outputs 1 partition already; no
+            // RepartitionExec needed. Hint to the type system:
+            let _ = Partitioning::UnknownPartitioning(1);
+            merged
+        };
+        Ok(Arc::new(crate::dedup_exec::DeduplicateExec::new(sorted, key_idx)))
     }
 
     /// Wrap an execution plan with type coercion if the output schema doesn't match the target.

--- a/src/dedup_exec.rs
+++ b/src/dedup_exec.rs
@@ -1,0 +1,227 @@
+//! Sorted-stream distinct: emits one row per `key_columns` tuple from a
+//! pre-sorted input stream. Used to collapse cross-file Delta duplicates
+//! at query time when the partition's per-file min/max ranges overlap.
+//!
+//! Correctness invariant: the input MUST be sorted by `key_columns` —
+//! enforced via `required_input_ordering` and `required_input_distribution`.
+
+use std::{any::Any, sync::Arc};
+
+use arrow::{
+    array::{ArrayRef, BooleanArray},
+    compute::filter_record_batch,
+    row::{OwnedRow, RowConverter, SortField},
+};
+use datafusion::{
+    common::DataFusionError,
+    error::Result as DFResult,
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_expr::{EquivalenceProperties, LexRequirement, OrderingRequirements, PhysicalSortRequirement, expressions::Column},
+    physical_plan::{
+        DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties, stream::RecordBatchStreamAdapter,
+    },
+};
+use futures::StreamExt;
+
+#[derive(Debug)]
+pub struct DeduplicateExec {
+    input:       Arc<dyn ExecutionPlan>,
+    key_columns: Arc<Vec<usize>>,
+    properties:  Arc<PlanProperties>,
+}
+
+impl DeduplicateExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, key_columns: Vec<usize>) -> Self {
+        let in_props = input.properties();
+        // Distinct preserves the input ordering and partitioning; only the
+        // row set shrinks. Equivalence properties forward from the input.
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            in_props.partitioning.clone(),
+            in_props.emission_type,
+            in_props.boundedness,
+        ));
+        Self { input, key_columns: Arc::new(key_columns), properties }
+    }
+}
+
+impl DisplayAs for DeduplicateExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let schema = self.input.schema();
+        let names: Vec<String> = self.key_columns.iter().map(|&i| schema.field(i).name().clone()).collect();
+        write!(f, "DeduplicateExec: keys=[{}]", names.join(","))
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionPlan for DeduplicateExec {
+    fn name(&self) -> &'static str {
+        "DeduplicateExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(self: Arc<Self>, children: Vec<Arc<dyn ExecutionPlan>>) -> DFResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self::new(children[0].clone(), (*self.key_columns).clone())))
+    }
+
+    /// Streaming distinct only works on a single partition — without it, two
+    /// partitions could each carry a copy of the duplicate row and our
+    /// per-partition stream wouldn't see across them.
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition]
+    }
+
+    /// Demand that the input is sorted ascending on every key column. The
+    /// caller wraps with `SortPreservingMergeExec` (or `SortExec`) to satisfy.
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        let schema = self.input.schema();
+        let req = LexRequirement::new(self.key_columns.iter().map(|&i| {
+            PhysicalSortRequirement::new(
+                Arc::new(Column::new(schema.field(i).name(), i)) as Arc<dyn datafusion::physical_expr::PhysicalExpr>,
+                Some(datafusion::arrow::compute::SortOptions { descending: false, nulls_first: true }),
+            )
+        }));
+        vec![req.map(OrderingRequirements::new)]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn execute(&self, partition: usize, context: Arc<TaskContext>) -> DFResult<SendableRecordBatchStream> {
+        let input = self.input.execute(partition, context)?;
+        let schema = self.input.schema();
+        let key_columns = self.key_columns.clone();
+        let sort_fields: Vec<SortField> =
+            key_columns.iter().map(|&i| SortField::new(schema.field(i).data_type().clone())).collect();
+        let converter = RowConverter::new(sort_fields).map_err(arrow_to_df)?;
+        let last: Option<OwnedRow> = None;
+
+        // (input_stream, converter, last_emitted_key) carried across batches.
+        let stream = futures::stream::try_unfold((input, converter, last, key_columns), move |state| async move {
+            let (mut input, converter, mut last, key_columns) = state;
+            loop {
+                let Some(batch_res) = input.next().await else {
+                    return Ok::<_, DataFusionError>(None);
+                };
+                let batch = batch_res?;
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+                let arrs: Vec<ArrayRef> = key_columns.iter().map(|&i| batch.column(i).clone()).collect();
+                let rows = converter.convert_columns(&arrs).map_err(arrow_to_df)?;
+                let mut mask = Vec::with_capacity(batch.num_rows());
+                for i in 0..rows.num_rows() {
+                    let cur = rows.row(i);
+                    // `OwnedRow.row()` returns a view comparable with the current `Row`.
+                    let keep = match &last {
+                        Some(prev) => prev.row() != cur,
+                        None => true,
+                    };
+                    if keep {
+                        last = Some(cur.owned());
+                    }
+                    mask.push(keep);
+                }
+                let mask_arr = BooleanArray::from(mask);
+                let filtered = filter_record_batch(&batch, &mask_arr).map_err(arrow_to_df)?;
+                if filtered.num_rows() > 0 {
+                    return Ok(Some((filtered, (input, converter, last, key_columns))));
+                }
+                // All rows in this batch were duplicates of prior emissions — pull next batch.
+            }
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+fn arrow_to_df(e: arrow::error::ArrowError) -> DataFusionError {
+    DataFusionError::ArrowError(Box::new(e), None)
+}
+
+/// True iff any partition in `table` has two Add files with overlapping
+/// ranges on EVERY `dedup_keys` column. Cross-file duplicates can only
+/// exist when every key dimension overlaps — a single disjoint dimension
+/// proves a (file, file) pair is clean.
+///
+/// Returns `true` conservatively when stats are missing for any required
+/// column — we'd rather pay the sort than miss a duplicate.
+pub fn table_has_any_overlap(table: &deltalake::DeltaTable, dedup_keys: &[String]) -> anyhow::Result<bool> {
+    use std::collections::HashMap;
+
+    use datafusion::common::ScalarValue;
+
+    if dedup_keys.is_empty() {
+        return Ok(false);
+    }
+    let snapshot = table.snapshot()?;
+    let actions = snapshot.add_actions_table(true)?;
+    let n = actions.num_rows();
+    if n <= 1 {
+        return Ok(false);
+    }
+
+    // Per-key min/max columns must exist for overlap-stats gating; if missing,
+    // conservatively assume overlap so correctness is preserved.
+    let mut key_cols: Vec<(&arrow::array::ArrayRef, &arrow::array::ArrayRef)> = Vec::with_capacity(dedup_keys.len());
+    for key in dedup_keys {
+        let (Some(mn), Some(mx)) =
+            (actions.column_by_name(&format!("min.{}", key)), actions.column_by_name(&format!("max.{}", key)))
+        else {
+            return Ok(true);
+        };
+        key_cols.push((mn, mx));
+    }
+
+    // Partition-column arrays for grouping. Absence (custom-project tables
+    // without a project_id partition) → single virtual group keyed by date.
+    let part_proj = actions.column_by_name("partition.project_id");
+    let part_date = actions.column_by_name("partition.date");
+    let group_key = |row: usize| -> String {
+        let p = part_proj.map(|a| arrow::util::display::array_value_to_string(a, row).unwrap_or_default()).unwrap_or_default();
+        let d = part_date.map(|a| arrow::util::display::array_value_to_string(a, row).unwrap_or_default()).unwrap_or_default();
+        format!("{}|{}", p, d)
+    };
+
+    // Bucket file rows by partition group, then run pairwise overlap check
+    // per group. False positives across groups are impossible (different
+    // partitions can never share a (project_id, date) tuple).
+    let mut groups: HashMap<String, Vec<Vec<(ScalarValue, ScalarValue)>>> = HashMap::new();
+    for row in 0..n {
+        let mut per_key = Vec::with_capacity(dedup_keys.len());
+        for (mn, mx) in &key_cols {
+            if mn.is_null(row) || mx.is_null(row) {
+                return Ok(true); // Missing stats → assume overlap.
+            }
+            per_key.push((ScalarValue::try_from_array(mn, row)?, ScalarValue::try_from_array(mx, row)?));
+        }
+        groups.entry(group_key(row)).or_default().push(per_key);
+    }
+
+    for ranges in groups.values() {
+        if ranges.len() <= 1 {
+            continue;
+        }
+        for i in 0..ranges.len() {
+            for j in (i + 1)..ranges.len() {
+                let all_overlap = ranges[i].iter().zip(&ranges[j]).all(|((a_lo, a_hi), (b_lo, b_hi))| a_lo <= b_hi && b_lo <= a_hi);
+                if all_overlap {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -309,7 +309,7 @@ impl ScalarUDFImpl for JsonToPgTextUdf {
 /// their first arg and bail with "Extension type name missing" when the
 /// field lacks the `ARROW:extension:name = arrow.parquet.variant` marker.
 /// That marker survives in the LogicalPlan's `projected_schema` (set by
-/// `VariantSelectRewriter::patch_table_scan` and by `SchemaRegistry`'s
+/// `VariantTableScanSchemaPatch` and by `SchemaRegistry`'s
 /// `fields()`), but is stripped on the way to the physical executor's
 /// per-row Field — so any SELECT touching a Variant column would panic at
 /// execution time. We re-stamp the marker here right before delegating.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod buffered_write_layer;
 pub mod clock;
 pub mod config;
 pub mod database;
+pub mod dedup_exec;
 pub mod dml;
 pub mod functions;
 pub mod grpc_handlers;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -71,6 +71,7 @@ counter_registry! {
     tantivy_prefilter_errors   => "timefusion.tantivy.prefilter_errors": "Tantivy lookups that errored (S3 down, parse failure, etc.)",
     tantivy_build_failures     => "timefusion.tantivy.build_failures": "Post-flush tantivy index builds that errored — accumulating drift means queries silently fall back to UDF scan",
     dedup_dropped_rows         => "timefusion.flush.dedup_dropped_rows": "Rows collapsed by per-table dedup_keys (last-write-wins) before Delta commit",
+    compaction_dedup_dropped_rows => "timefusion.compaction.dedup_dropped_rows": "Rows collapsed by Delta-vs-Delta dedup compaction (cross-flush duplicates)",
 }
 
 pub fn registry() -> Option<&'static MetricsRegistry> {
@@ -273,5 +274,11 @@ simple_recorders! {
 pub fn record_dedup_dropped(rows: u64) {
     if let Some(m) = METRICS.get() {
         m.dedup_dropped_rows.add(rows, &[]);
+    }
+}
+
+pub fn record_compaction_dedup_dropped(rows: u64) {
+    if let Some(m) = METRICS.get() {
+        m.compaction_dedup_dropped_rows.add(rows, &[]);
     }
 }

--- a/src/optimizers/mod.rs
+++ b/src/optimizers/mod.rs
@@ -8,7 +8,7 @@ use datafusion::{
 };
 pub use tantivy_rewriter::TantivyPredicateRewriter;
 pub use variant_insert_rewriter::VariantInsertRewriter;
-pub use variant_select_rewriter::VariantSelectRewriter;
+pub use variant_select_rewriter::{VariantPgwireRootWrap, VariantTableScanSchemaPatch};
 
 /// Utilities for converting timestamp filters to date partition filters
 /// for better partition pruning in Delta Lake

--- a/src/optimizers/variant_select_rewriter.rs
+++ b/src/optimizers/variant_select_rewriter.rs
@@ -1,26 +1,32 @@
-//! Variant-aware SELECT-plan post-processing.
+//! Variant-aware analyzer rules.
 //!
-//! Two passes, both gated on the plan being a non-DML (SELECT-like) plan:
+//! Two independent rules, both gated on the plan being non-DML:
 //!
-//! 1. **TableScan schema patch.** TimeFusion's `ProjectRoutingTable::schema()`
-//!    returns a *lying* schema that substitutes Variant columns with
-//!    `Utf8View` so DataFusion's INSERT-VALUES type checker accepts raw
-//!    JSON string literals. For SELECT plans we want the real Variant
-//!    type so downstream UDFs (`variant_get`, `jsonb_path_exists`, …)
-//!    receive Struct{Binary,Binary} and call
+//! 1. **`VariantTableScanSchemaPatch`** — always-on. TimeFusion's
+//!    `ProjectRoutingTable::schema()` returns a *lying* schema that substitutes
+//!    Variant columns with `Utf8View` so DataFusion's INSERT-VALUES type
+//!    checker accepts raw JSON string literals. For SELECT plans we want the
+//!    real Variant type so downstream UDFs (`variant_get`,
+//!    `jsonb_path_exists`, …) receive Struct{Binary,Binary} and call
 //!    `parquet_variant_compute::variant_get` directly. We walk each
 //!    `LogicalPlan::TableScan`, downcast its source to
 //!    `DefaultTableSource → ProjectRoutingTable`, and rebuild the scan's
 //!    `projected_schema` with Variant types restored.
 //!
-//! 2. **Root-projection JSON wrap.** Bare `SELECT payload` from a pgwire
-//!    client must serialize the Variant to JSON text for the wire. We
-//!    used to do this at the scan boundary (`VariantToJsonExec`) which
-//!    forced every intermediate operator to deal with Utf8 and made
-//!    Variant slower than plain JSON text. Now we wrap only the
-//!    *outermost* Projection — peeling Sort/Limit/Distinct/SubqueryAlias —
-//!    so intermediate `variant_get` / `jsonb_path_exists` etc. operate
-//!    on the binary Variant.
+//! 2. **`VariantPgwireRootWrap`** — wire-format concern, register only on
+//!    session contexts that drive pgwire. Bare `SELECT payload` from a pgwire
+//!    client must serialize the Variant to JSON text for the wire (Postgres
+//!    has no native Variant type). We wrap only the *outermost* Projection —
+//!    peeling Sort/Limit/Distinct/SubqueryAlias/Filter — so intermediate
+//!    `variant_get` / `jsonb_path_exists` etc. operate on the binary Variant.
+//!    Internal SQL contexts (see `Database::create_internal_session_context`)
+//!    omit this rule and receive binary Variant end-to-end.
+//!
+//! Lives in the analyzer because `datafusion-postgres`'s
+//! `DfSessionService::do_query` seals the plan→encode path; intercepting
+//! between planning and `arrow_pg::encode_dataframe` would require
+//! reimplementing the handler. The pgwire-binding is made explicit by
+//! registering this rule only on pgwire-facing session contexts.
 
 use std::sync::Arc;
 
@@ -39,40 +45,51 @@ use tracing::{debug, warn};
 
 use crate::{database::ProjectRoutingTable, functions::VariantToJsonExtUdf, schema_loader::is_variant_type};
 
+/// Rule #1 from the module overview. The bottom-up `recompute_schema` after
+/// each node is load-bearing: without it, intermediate Projection/Sort/Filter
+/// DFSchemas stay cached as `Utf8View` and `VariantPgwireRootWrap`'s
+/// `is_variant_expr` check sees the stale type.
 #[derive(Debug, Default)]
-pub struct VariantSelectRewriter;
+pub struct VariantTableScanSchemaPatch;
 
-impl AnalyzerRule for VariantSelectRewriter {
+impl AnalyzerRule for VariantTableScanSchemaPatch {
     fn name(&self) -> &str {
-        "variant_select_rewriter"
+        "variant_table_scan_schema_patch"
     }
 
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
-        // Skip DML entirely. DML targets aren't a wire projection (no
-        // variant_to_json wrap needed), and DML's input scans are already
-        // handled by VariantInsertRewriter wrapping literals with
-        // json_to_variant; injecting a Variant-typed schema there would
+        // Skip DML: input scans are handled by VariantInsertRewriter wrapping
+        // Utf8 literals with json_to_variant; patching to Variant here would
         // mismatch the writer's expected Utf8 input.
         if matches!(plan, LogicalPlan::Dml(_)) {
             return Ok(plan);
         }
-        // Pass 1: bottom-up: patch each TableScan's projected_schema so
-        // Variant columns carry the real Variant type, then recompute every
-        // parent's cached DFSchema so the new type propagates up through
-        // intermediate Projections / Sorts / Filters. Without the per-node
-        // recompute, `wrap_projection`'s `is_variant_expr` check sees a
-        // stale Utf8View type from a parent's cached schema and skips
-        // wrapping (e.g. `ORDER BY x LIMIT n` introduces an outer
-        // Projection over a Sort whose schema must be re-derived).
-        let patched = plan
+        Ok(plan
             .transform_up(|node| {
                 let patched = patch_table_scan(node)?.data;
                 Ok(Transformed::yes(patched.recompute_schema()?))
             })?
-            .data;
-        // Pass 2: wrap Variant-typed projections at the topmost SELECT
-        // projection with variant_to_json for the wire.
-        wrap_root_projection(patched)
+            .data)
+    }
+}
+
+/// Rule #2 from the module overview. The peel set (Sort, Limit, Distinct,
+/// SubqueryAlias, Filter) is what makes intermediate UDFs see binary Variant;
+/// for un-peelable shapes (Union/Aggregate/Join/Window) a top-level
+/// Projection is added above them.
+#[derive(Debug, Default)]
+pub struct VariantPgwireRootWrap;
+
+impl AnalyzerRule for VariantPgwireRootWrap {
+    fn name(&self) -> &str {
+        "variant_pgwire_root_wrap"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        if matches!(plan, LogicalPlan::Dml(_)) {
+            return Ok(plan);
+        }
+        wrap_root_projection(plan)
     }
 }
 
@@ -332,7 +349,7 @@ mod peel_tests {
 
     fn analyze(plan: LogicalPlan) -> LogicalPlan {
         let cfg = ConfigOptions::default();
-        VariantSelectRewriter.analyze(plan, &cfg).unwrap()
+        VariantPgwireRootWrap.analyze(plan, &cfg).unwrap()
     }
 
     fn is_variant_to_json_call(expr: &Expr) -> bool {
@@ -357,6 +374,20 @@ mod peel_tests {
     fn wraps_bare_projection() {
         let out = analyze(variant_projection());
         assert!(is_variant_to_json_call(first_projection_expr(&out)));
+    }
+
+    /// Pins the rule split: `VariantTableScanSchemaPatch` must NEVER wrap with
+    /// `variant_to_json` — that's strictly `VariantPgwireRootWrap`'s job. This
+    /// is the invariant that lets internal SQL contexts skip the pgwire rule
+    /// and still get binary Variant end-to-end.
+    #[test]
+    fn schema_patch_does_not_introduce_variant_to_json_wrap() {
+        let cfg = ConfigOptions::default();
+        let out = VariantTableScanSchemaPatch.analyze(variant_projection(), &cfg).unwrap();
+        assert!(
+            !is_variant_to_json_call(first_projection_expr(&out)),
+            "schema patch rule must leave projection expr untouched; only pgwire-wrap rule injects variant_to_json"
+        );
     }
 
     #[test]

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -6,12 +6,39 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
+use datafusion::arrow::array::{Array, Int64Array};
+use deltalake::DeltaTable;
 use serial_test::serial;
 use timefusion::{
     database::Database,
     test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
 };
+
+/// Sum `stats.numRecords` across all Add files in the (project_id, date)
+/// partition. Bypasses the read-side dedup wrapper so we can assert on the
+/// raw on-disk row set.
+async fn rows_in_partition(table: &DeltaTable, project_id: &str, date: &str) -> Result<i64> {
+    let snap = table.snapshot()?;
+    let actions = snap.add_actions_table(true)?;
+    let n = actions.num_rows();
+    let proj_col = actions.column_by_name("partition.project_id");
+    let date_col = actions.column_by_name("partition.date");
+    let nrec = actions
+        .column_by_name("num_records")
+        .or_else(|| actions.column_by_name("stats.numRecords"))
+        .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+        .ok_or_else(|| anyhow::anyhow!("num_records column missing or wrong type"))?;
+    let mut sum = 0i64;
+    for i in 0..n {
+        let proj_ok =
+            proj_col.is_none() || proj_col.map(|c| arrow::util::display::array_value_to_string(c, i).ok()) == Some(Some(project_id.into()));
+        let date_ok = date_col.map(|c| arrow::util::display::array_value_to_string(c, i).ok()) == Some(Some(date.into()));
+        if proj_ok && date_ok && !nrec.is_null(i) {
+            sum += nrec.value(i);
+        }
+    }
+    Ok(sum)
+}
 
 #[serial]
 #[tokio::test]
@@ -34,31 +61,28 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
     db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("first")?], true, None).await?;
     db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("second")?], true, None).await?;
 
-    // Sanity: the duplicate really did land in Delta.
-    let count_sql =
-        format!("SELECT COUNT(*) AS cnt FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id);
-    let pre = db.query_delta_only(&count_sql).await?;
-    let pre_count = pre[0].column(0).as_primitive::<Int64Type>().value(0);
-    assert_eq!(pre_count, 2, "pre-dedup: cross-flush duplicate should exist as 2 rows in Delta");
-
-    // Verify there are at least two parquet files in the partition (proves the
-    // two commits did not coalesce by accident).
+    // Verify the duplicate really landed in Delta as two separate file rows.
+    // We assert on raw Delta stats (not SQL COUNT) because Phase 2's read
+    // wrapper now collapses cross-file dupes on every query — the bug we
+    // care about here is the on-disk state, which only Phase 1's compaction
+    // sweep fixes.
     let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
-    let date_str = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive().to_string();
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
+    let date_str = date.to_string();
     let part_marker = format!("project_id={}/date={}", project_id, date_str);
-    let file_count_before =
-        table_ref.read().await.get_file_uris()?.filter(|u| u.contains(&part_marker)).count();
+    let file_count_before = table_ref.read().await.get_file_uris()?.filter(|u| u.contains(&part_marker)).count();
     assert!(file_count_before >= 2, "expected >=2 files in partition before dedup, got {}", file_count_before);
 
+    let pre_rows = rows_in_partition(&*table_ref.read().await, &project_id, &date_str).await?;
+    assert_eq!(pre_rows, 2, "pre-dedup: on-disk partition should hold the duplicate as 2 rows");
+
     // Run the new dedup compaction on the partition.
-    let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
     let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
     assert_eq!(dropped, 1, "expected exactly one duplicate row dropped");
 
-    // After dedup, COUNT must be 1.
-    let post = db.query_delta_only(&count_sql).await?;
-    let post_count = post[0].column(0).as_primitive::<Int64Type>().value(0);
-    assert_eq!(post_count, 1, "post-dedup: duplicate should be collapsed to a single row");
+    // After dedup the on-disk row count for this partition is 1.
+    let post_rows = rows_in_partition(&*table_ref.read().await, &project_id, &date_str).await?;
+    assert_eq!(post_rows, 1, "post-dedup: partition should hold a single row on disk");
 
     Ok(())
 }

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -1,0 +1,64 @@
+//! Regression: copy A of a row flushes to Delta, then a retry (copy B) lands
+//! in a different Delta file in the same `(project_id, date)` partition.
+//! Flush-time dedup runs per-bucket and cannot see across files, so without
+//! a Delta-vs-Delta compaction pass the duplicate persists forever.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
+use serial_test::serial;
+use timefusion::{
+    database::Database,
+    test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
+};
+
+#[serial]
+#[tokio::test]
+async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
+    let cfg = TestConfigBuilder::new("dedup_compaction").with_buffer_mode(BufferMode::Enabled).build();
+    // SAFETY: walrus-rust reads WALRUS_DATA_DIR from process env. `#[serial]`
+    // serializes the suite; this set is racy in principle but safe here.
+    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    // Pick a fixed timestamp so both inserts share (id, timestamp) and date.
+    let ts = chrono::Utc::now().timestamp_micros();
+    let row = |name: &str| -> Result<_> { json_to_batch(vec![test_span_ts("dup_id", name, &project_id, ts)]) };
+
+    // Two skip_queue=true inserts → two independent Delta commits, two files
+    // in the same (project_id, date) partition. This is the cross-flush
+    // scenario in production: bucket A flushes, then a client retry arrives
+    // in a fresh bucket B and flushes separately.
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("first")?], true, None).await?;
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("second")?], true, None).await?;
+
+    // Sanity: the duplicate really did land in Delta.
+    let count_sql =
+        format!("SELECT COUNT(*) AS cnt FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id);
+    let pre = db.query_delta_only(&count_sql).await?;
+    let pre_count = pre[0].column(0).as_primitive::<Int64Type>().value(0);
+    assert_eq!(pre_count, 2, "pre-dedup: cross-flush duplicate should exist as 2 rows in Delta");
+
+    // Verify there are at least two parquet files in the partition (proves the
+    // two commits did not coalesce by accident).
+    let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
+    let date_str = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive().to_string();
+    let part_marker = format!("project_id={}/date={}", project_id, date_str);
+    let file_count_before =
+        table_ref.read().await.get_file_uris()?.filter(|u| u.contains(&part_marker)).count();
+    assert!(file_count_before >= 2, "expected >=2 files in partition before dedup, got {}", file_count_before);
+
+    // Run the new dedup compaction on the partition.
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
+    let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
+    assert_eq!(dropped, 1, "expected exactly one duplicate row dropped");
+
+    // After dedup, COUNT must be 1.
+    let post = db.query_delta_only(&count_sql).await?;
+    let post_count = post[0].column(0).as_primitive::<Int64Type>().value(0);
+    assert_eq!(post_count, 1, "post-dedup: duplicate should be collapsed to a single row");
+
+    Ok(())
+}

--- a/tests/dedup_read_side_test.rs
+++ b/tests/dedup_read_side_test.rs
@@ -1,0 +1,90 @@
+//! Read-side dedup (Phase 2): when two Delta files in the same partition
+//! hold the same `(id, timestamp)` row, the user-facing query must return
+//! a single row. Phase 1's compaction sweep only runs on the maintenance
+//! tick — queries hitting Delta before that sweep landed must still see
+//! the deduplicated view.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
+use serial_test::serial;
+use timefusion::{
+    database::Database,
+    test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
+};
+
+async fn count(db: &Arc<Database>, sql: &str) -> Result<i64> {
+    let mut ctx = Arc::clone(db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    let r = ctx.sql(sql).await?.collect().await?;
+    Ok(r[0].column(0).as_primitive::<Int64Type>().value(0))
+}
+
+#[serial]
+#[tokio::test]
+async fn read_dedup_collapses_overlapping_delta_files() -> Result<()> {
+    let cfg = TestConfigBuilder::new("read_dedup").with_buffer_mode(BufferMode::Enabled).build();
+    // SAFETY: walrus-rust reads WALRUS_DATA_DIR from process env. #[serial]
+    // serializes the test suite; this set is racy in principle but safe here.
+    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let ts = chrono::Utc::now().timestamp_micros();
+    let row = |name: &str| -> Result<_> { json_to_batch(vec![test_span_ts("dup_id", name, &project_id, ts)]) };
+
+    // Two separate Delta commits, two files, same (id, timestamp). This is
+    // the cross-flush dupe Phase 1 compaction collapses on the maintenance
+    // tick — Phase 2 must hide it from live queries too.
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("first")?], true, None).await?;
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("second")?], true, None).await?;
+
+    // Use SELECT name (not COUNT(*)) so DataFusion can't shortcut to
+    // file-level statistics — we must exercise the actual scan stream.
+    let mut ctx = Arc::clone(&db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    let rows = ctx
+        .sql(&format!("SELECT name FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id))
+        .await?
+        .collect()
+        .await?;
+    let total: usize = rows.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 1, "read-side dedup should collapse cross-file duplicates on the live query path");
+
+    Ok(())
+}
+
+#[serial]
+#[tokio::test]
+async fn read_dedup_skips_non_overlapping_partitions() -> Result<()> {
+    // Two distinct (id, ts) rows in the same partition share no key. The
+    // overlap-stats gate must skip DeduplicateExec entirely — query returns
+    // both rows and pays no sort/distinct cost.
+    let cfg = TestConfigBuilder::new("read_dedup_skip").with_buffer_mode(BufferMode::Enabled).build();
+    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let now = chrono::Utc::now().timestamp_micros();
+    db.insert_records_batch(
+        &project_id,
+        "otel_logs_and_spans",
+        vec![json_to_batch(vec![test_span_ts("id_a", "a", &project_id, now)])?],
+        true,
+        None,
+    )
+    .await?;
+    db.insert_records_batch(
+        &project_id,
+        "otel_logs_and_spans",
+        vec![json_to_batch(vec![test_span_ts("id_b", "b", &project_id, now + 1)])?],
+        true,
+        None,
+    )
+    .await?;
+
+    let n = count(&db, &format!("SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id = '{}'", project_id)).await?;
+    assert_eq!(n, 2, "non-overlapping rows must not be deduplicated");
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -187,7 +187,7 @@ mod integration {
         assert_eq!(total, 6);
 
         // Targeted column selection — keeps the test focused on a specific row's
-        // typed columns. VariantSelectRewriter already serializes Variant columns
+        // typed columns. VariantPgwireRootWrap already serializes Variant columns
         // to JSON at the root projection, so `SELECT *` would also work end-to-end;
         // this assertion just doesn't need every field.
         let row = client
@@ -365,7 +365,7 @@ mod integration {
     /// End-to-end coverage of the Variant pipeline:
     ///   INSERT (Utf8 literal → VariantInsertRewriter wraps with json_to_variant)
     ///   → Delta/MemBuffer (binary Variant storage)
-    ///   → SELECT (VariantSelectRewriter wraps root projection with variant_to_json)
+    ///   → SELECT (VariantPgwireRootWrap wraps root projection with variant_to_json)
     ///   → pgwire (wire bytes are JSON text, not raw binary)
     /// Regression guard for PR's core contract.
     ///
@@ -407,7 +407,7 @@ mod integration {
         assert_eq!(parsed["http"]["method"], "GET");
         assert_eq!(parsed["user"], "alice");
 
-        // Sort/Limit peel path: VariantSelectRewriter must wrap through Sort+Limit.
+        // Sort/Limit peel path: VariantPgwireRootWrap must wrap through Sort+Limit.
         let row = client
             .query_one(
                 "SELECT attributes FROM otel_logs_and_spans WHERE project_id = $1 AND id = $2 \


### PR DESCRIPTION
## Summary

Stacked on #36. Phase 1 collapses cross-flush duplicates on the maintenance tick, but queries hitting Delta between writes and the next sweep still saw both copies. This PR wraps the Delta scan with a sort + streaming distinct when the snapshot has actual cross-file overlap on the schema's `dedup_keys`.

- `src/dedup_exec.rs::DeduplicateExec` — sorted-stream distinct physical operator. Demands `SinglePartition` and an ordering on `key_columns`; streams one row per dedup_keys tuple via Arrow's `RowConverter` so equality is typed (works for any key type without per-column casts).
- `src/dedup_exec.rs::table_has_any_overlap` — per-partition pairwise overlap check over Add stats (`min.<col>` / `max.<col>`). Groups Add rows by `(partition.project_id, partition.date)` so cross-partition file pairs aren't compared. Returns `false` fast for clean tables — read-side cost is one stats scan per query, zero overhead beyond that.
- `scan_delta_table` wiring: when overlap is detected, augments the projection to include `dedup_keys` (so `SELECT name WHERE id = …` still has the keys at sort time), wraps with `SortExec` → `SortPreservingMergeExec` → `DeduplicateExec`, then projects the extra columns back out so callers see the original schema.

Tiebreaker is `timestamp DESC` after `dedup_keys ASC`, which keeps the newest row in each duplicate group. The cross-file commit-version tiebreaker is intentionally deferred — Phase 1's compaction sweep handles it on the next maintenance tick.

## Test plan

- [x] New regression test `read_dedup_collapses_overlapping_delta_files` — two skip_queue commits of the same `(id, timestamp)`; verifies the test fails for the right reason without the fix, passes after.
- [x] New negative test `read_dedup_skips_non_overlapping_partitions` — two distinct rows in the same partition; verifies the operator is not inserted (correctness + perf).
- [x] Phase 1 regression test migrated to assert on raw Delta `num_records` (since the read wrapper now hides cross-file dupes from any SQL path).
- [x] `cargo test --lib` (114 passed)
- [x] `cargo test --test buffer_consistency_test` (11 passed)
- [x] `cargo test --test integration_test --test sqllogictest --test test_dml_operations` (all pass)