### PR TITLE
fast-boot: persist cursor snapshot to skip ~6.5-min cold-start Delta …

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -232,6 +232,38 @@ Mitigation: copy quarantine files off-host for forensic analysis,
 then delete (they're not source-of-truth). Set
 `TIMEFUSION_WAL_CORRUPTION_THRESHOLD=1` if you want fail-fast.
 
+### Stale cursor snapshot
+
+The fast-boot path restores `<wal>/.timefusion_meta/cursor_snapshot.json`
+to skip the per-table Delta scan. The snapshot is rewritten after every
+flush cycle (`clean_shutdown=false`) and on graceful shutdown
+(`clean_shutdown=true`). When a write fails (disk full, perms, etc.)
+the post-flush helper deletes the now-stale file so the next boot
+reconciles against Delta.
+
+Failure mode this runbook addresses: both the write **and** the delete
+fail (e.g. `meta_dir` became read-only). The pre-existing snapshot then
+survives indefinitely. On the next boot it seeds cursors, then the
+Delta verifier runs with `TIMEFUSION_DELTA_SCAN_DEPTH` (default 8). If
+more than 8 commits accumulated since the last good write, the cursor
+is left behind — Delta will be re-scanned on those commits at the next
+flush ("at-least-once").
+
+Signals to watch:
+- repeated `warn!` lines like `write_cursor_snapshot (post-flush) failed`
+  or `delete stale cursor snapshot also failed`.
+- on boot, `Cursor snapshot restored … age=<large>h` — a 24h+ age also
+  fires its own warn.
+
+Recovery:
+```sh
+# inside the container
+rm /app/data/timefusion/wal/.timefusion_meta/cursor_snapshot.json
+```
+Forces the next boot to run the full Delta verifier. Optionally raise
+`TIMEFUSION_DELTA_SCAN_DEPTH` (env var, hot-restart) if you suspect
+many commits to recover. Fix the underlying perms/disk issue separately.
+
 ### Cold-start taking > 5 minutes
 
 WAL replay is taking too long. Causes:

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -650,10 +650,12 @@ impl BufferedWriteLayer {
             .await;
 
         // Process results: checkpoint WAL and drain MemBuffer for successful flushes
+        let mut any_ok = false;
         for (bucket, result) in flush_results {
             match result {
                 Ok(()) => {
                     self.checkpoint_and_drain(&bucket);
+                    any_ok = true;
                     crate::metrics::record_flush(true);
                     debug!(
                         "Flushed bucket: project={}, table={}, bucket_id={}, rows={}",
@@ -668,6 +670,9 @@ impl BufferedWriteLayer {
                     );
                 }
             }
+        }
+        if any_ok {
+            self.write_post_flush_snapshot();
         }
 
         Ok(())
@@ -742,13 +747,25 @@ impl BufferedWriteLayer {
         if let Err(e) = self.wal.advance_by_counts(&bucket.project_id, &bucket.table_name, &bucket.wal_shard_counts) {
             warn!("WAL advance_by_counts failed: {}", e);
         }
-        // Persist the post-advance cursor so the next boot can skip the
-        // Delta scan. Hard-kill in-between means `clean_shutdown=false` and
-        // the boot path still runs the (shortened) verifier. Best-effort.
+        self.mem_buffer.drain_bucket(&bucket.project_id, &bucket.table_name, bucket.bucket_id);
+    }
+
+    /// Persist a `clean_shutdown=false` cursor snapshot for the next boot.
+    /// Called once per flush cycle (not per bucket) — the snapshot reads
+    /// every topic's positions, so collapsing N per-bucket calls into one
+    /// post-cycle write turns this from O(N²) into O(N).
+    ///
+    /// On write failure we delete any pre-existing snapshot: a stale file
+    /// would let the (shallow) boot verifier skip commits made since the
+    /// last successful write. Removing it forces a fresh Delta scan, which
+    /// is correct-but-slow rather than fast-but-wrong.
+    fn write_post_flush_snapshot(&self) {
         if let Err(e) = self.wal.write_cursor_snapshot(false) {
             debug!("write_cursor_snapshot (post-flush) failed: {}", e);
+            if let Err(rm_err) = self.wal.delete_cursor_snapshot() {
+                debug!("delete stale cursor snapshot after write failure also failed: {}", rm_err);
+            }
         }
-        self.mem_buffer.drain_bucket(&bucket.project_id, &bucket.table_name, bucket.bucket_id);
     }
 
     #[instrument(skip(self))]
@@ -835,6 +852,9 @@ impl BufferedWriteLayer {
                     stats.buckets_failed += 1;
                 }
             }
+        }
+        if stats.buckets_flushed > 0 {
+            self.write_post_flush_snapshot();
         }
         Ok(stats)
     }

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -742,6 +742,12 @@ impl BufferedWriteLayer {
         if let Err(e) = self.wal.advance_by_counts(&bucket.project_id, &bucket.table_name, &bucket.wal_shard_counts) {
             warn!("WAL advance_by_counts failed: {}", e);
         }
+        // Persist the post-advance cursor so the next boot can skip the
+        // Delta scan. Hard-kill in-between means `clean_shutdown=false` and
+        // the boot path still runs the (shortened) verifier. Best-effort.
+        if let Err(e) = self.wal.write_cursor_snapshot(false) {
+            debug!("write_cursor_snapshot (post-flush) failed: {}", e);
+        }
         self.mem_buffer.drain_bucket(&bucket.project_id, &bucket.table_name, bucket.bucket_id);
     }
 
@@ -780,6 +786,14 @@ impl BufferedWriteLayer {
                 Ok(()) => self.checkpoint_and_drain(&bucket),
                 Err(e) => error!("Shutdown flush failed for bucket {}: {}", bucket.bucket_id, e),
             }
+        }
+
+        // Final cursor snapshot with the clean-shutdown marker — boot can
+        // then skip `derive_wal_cursors_from_delta` entirely (~6.5 min saved
+        // on the next start).
+        match self.wal.write_cursor_snapshot(true) {
+            Ok(()) => info!("Cursor snapshot written (clean_shutdown=true)"),
+            Err(e) => warn!("Cursor snapshot on shutdown failed: {} — next boot will Delta-scan", e),
         }
 
         info!("BufferedWriteLayer shutdown complete");

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -672,7 +672,7 @@ impl BufferedWriteLayer {
             }
         }
         if any_ok {
-            self.write_post_flush_snapshot();
+            self.write_post_flush_snapshot().await;
         }
 
         Ok(())
@@ -766,13 +766,30 @@ impl BufferedWriteLayer {
     /// `write_cursor_snapshot(true)` in `shutdown()` writes the
     /// definitive `clean_shutdown=true` snapshot and supersedes any
     /// dirty one we'd write here.
-    fn write_post_flush_snapshot(&self) {
-        if let Err(e) = self.wal.write_cursor_snapshot(false) {
-            debug!("write_cursor_snapshot (post-flush) failed: {}", e);
-            if let Err(rm_err) = self.wal.delete_cursor_snapshot() {
-                debug!("delete stale cursor snapshot after write failure also failed: {}", rm_err);
+    async fn write_post_flush_snapshot(&self) {
+        // Local-disk JSON write + rename is normally <1 ms but the call is on
+        // a Tokio worker thread; offload to a blocking pool so a slow mount
+        // (network-backed WAL dir, hung syscall) can't stall the flush task.
+        let wal = self.wal.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            if let Err(e) = wal.write_cursor_snapshot(false) {
+                // Silent failure erodes the fast-boot guarantee over time —
+                // surface at warn! so an operator at info level notices.
+                warn!("write_cursor_snapshot (post-flush) failed: {} — will delete stale snapshot", e);
+                if let Err(rm_err) = wal.delete_cursor_snapshot() {
+                    // Worse: stale snapshot survives → next boot may restore
+                    // outdated cursors and the shallow Delta verifier (default
+                    // depth 8) can miss commits made since the last good write.
+                    // See RUNBOOK.md "Stale cursor snapshot" for recovery.
+                    warn!(
+                        "delete stale cursor snapshot also failed: {} — next boot may restore stale state; \
+                         delete `.timefusion_meta/cursor_snapshot.json` manually if symptoms appear",
+                        rm_err
+                    );
+                }
             }
-        }
+        })
+        .await;
     }
 
     #[instrument(skip(self))]
@@ -815,9 +832,11 @@ impl BufferedWriteLayer {
         // Final cursor snapshot with the clean-shutdown marker — boot can
         // then skip `derive_wal_cursors_from_delta` entirely (~6.5 min saved
         // on the next start).
-        match self.wal.write_cursor_snapshot(true) {
-            Ok(()) => info!("Cursor snapshot written (clean_shutdown=true)"),
-            Err(e) => warn!("Cursor snapshot on shutdown failed: {} — next boot will Delta-scan", e),
+        let wal_for_snap = self.wal.clone();
+        match tokio::task::spawn_blocking(move || wal_for_snap.write_cursor_snapshot(true)).await {
+            Ok(Ok(())) => info!("Cursor snapshot written (clean_shutdown=true)"),
+            Ok(Err(e)) => warn!("Cursor snapshot on shutdown failed: {} — next boot will Delta-scan", e),
+            Err(join_err) => warn!("Cursor snapshot blocking task panicked: {} — next boot will Delta-scan", join_err),
         }
 
         info!("BufferedWriteLayer shutdown complete");
@@ -861,7 +880,7 @@ impl BufferedWriteLayer {
             }
         }
         if stats.buckets_flushed > 0 {
-            self.write_post_flush_snapshot();
+            self.write_post_flush_snapshot().await;
         }
         Ok(stats)
     }

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -759,6 +759,13 @@ impl BufferedWriteLayer {
     /// would let the (shallow) boot verifier skip commits made since the
     /// last successful write. Removing it forces a fresh Delta scan, which
     /// is correct-but-slow rather than fast-but-wrong.
+    ///
+    /// Callers: `flush_completed_buckets` (guards on `any_ok`) and
+    /// `flush_all_now` (guards on `stats.buckets_flushed > 0`). Shutdown's
+    /// per-bucket loop deliberately does NOT call this — the trailing
+    /// `write_cursor_snapshot(true)` in `shutdown()` writes the
+    /// definitive `clean_shutdown=true` snapshot and supersedes any
+    /// dirty one we'd write here.
     fn write_post_flush_snapshot(&self) {
         if let Err(e) = self.wal.write_cursor_snapshot(false) {
             debug!("write_cursor_snapshot (post-flush) failed: {}", e);

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,12 @@ const_default!(d_wal_shards_per_topic: usize = 4);
 const_default!(d_shutdown_timeout: u64 = 180);
 const_default!(d_wal_corruption_threshold: usize = 10);
 const_default!(d_flush_parallelism: usize = 4);
+// Cold-boot Delta cursor reconciliation. R2 happily takes 64+ concurrent
+// gets per bucket; the original 8 left ~8× headroom. Depth 2 is enough to
+// catch one writer that committed after our last snapshot — the snapshot
+// itself replaces the older 16-deep scan.
+const_default!(d_delta_scan_concurrency: usize = 64);
+const_default!(d_delta_scan_depth: usize = 2);
 const_default!(d_wal_fsync_ms: u64 = 200);
 // MemBuffer bucket window (seconds). Smaller windows free RAM sooner because
 // the previous bucket becomes flushable sooner; larger windows amortize into
@@ -367,6 +373,15 @@ pub struct BufferConfig {
     /// at the cost of O(shards) recovery memory and more file handles.
     #[serde(default = "d_wal_shards_per_topic")]
     pub timefusion_wal_shards_per_topic:     usize,
+    /// Max concurrent S3/R2 reads when reconciling per-table Delta watermarks
+    /// at boot. Only used when the cursor snapshot is missing or stale.
+    #[serde(default = "d_delta_scan_concurrency")]
+    pub timefusion_delta_scan_concurrency:   usize,
+    /// Per-table Delta commit history depth scanned at boot. The cursor
+    /// snapshot covers the bulk of the watermark; this only needs to catch
+    /// a writer that committed after the last snapshot was written.
+    #[serde(default = "d_delta_scan_depth")]
+    pub timefusion_delta_scan_depth:         usize,
 }
 
 /// WAL durability mode. See `d_wal_fsync_mode` for the env-var encoding.
@@ -398,6 +413,12 @@ impl BufferConfig {
     }
     pub fn flush_parallelism(&self) -> usize {
         self.timefusion_flush_parallelism.max(1)
+    }
+    pub fn delta_scan_concurrency(&self) -> usize {
+        self.timefusion_delta_scan_concurrency.max(1)
+    }
+    pub fn delta_scan_depth(&self) -> usize {
+        self.timefusion_delta_scan_depth.max(1)
     }
     pub fn flush_immediately(&self) -> bool {
         self.timefusion_flush_immediately

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,11 +121,13 @@ const_default!(d_shutdown_timeout: u64 = 180);
 const_default!(d_wal_corruption_threshold: usize = 10);
 const_default!(d_flush_parallelism: usize = 4);
 // Cold-boot Delta cursor reconciliation. R2 happily takes 64+ concurrent
-// gets per bucket; the original 8 left ~8× headroom. Depth 2 is enough to
-// catch one writer that committed after our last snapshot — the snapshot
-// itself replaces the older 16-deep scan.
+// gets per bucket; the original 8 left ~8× headroom. Depth 8 is half the
+// original 16 (the snapshot replaces the bulk of the scan) but keeps a
+// safety margin: if a few snapshot writes failed silently before reboot,
+// depth-2 could miss the legitimate cursor advance. Tune via env if the
+// fallback Delta scan is the bottleneck.
 const_default!(d_delta_scan_concurrency: usize = 64);
-const_default!(d_delta_scan_depth: usize = 2);
+const_default!(d_delta_scan_depth: usize = 8);
 const_default!(d_wal_fsync_ms: u64 = 200);
 // MemBuffer bucket window (seconds). Smaller windows free RAM sooner because
 // the previous bucket becomes flushable sooner; larger windows amortize into

--- a/src/database.rs
+++ b/src/database.rs
@@ -1913,7 +1913,10 @@ impl Database {
         let delta_max = max_watermark_across_commits(commits.iter().map(|ci| &ci.info), wal.shards_per_topic());
         let advanced = wal.merge_persisted_positions(project_id, table_name, &delta_max)?;
         if advanced > 0 {
-            info!("Delta-derived cursor advance: project={}, table={}, shards_advanced={}", project_id, table_name, advanced);
+            info!(
+                "Delta-derived cursor advance: project={}, table={}, shards_advanced={}",
+                project_id, table_name, advanced
+            );
         }
         Ok(advanced)
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1886,11 +1886,9 @@ impl Database {
     /// so this can't make recovery worse than today's at-least-once behaviour.
     pub async fn derive_wal_cursors_from_delta(&self, wal: &crate::wal::WalManager) -> anyhow::Result<usize> {
         use futures::stream::{self, StreamExt};
-        let pairs = wal.list_topic_pairs()?;
-        // Cap concurrency to bound S3 connections at startup.
-        let totals: Vec<usize> = stream::iter(pairs)
+        let totals: Vec<usize> = stream::iter(wal.list_topic_pairs()?)
             .map(|(project_id, table_name)| async move { self.derive_wal_cursor_for_table(wal, &project_id, &table_name).await.unwrap_or(0) })
-            .buffer_unordered(8)
+            .buffer_unordered(self.config.buffer.delta_scan_concurrency())
             .collect()
             .await;
         Ok(totals.into_iter().sum())
@@ -1899,12 +1897,11 @@ impl Database {
     async fn derive_wal_cursor_for_table(&self, wal: &crate::wal::WalManager, project_id: &str, table_name: &str) -> anyhow::Result<usize> {
         // Scan recent commits; replay-derived commits without a watermark
         // contribute nothing so they can't reset the MAX backward.
-        const SCAN_DEPTH: usize = 16;
         let Ok(table_ref) = self.resolve_table(project_id, table_name).await else {
             return Ok(0);
         };
         let table = table_ref.read().await;
-        let commits: Vec<_> = match table.history(Some(SCAN_DEPTH)).await {
+        let commits: Vec<_> = match table.history(Some(self.config.buffer.delta_scan_depth())).await {
             Ok(it) => it.collect(),
             Err(e) => {
                 debug!("derive_wal_cursor: history unavailable for {}/{}: {}", project_id, table_name, e);
@@ -1913,29 +1910,12 @@ impl Database {
         };
         drop(table);
 
-        let shards = wal.shards_per_topic();
-        let delta_max = max_watermark_across_commits(commits.iter().map(|ci| &ci.info), shards);
-        let local = wal.persisted_read_positions(project_id, table_name).unwrap_or_else(|_| vec![None; shards]);
-
-        let mut to_set = local.clone();
-        let mut any_advance = 0usize;
-        for shard in 0..shards {
-            let Some(dpos) = delta_max[shard] else { continue };
-            let ahead = local[shard].map_or(!dpos.is_origin(), |lpos| dpos > lpos);
-            if ahead {
-                to_set[shard] = Some(dpos);
-                any_advance += 1;
-            }
+        let delta_max = max_watermark_across_commits(commits.iter().map(|ci| &ci.info), wal.shards_per_topic());
+        let advanced = wal.merge_persisted_positions(project_id, table_name, &delta_max)?;
+        if advanced > 0 {
+            info!("Delta-derived cursor advance: project={}, table={}, shards_advanced={}", project_id, table_name, advanced);
         }
-        if any_advance > 0 {
-            let positions: Vec<walrus_rust::WalPosition> = to_set.into_iter().map(|p| p.unwrap_or(walrus_rust::WalPosition::ORIGIN)).collect();
-            wal.set_persisted_positions(project_id, table_name, &positions)?;
-            info!(
-                "Delta-derived cursor advance: project={}, table={}, shards_advanced={}",
-                project_id, table_name, any_advance
-            );
-        }
-        Ok(any_advance)
+        Ok(advanced)
     }
 
     /// Optimize the Delta table using Z-ordering on timestamp and id columns

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,16 +142,41 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
         error!("Failed to initialize OTel metrics: {} — continuing without metrics export", e);
     }
 
-    // Before WAL replay, fast-forward walrus cursors to whatever each table's
-    // latest Delta commits say is durable. Closes the crash-mid-flush window
-    // where Delta committed but `advance_by_counts` didn't finish — without
-    // this, replay re-injects entries already in Delta and the next flush
-    // double-writes them. Best-effort: missing/older metadata falls back to
-    // the locally-fsynced walrus state (today's at-least-once behaviour).
-    match db.derive_wal_cursors_from_delta(buffered_layer.wal()).await {
-        Ok(0) => info!("Delta-derived cursor: no advancement needed (clean shutdown)"),
-        Ok(n) => info!("Delta-derived cursor: advanced {} shard(s) past Delta watermark", n),
-        Err(e) => warn!("Delta-derived cursor derivation failed (continuing with local cursor): {}", e),
+    // Fast-forward walrus cursors before WAL replay so we don't re-inject
+    // entries Delta already has. Fast path: a `clean_shutdown=true` snapshot
+    // on local disk lets us skip the ~6.5-min R2 scan entirely. Dirty/missing
+    // snapshot still seeds positions, then falls through to the (env-tuned,
+    // shorter) Delta verifier to catch commits made after the last snapshot.
+    let wal_ref = buffered_layer.wal();
+    let skip_delta_scan = if let Some(snap) = wal_ref.load_cursor_snapshot() {
+        let age_secs = timefusion::clock::now_micros().saturating_sub(snap.written_at_micros) / 1_000_000;
+        match wal_ref.restore_cursor_snapshot(&snap) {
+            Ok(advanced) => {
+                info!(
+                    "Cursor snapshot restored: {} table(s) seeded, {} advanced, clean_shutdown={}, age={}s",
+                    snap.entries.len(),
+                    advanced,
+                    snap.clean_shutdown,
+                    age_secs
+                );
+                snap.clean_shutdown
+            }
+            Err(e) => {
+                warn!("Cursor snapshot restore failed, falling back to Delta scan: {}", e);
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if skip_delta_scan {
+        info!("Skipping Delta-derived cursor reconciliation (cursor snapshot is clean)");
+    } else {
+        match db.derive_wal_cursors_from_delta(wal_ref).await {
+            Ok(0) => info!("Delta-derived cursor: no advancement needed"),
+            Ok(n) => info!("Delta-derived cursor: advanced {} shard(s) past Delta watermark", n),
+            Err(e) => warn!("Delta-derived cursor derivation failed (continuing with local cursor): {}", e),
+        }
     }
 
     // Recover from WAL on startup

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,8 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let skip_delta_scan = if let Some(snap) = wal_ref.load_cursor_snapshot() {
         // Surfaced in the boot log only — not gating the skip. See CursorSnapshot
         // docs for the single-writer assumption and the `rm` escape hatch.
+        // Backwards clock skew (NTP correction, snapshot ported across hosts)
+        // is clamped to 0 by `saturating_sub` rather than wrapping negative.
         let age_secs = timefusion::clock::now_micros().saturating_sub(snap.written_at_micros) / 1_000_000;
         match wal_ref.restore_cursor_snapshot(&snap) {
             Ok(tables_advanced) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,8 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // shorter) Delta verifier to catch commits made after the last snapshot.
     let wal_ref = buffered_layer.wal();
     let skip_delta_scan = if let Some(snap) = wal_ref.load_cursor_snapshot() {
+        // Surfaced in the boot log only — not gating the skip. See CursorSnapshot
+        // docs for the single-writer assumption and the `rm` escape hatch.
         let age_secs = timefusion::clock::now_micros().saturating_sub(snap.written_at_micros) / 1_000_000;
         match wal_ref.restore_cursor_snapshot(&snap) {
             Ok(tables_advanced) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,11 +151,11 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let skip_delta_scan = if let Some(snap) = wal_ref.load_cursor_snapshot() {
         let age_secs = timefusion::clock::now_micros().saturating_sub(snap.written_at_micros) / 1_000_000;
         match wal_ref.restore_cursor_snapshot(&snap) {
-            Ok(advanced) => {
+            Ok(tables_advanced) => {
                 info!(
-                    "Cursor snapshot restored: {} table(s) seeded, {} advanced, clean_shutdown={}, age={}s",
+                    "Cursor snapshot restored: {} table(s) seeded, {} table(s) advanced, clean_shutdown={}, age={}s",
                     snap.entries.len(),
-                    advanced,
+                    tables_advanced,
                     snap.clean_shutdown,
                     age_secs
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,12 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     if skip_delta_scan {
         info!("Skipping Delta-derived cursor reconciliation (cursor snapshot is clean)");
     } else {
+        info!(
+            "Running Delta-derived cursor reconciliation (snapshot missing/dirty); scan_depth={}, concurrency={} \
+             — set TIMEFUSION_DELTA_SCAN_DEPTH higher if a deployment lost more commits than that since its last clean state",
+            cfg.buffer.delta_scan_depth(),
+            cfg.buffer.delta_scan_concurrency()
+        );
         match db.derive_wal_cursors_from_delta(wal_ref).await {
             Ok(0) => info!("Delta-derived cursor: no advancement needed"),
             Ok(n) => info!("Delta-derived cursor: advanced {} shard(s) past Delta watermark", n),

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -66,9 +66,19 @@ fn snap_to_pos((block_id, offset): SnapPos) -> WalPosition {
 /// Serialized form of every known topic's per-shard persisted-read cursor.
 /// Written after every successful Delta flush + on graceful shutdown; read
 /// on boot to skip the Delta scan when the cursor is known-current.
+///
+/// Correctness assumes this timefusion process is the **only** writer to its
+/// Delta tables — `BufferedWriteLayer::flush` is the sole commit path. If you
+/// ever run a parallel writer (manual `OPTIMIZE`, an external delta-rs
+/// client, a sister process) between a clean-shutdown snapshot and the next
+/// boot, delete `cursor_snapshot.json` to force a Delta reconciliation; the
+/// `clean_shutdown` flag alone won't catch out-of-band commits.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CursorSnapshot {
     pub version:           u32,
+    /// Wall-clock micros (`clock::now_micros`) at write time. Informational
+    /// only — surfaced in the boot log so operators can spot a stale
+    /// snapshot, but not enforced as a max-age gate.
     pub written_at_micros: i64,
     pub shards_per_topic:  usize,
     /// True only when written by the graceful-shutdown path. Boot uses this
@@ -747,8 +757,11 @@ impl WalManager {
     /// Fast-forward walrus persisted-read cursors from a loaded snapshot.
     /// Returns the number of shards that advanced (i.e. snapshot was ahead of
     /// the locally-fsynced walrus state).
+    /// Returns the number of *tables* where at least one shard moved (not the
+    /// total shard-advance count — that's per-call via
+    /// [`merge_persisted_positions`]).
     pub fn restore_cursor_snapshot(&self, snap: &CursorSnapshot) -> Result<usize, WalError> {
-        let mut advanced = 0usize;
+        let mut tables_advanced = 0usize;
         for (topic, snapshot_positions) in &snap.entries {
             let Some((project_id, table_name)) = Self::parse_topic(topic) else { continue };
             if snapshot_positions.len() != self.shards_per_topic {
@@ -760,10 +773,10 @@ impl WalManager {
 
             let candidate: Vec<Option<WalPosition>> = snapshot_positions.iter().map(|p| p.map(snap_to_pos)).collect();
             if self.merge_persisted_positions(&project_id, &table_name, &candidate)? > 0 {
-                advanced += 1;
+                tables_advanced += 1;
             }
         }
-        Ok(advanced)
+        Ok(tables_advanced)
     }
 
     /// Fast-forward each shard's persisted-read cursor to `candidate[shard]`
@@ -1034,15 +1047,51 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
-        let meta = path.join(".timefusion_meta");
-        std::fs::create_dir_all(&meta).unwrap();
-        // Write a syntactically valid JSON with a bumped version.
+        // `.timefusion_meta/` is guaranteed by WalManager construction.
         std::fs::write(
-            meta.join("cursor_snapshot.json"),
+            path.join(".timefusion_meta/cursor_snapshot.json"),
             br#"{"version":999,"written_at_micros":0,"shards_per_topic":4,"clean_shutdown":true,"entries":{}}"#,
         )
         .unwrap();
         assert!(wal.load_cursor_snapshot().is_none());
+    }
+
+    /// If an operator changes `TIMEFUSION_WAL_SHARDS_PER_TOPIC` between
+    /// restarts, the snapshot's per-shard layout is incompatible. Reject it
+    /// so the boot falls through to the Delta scan rather than restoring
+    /// shard-misaligned positions.
+    #[test]
+    fn cursor_snapshot_rejects_shard_count_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        {
+            let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+            wal.append("proj", "tbl", &create_test_batch()).unwrap();
+            wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
+            wal.write_cursor_snapshot(true).unwrap();
+        }
+        // Re-open with a different shard count — load must refuse.
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 8).unwrap();
+        assert!(wal.load_cursor_snapshot().is_none());
+    }
+
+    /// A snapshot written from the flush path (clean_shutdown=false) loads
+    /// fine but must not let the boot path skip the Delta verifier — that
+    /// gate is reserved for the graceful-shutdown marker.
+    #[test]
+    fn cursor_snapshot_dirty_path_loads_but_signals_unclean() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+        wal.append("proj", "tbl", &create_test_batch()).unwrap();
+        wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
+        wal.write_cursor_snapshot(false).unwrap();
+
+        let snap = wal.load_cursor_snapshot().expect("dirty snapshot must still be loadable");
+        assert!(!snap.clean_shutdown, "dirty snapshot must not claim clean_shutdown");
+        // Sanity: restore is still safe (idempotent on matching state).
+        let tables_advanced = wal.restore_cursor_snapshot(&snap).unwrap();
+        assert_eq!(tables_advanced, 0);
     }
 
     #[test]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -7,6 +7,7 @@ use arrow_ipc::{
 };
 use bincode::{Decode, Encode};
 use dashmap::DashSet;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, warn};
 use walrus_rust::{FsyncSchedule, ReadConsistency, WalPosition, Walrus};
@@ -47,6 +48,35 @@ const WAL_MAGIC: [u8; 4] = [0x57, 0x41, 0x4C, 0x32];
 /// written by a different version, so existing data must be wiped on bump.
 const WAL_VERSION: u8 = 1;
 const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard();
+/// On-disk format version for `cursor_snapshot.json`. Bump on any breaking
+/// schema change so older readers fall back to the Delta scan instead of
+/// silently misinterpreting the file.
+const SNAPSHOT_VERSION: u32 = 1;
+
+/// `WalPosition` serialized as `(block_id, offset)` — tuples already have
+/// Serialize/Deserialize, so we skip the mirror struct.
+type SnapPos = (u64, u64);
+fn pos_to_snap(p: WalPosition) -> SnapPos {
+    (p.block_id, p.offset)
+}
+fn snap_to_pos((block_id, offset): SnapPos) -> WalPosition {
+    WalPosition { block_id, offset }
+}
+
+/// Serialized form of every known topic's per-shard persisted-read cursor.
+/// Written after every successful Delta flush + on graceful shutdown; read
+/// on boot to skip the Delta scan when the cursor is known-current.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorSnapshot {
+    pub version:           u32,
+    pub written_at_micros: i64,
+    pub shards_per_topic:  usize,
+    /// True only when written by the graceful-shutdown path. Boot uses this
+    /// flag to decide whether the Delta verifier can be skipped entirely.
+    pub clean_shutdown:    bool,
+    /// `"project_id:table_name"` → per-shard cursor (None = never written).
+    pub entries:           std::collections::BTreeMap<String, Vec<Option<SnapPos>>>,
+}
 /// Maximum size for a single record batch (100MB) - prevents unbounded memory allocation from malicious/corrupted WAL
 const MAX_BATCH_SIZE: usize = 100 * 1024 * 1024;
 /// Fsync schedule interval in milliseconds - balances durability with performance
@@ -640,6 +670,123 @@ impl WalManager {
         &self.data_dir
     }
 
+    fn cursor_snapshot_path(&self) -> PathBuf {
+        self.data_dir.join(".timefusion_meta").join("cursor_snapshot.json")
+    }
+
+    /// Capture every known topic's per-shard persisted-read cursor to a single
+    /// JSON file on local disk. On boot, the file lets us skip
+    /// `derive_wal_cursors_from_delta`'s ~6.5-minute R2 scan when it's known
+    /// to be current — the dominant cold-boot cost.
+    ///
+    /// `clean_shutdown=true` is set only by the graceful-shutdown path; flush
+    /// callers pass false so a hard kill still falls back to the Delta scan
+    /// to verify the cursor.
+    ///
+    /// Atomic: writes to `.tmp` then renames. Best-effort: returns Err but the
+    /// caller logs-and-continues — a missing snapshot only costs us the next
+    /// boot's fast path, never correctness.
+    pub fn write_cursor_snapshot(&self, clean_shutdown: bool) -> Result<(), WalError> {
+        let mut entries = std::collections::BTreeMap::new();
+        for (project_id, table_name) in self.list_topic_pairs()? {
+            let positions = match self.persisted_read_positions(&project_id, &table_name) {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!("write_cursor_snapshot: skipping {}/{}: {}", project_id, table_name, e);
+                    continue;
+                }
+            };
+            entries.insert(Self::make_topic(&project_id, &table_name), positions.into_iter().map(|p| p.map(pos_to_snap)).collect());
+        }
+        let snap = CursorSnapshot {
+            version: SNAPSHOT_VERSION,
+            written_at_micros: crate::clock::now_micros(),
+            shards_per_topic: self.shards_per_topic,
+            clean_shutdown,
+            entries,
+        };
+        // `.timefusion_meta/` is created in `with_fsync_mode_and_shards`; no
+        // create_dir_all needed on every flush.
+        let target = self.cursor_snapshot_path();
+        let tmp = target.with_extension("json.tmp");
+        let bytes = serde_json::to_vec(&snap).map_err(|e| WalError::Internal(format!("cursor snapshot encode: {}", e)))?;
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, &target)?;
+        Ok(())
+    }
+
+    /// Read the cursor snapshot if present. Returns None on missing/parse/version
+    /// mismatch so the boot path falls through to Delta reconciliation.
+    pub fn load_cursor_snapshot(&self) -> Option<CursorSnapshot> {
+        let path = self.cursor_snapshot_path();
+        let bytes = std::fs::read(&path).ok()?;
+        let snap: CursorSnapshot = match serde_json::from_slice(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("cursor snapshot at {:?} unreadable, falling back to Delta scan: {}", path, e);
+                return None;
+            }
+        };
+        if snap.version != SNAPSHOT_VERSION {
+            warn!("cursor snapshot version {} != {} — ignoring", snap.version, SNAPSHOT_VERSION);
+            return None;
+        }
+        if snap.shards_per_topic != self.shards_per_topic {
+            warn!(
+                "cursor snapshot shards_per_topic {} != current {} — ignoring (config changed)",
+                snap.shards_per_topic, self.shards_per_topic
+            );
+            return None;
+        }
+        Some(snap)
+    }
+
+    /// Fast-forward walrus persisted-read cursors from a loaded snapshot.
+    /// Returns the number of shards that advanced (i.e. snapshot was ahead of
+    /// the locally-fsynced walrus state).
+    pub fn restore_cursor_snapshot(&self, snap: &CursorSnapshot) -> Result<usize, WalError> {
+        let mut advanced = 0usize;
+        for (topic, snapshot_positions) in &snap.entries {
+            let Some((project_id, table_name)) = Self::parse_topic(topic) else { continue };
+            if snapshot_positions.len() != self.shards_per_topic {
+                continue;
+            }
+            // Seed `known_topics` so a later list_topic_pairs() includes a
+            // table that hasn't yet been re-touched in this process.
+            self.persist_topic(topic);
+
+            let candidate: Vec<Option<WalPosition>> = snapshot_positions.iter().map(|p| p.map(snap_to_pos)).collect();
+            if self.merge_persisted_positions(&project_id, &table_name, &candidate)? > 0 {
+                advanced += 1;
+            }
+        }
+        Ok(advanced)
+    }
+
+    /// Fast-forward each shard's persisted-read cursor to `candidate[shard]`
+    /// when the candidate is strictly ahead. Returns the number of shards
+    /// that moved. Shared by snapshot restore and Delta-derived reconciliation.
+    pub fn merge_persisted_positions(&self, project_id: &str, table_name: &str, candidate: &[Option<WalPosition>]) -> Result<usize, WalError> {
+        if candidate.len() != self.shards_per_topic {
+            return Ok(0);
+        }
+        let local = self.persisted_read_positions(project_id, table_name).unwrap_or_else(|_| vec![None; self.shards_per_topic]);
+        let mut to_set: Vec<WalPosition> = local.iter().map(|p| p.unwrap_or(WalPosition::ORIGIN)).collect();
+        let mut advanced = 0usize;
+        for shard in 0..self.shards_per_topic {
+            let Some(cand) = candidate[shard] else { continue };
+            let ahead = local[shard].map_or(!cand.is_origin(), |lpos| cand > lpos);
+            if ahead {
+                to_set[shard] = cand;
+                advanced += 1;
+            }
+        }
+        if advanced > 0 {
+            self.set_persisted_positions(project_id, table_name, &to_set)?;
+        }
+        Ok(advanced)
+    }
+
     /// Configured number of walrus collections per logical topic. Reported
     /// out for `timefusion.stats()` so operators can see effective parallelism.
     pub fn shards_per_topic(&self) -> usize {
@@ -833,6 +980,66 @@ mod tests {
                 "({p1:?},{t1:?}) and ({p2:?},{t2:?}) collide"
             );
         }
+    }
+
+    /// Round-trip cursor snapshot: write, drop the manager, re-open, restore.
+    /// Verifies the on-disk file is enough to fast-forward walrus cursors on
+    /// a fresh process without touching Delta — the whole point of the fast
+    /// boot path.
+    #[test]
+    fn cursor_snapshot_roundtrip_restores_persisted_positions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+
+        // Process A: append, advance cursor, write snapshot with clean flag.
+        {
+            let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+            let batch = create_test_batch();
+            wal.append("proj", "tbl", &batch).unwrap();
+            // Advance by 1 on the only shard we wrote to (round-robin picks
+            // shard 0 first for an unseen topic).
+            wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
+            let before = wal.persisted_read_positions("proj", "tbl").unwrap();
+            assert!(before[0].is_some_and(|p| !p.is_origin()), "advance must move shard 0 off origin");
+
+            wal.write_cursor_snapshot(true).unwrap();
+            assert!(path.join(".timefusion_meta/cursor_snapshot.json").exists());
+        }
+
+        // Process B: fresh manager, snapshot present, no walrus state mutation
+        // beyond what restore does.
+        {
+            let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+            let snap = wal.load_cursor_snapshot().expect("snapshot loadable");
+            assert!(snap.clean_shutdown);
+            assert_eq!(snap.shards_per_topic, 4);
+            assert!(snap.entries.contains_key("proj:tbl"));
+
+            // Restore is idempotent — walrus state already reflects the
+            // advance, so `restore` advances 0 shards but seeds known_topics.
+            let advanced = wal.restore_cursor_snapshot(&snap).unwrap();
+            assert_eq!(advanced, 0, "snapshot positions match walrus's own fsynced state");
+            assert!(wal.list_topic_pairs().unwrap().iter().any(|(p, t)| p == "proj" && t == "tbl"));
+        }
+    }
+
+    /// Snapshot version mismatch (or a corrupted file) must return None so
+    /// boot falls through to the Delta scan rather than misinterpreting the
+    /// payload.
+    #[test]
+    fn cursor_snapshot_rejects_version_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+        let meta = path.join(".timefusion_meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        // Write a syntactically valid JSON with a bumped version.
+        std::fs::write(
+            meta.join("cursor_snapshot.json"),
+            br#"{"version":999,"written_at_micros":0,"shards_per_topic":4,"clean_shutdown":true,"entries":{}}"#,
+        )
+        .unwrap();
+        assert!(wal.load_cursor_snapshot().is_none());
     }
 
     #[test]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -696,7 +696,10 @@ impl WalManager {
                     continue;
                 }
             };
-            entries.insert(Self::make_topic(&project_id, &table_name), positions.into_iter().map(|p| p.map(pos_to_snap)).collect());
+            entries.insert(
+                Self::make_topic(&project_id, &table_name),
+                positions.into_iter().map(|p| p.map(pos_to_snap)).collect(),
+            );
         }
         let snap = CursorSnapshot {
             version: SNAPSHOT_VERSION,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -207,6 +207,11 @@ impl WalManager {
             }
         }
 
+        // Sweep a leftover snapshot tmp file from a crash between
+        // `fs::write(tmp)` and `fs::rename(tmp, target)`. Harmless if it
+        // sticks around but trivial to clean here.
+        let _ = std::fs::remove_file(meta_dir.join("cursor_snapshot.json.tmp"));
+
         let shards_per_topic = shards_per_topic.max(1);
         info!(
             "WAL initialized at {:?}, known topics: {}, shards/topic: {}",
@@ -723,6 +728,9 @@ impl WalManager {
         // create_dir_all needed on every flush.
         let target = self.cursor_snapshot_path();
         let tmp = target.with_extension("json.tmp");
+        // Defensive: serde_json::to_vec on a struct with only primitive +
+        // standard-collection fields is infallible. Keep the map_err so a
+        // future field addition (custom Serialize) still surfaces clearly.
         let bytes = serde_json::to_vec(&snap).map_err(|e| WalError::Internal(format!("cursor snapshot encode: {}", e)))?;
         std::fs::write(&tmp, bytes)?;
         std::fs::rename(&tmp, &target)?;
@@ -768,8 +776,6 @@ impl WalManager {
     }
 
     /// Fast-forward walrus persisted-read cursors from a loaded snapshot.
-    /// Returns the number of shards that advanced (i.e. snapshot was ahead of
-    /// the locally-fsynced walrus state).
     /// Returns the number of *tables* where at least one shard moved (not the
     /// total shard-advance count — that's per-call via
     /// [`merge_persisted_positions`]).
@@ -1095,6 +1101,54 @@ mod tests {
         // Re-open with a different shard count — load must refuse.
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 8).unwrap();
         assert!(wal.load_cursor_snapshot().is_none());
+    }
+
+    /// Rescue path: walrus has no fsynced state for this topic (simulating a
+    /// crash that lost the persisted cursor while the WAL files themselves
+    /// survived). Restore from a hand-crafted snapshot pointing past origin
+    /// must actually move walrus's persisted_read_position forward — this
+    /// is the scenario the snapshot exists to handle, distinct from the
+    /// idempotent path in `..._roundtrip_restores_persisted_positions`.
+    #[test]
+    fn cursor_snapshot_restore_advances_walrus_past_local_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path, crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+
+        // Walrus knows nothing about ("p", "t") yet → all shards None.
+        assert!(wal.persisted_read_positions("p", "t").unwrap().iter().all(Option::is_none));
+
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(WalManager::make_topic("p", "t"), vec![Some((7u64, 42u64)), None, Some((3, 0)), None]);
+        let snap = CursorSnapshot {
+            version: SNAPSHOT_VERSION,
+            written_at_micros: 0,
+            shards_per_topic: 4,
+            clean_shutdown: true,
+            entries,
+        };
+        let tables_advanced = wal.restore_cursor_snapshot(&snap).unwrap();
+        assert_eq!(tables_advanced, 1, "the one snapshot table must advance from origin");
+
+        let after = wal.persisted_read_positions("p", "t").unwrap();
+        assert_eq!(after[0].map(|p| (p.block_id, p.offset)), Some((7, 42)));
+        assert_eq!(after[2].map(|p| (p.block_id, p.offset)), Some((3, 0)));
+    }
+
+    /// On crash between `fs::write(tmp)` and `fs::rename(tmp, target)` we
+    /// leave `cursor_snapshot.json.tmp` behind. The next WalManager init
+    /// must sweep it so it doesn't accumulate over many crash-restart cycles.
+    #[test]
+    fn cursor_snapshot_tmp_swept_on_init() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        // First init creates `.timefusion_meta/`.
+        drop(WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap());
+        let tmp = path.join(".timefusion_meta/cursor_snapshot.json.tmp");
+        std::fs::write(&tmp, b"partial").unwrap();
+        assert!(tmp.exists());
+        drop(WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap());
+        assert!(!tmp.exists(), "init must sweep leftover tmp file");
     }
 
     /// `delete_cursor_snapshot` removes a present file and is a no-op when

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -784,6 +784,17 @@ impl WalManager {
         for (topic, snapshot_positions) in &snap.entries {
             let Some((project_id, table_name)) = Self::parse_topic(topic) else { continue };
             if snapshot_positions.len() != self.shards_per_topic {
+                // load_cursor_snapshot already rejects whole-file mismatches;
+                // hitting this means a per-entry corruption. Surface it so a
+                // future "why didn't this table restore?" investigation has
+                // a thread to pull on.
+                warn!(
+                    "cursor snapshot entry for {}/{} has {} shards but topic has {} — skipping",
+                    project_id,
+                    table_name,
+                    snapshot_positions.len(),
+                    self.shards_per_topic
+                );
                 continue;
             }
             // Seed `known_topics` so a later list_topic_pairs() includes a
@@ -1025,11 +1036,9 @@ mod tests {
     /// Scope note: this exercises the *idempotent* path — walrus's own fsync
     /// already persisted shard 0's advance to disk in Process A, so when
     /// Process B opens the same dir, restore finds nothing to advance and
-    /// returns 0 tables. The scenario the snapshot actually *rescues* is a
-    /// hard kill where walrus's in-memory cursor moved but its fsync hadn't
-    /// landed — hard to simulate here without injecting into walrus's
-    /// internal state, so it's covered by the prod canary in the plan
-    /// instead.
+    /// returns 0 tables. The rescue path (snapshot is ahead of walrus's
+    /// own fsynced state) is covered by
+    /// [`cursor_snapshot_restore_advances_walrus_past_local_state`].
     #[test]
     fn cursor_snapshot_roundtrip_restores_persisted_positions() {
         let dir = tempfile::tempdir().unwrap();
@@ -1115,11 +1124,20 @@ mod tests {
         let path = dir.path().to_path_buf();
         let wal = WalManager::with_fsync_mode_and_shards(path, crate::config::WalFsyncMode::SyncEach, 4).unwrap();
 
-        // Walrus knows nothing about ("p", "t") yet → all shards None.
-        assert!(wal.persisted_read_positions("p", "t").unwrap().iter().all(Option::is_none));
+        // Walrus uses a process-global `WALRUS_DATA_DIR` so other tests may
+        // have seeded state for shared collection keys. Use a per-test
+        // unique topic name so the hashed walrus key is guaranteed fresh.
+        let table = format!(
+            "rescue_{}",
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        );
+        let project = "p";
+
+        let before = wal.persisted_read_positions(project, &table).unwrap();
+        assert!(before.iter().all(Option::is_none), "fresh walrus key must have no persisted cursor");
 
         let mut entries = std::collections::BTreeMap::new();
-        entries.insert(WalManager::make_topic("p", "t"), vec![Some((7u64, 42u64)), None, Some((3, 0)), None]);
+        entries.insert(WalManager::make_topic(project, &table), vec![Some((7u64, 42u64)), None, Some((3, 0)), None]);
         let snap = CursorSnapshot {
             version: SNAPSHOT_VERSION,
             written_at_micros: 0,
@@ -1130,7 +1148,7 @@ mod tests {
         let tables_advanced = wal.restore_cursor_snapshot(&snap).unwrap();
         assert_eq!(tables_advanced, 1, "the one snapshot table must advance from origin");
 
-        let after = wal.persisted_read_positions("p", "t").unwrap();
+        let after = wal.persisted_read_positions(project, &table).unwrap();
         assert_eq!(after[0].map(|p| (p.block_id, p.offset)), Some((7, 42)));
         assert_eq!(after[2].map(|p| (p.block_id, p.offset)), Some((3, 0)));
     }
@@ -1149,6 +1167,32 @@ mod tests {
         assert!(tmp.exists());
         drop(WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap());
         assert!(!tmp.exists(), "init must sweep leftover tmp file");
+    }
+
+    /// Simulates the BufferedWriteLayer write_post_flush_snapshot recovery
+    /// path: if `write_cursor_snapshot` fails after a previous good write,
+    /// the caller must remove the now-stale file so the next boot's shallow
+    /// verifier doesn't trust it. Failure is forced by putting a directory
+    /// in the spot the atomic-rename tmp would occupy — `fs::write` to a
+    /// directory path errors, so the rename never happens.
+    #[test]
+    fn write_cursor_snapshot_failure_leaves_stale_file_to_be_swept() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+        wal.write_cursor_snapshot(true).unwrap();
+        let target = path.join(".timefusion_meta/cursor_snapshot.json");
+        let tmp = path.join(".timefusion_meta/cursor_snapshot.json.tmp");
+        assert!(target.exists());
+
+        // Force the next write to fail by squatting on the tmp path with a dir.
+        std::fs::create_dir(&tmp).unwrap();
+        assert!(wal.write_cursor_snapshot(false).is_err(), "tmp-path collision must fail the write");
+        assert!(target.exists(), "stale snapshot still on disk after failed write");
+
+        // BufferedWriteLayer's recovery: delete the stale file.
+        wal.delete_cursor_snapshot().unwrap();
+        assert!(!target.exists(), "delete clears the stale snapshot");
     }
 
     /// `delete_cursor_snapshot` removes a present file and is a no-op when

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -87,6 +87,7 @@ pub struct CursorSnapshot {
     /// `"project_id:table_name"` → per-shard cursor (None = never written).
     pub entries:           std::collections::BTreeMap<String, Vec<Option<SnapPos>>>,
 }
+
 /// Maximum size for a single record batch (100MB) - prevents unbounded memory allocation from malicious/corrupted WAL
 const MAX_BATCH_SIZE: usize = 100 * 1024 * 1024;
 /// Fsync schedule interval in milliseconds - balances durability with performance
@@ -728,6 +729,18 @@ impl WalManager {
         Ok(())
     }
 
+    /// Remove the on-disk cursor snapshot. Called after a snapshot write
+    /// fails so the next boot doesn't fall back to stale-but-readable state
+    /// and shallow-scan over commits made since the last good write. NotFound
+    /// is silently ignored (caller's intent — "no file" is the goal state).
+    pub fn delete_cursor_snapshot(&self) -> Result<(), WalError> {
+        match std::fs::remove_file(self.cursor_snapshot_path()) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(WalError::Io(e)),
+        }
+    }
+
     /// Read the cursor snapshot if present. Returns None on missing/parse/version
     /// mismatch so the boot path falls through to Delta reconciliation.
     pub fn load_cursor_snapshot(&self) -> Option<CursorSnapshot> {
@@ -999,9 +1012,18 @@ mod tests {
     }
 
     /// Round-trip cursor snapshot: write, drop the manager, re-open, restore.
-    /// Verifies the on-disk file is enough to fast-forward walrus cursors on
+    /// Verifies the on-disk file is enough to seed walrus's known_topics on
     /// a fresh process without touching Delta — the whole point of the fast
     /// boot path.
+    ///
+    /// Scope note: this exercises the *idempotent* path — walrus's own fsync
+    /// already persisted shard 0's advance to disk in Process A, so when
+    /// Process B opens the same dir, restore finds nothing to advance and
+    /// returns 0 tables. The scenario the snapshot actually *rescues* is a
+    /// hard kill where walrus's in-memory cursor moved but its fsync hadn't
+    /// landed — hard to simulate here without injecting into walrus's
+    /// internal state, so it's covered by the prod canary in the plan
+    /// instead.
     #[test]
     fn cursor_snapshot_roundtrip_restores_persisted_positions() {
         let dir = tempfile::tempdir().unwrap();
@@ -1073,6 +1095,24 @@ mod tests {
         // Re-open with a different shard count — load must refuse.
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 8).unwrap();
         assert!(wal.load_cursor_snapshot().is_none());
+    }
+
+    /// `delete_cursor_snapshot` removes a present file and is a no-op when
+    /// absent. The flush path calls this on write failure to keep boot from
+    /// restoring stale state.
+    #[test]
+    fn delete_cursor_snapshot_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+        // Missing → Ok.
+        wal.delete_cursor_snapshot().unwrap();
+        wal.write_cursor_snapshot(true).unwrap();
+        assert!(path.join(".timefusion_meta/cursor_snapshot.json").exists());
+        wal.delete_cursor_snapshot().unwrap();
+        assert!(!path.join(".timefusion_meta/cursor_snapshot.json").exists());
+        // Second call must still be Ok.
+        wal.delete_cursor_snapshot().unwrap();
     }
 
     /// A snapshot written from the flush path (clean_shutdown=false) loads

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -772,6 +772,20 @@ impl WalManager {
             );
             return None;
         }
+        // 24h is well past the normal restart cadence; an older snapshot
+        // usually means the file was ported across hosts, the system clock
+        // moved backward, or the process was offline for an extended window.
+        // Surface it but still trust the snapshot — clean_shutdown is the
+        // gate, age is informational.
+        const STALE_AFTER_MICROS: i64 = 24 * 3600 * 1_000_000;
+        let age_micros = crate::clock::now_micros().saturating_sub(snap.written_at_micros);
+        if age_micros > STALE_AFTER_MICROS {
+            warn!(
+                "cursor snapshot is unusually old: age={}h, clean_shutdown={} — check for clock skew, ported data dir, or long downtime",
+                age_micros / 3_600_000_000,
+                snap.clean_shutdown
+            );
+        }
         Some(snap)
     }
 
@@ -1169,6 +1183,36 @@ mod tests {
         assert!(!tmp.exists(), "init must sweep leftover tmp file");
     }
 
+    /// Worst case for `write_post_flush_snapshot`: the meta dir is
+    /// read-only so the tmp write fails AND the subsequent
+    /// `delete_cursor_snapshot` also fails (POSIX unlink needs write on the
+    /// parent). The stale snapshot survives — documented in RUNBOOK.md as
+    /// "Stale cursor snapshot." The unit invariant we lock in here is just
+    /// that both calls return Err cleanly without panicking, so the flush
+    /// task can carry on.
+    #[cfg(unix)]
+    #[test]
+    fn write_and_delete_both_fail_under_readonly_meta_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
+        wal.write_cursor_snapshot(true).unwrap();
+        let meta = path.join(".timefusion_meta");
+        let target = meta.join("cursor_snapshot.json");
+
+        // Lock the meta dir: r-x only.
+        let original = std::fs::metadata(&meta).unwrap().permissions();
+        std::fs::set_permissions(&meta, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        assert!(wal.write_cursor_snapshot(false).is_err(), "write into RO dir must fail");
+        assert!(wal.delete_cursor_snapshot().is_err(), "unlink under RO parent must fail");
+        assert!(target.exists(), "stale snapshot survives both failures");
+
+        // Restore so tempdir teardown can clean up.
+        std::fs::set_permissions(&meta, original).unwrap();
+    }
+
     /// Simulates the BufferedWriteLayer write_post_flush_snapshot recovery
     /// path: if `write_cursor_snapshot` fails after a previous good write,
     /// the caller must remove the now-stale file so the next boot's shallow
@@ -1176,7 +1220,7 @@ mod tests {
     /// in the spot the atomic-rename tmp would occupy — `fs::write` to a
     /// directory path errors, so the rename never happens.
     #[test]
-    fn write_cursor_snapshot_failure_leaves_stale_file_to_be_swept() {
+    fn write_cursor_snapshot_failure_requires_caller_to_delete_stale_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();


### PR DESCRIPTION
## Problem

Every restart spent ~6.5 min between `Database initialized` and `WAL initialized` re-reading each table's last 16 Delta commits from R2 to fast-forward the walrus persisted-read cursor. The watermark we re-derive is byte-identical to what was already in memory at shutdown — we just threw it away on exit and re-fetched it on boot.

## Fix

Persist the cursor to `<wal>/.timefusion_meta/cursor_snapshot.json`:
- After every flush cycle in `BufferedWriteLayer` (clean_shutdown=false) — **one** write per cycle, not per bucket.
- On graceful shutdown (clean_shutdown=true).

On boot, restore it and — when `clean_shutdown=true` — skip the Delta scan entirely. Dirty/missing snapshot still seeds positions, then runs a (now-shortened, env-tuned) Delta verifier so we still catch commits made after the last snapshot was written.

## Defaults

- `TIMEFUSION_DELTA_SCAN_CONCURRENCY` default **64** (was hard-coded 8) — R2 happily handles it.
- `TIMEFUSION_DELTA_SCAN_DEPTH` default **8** (was hard-coded 16) — snapshot covers the bulk; depth 8 leaves a defensive margin in case a few snapshot writes failed silently.

## Safety nets

- On snapshot write failure (disk full / perms / tmp-path collision) we delete any pre-existing snapshot via `WalManager::delete_cursor_snapshot`, forcing the next boot to scan rather than restore stale state.
- Leftover `cursor_snapshot.json.tmp` from a crash mid-rename is swept at `WalManager` construction.
- Snapshot is rejected on version mismatch and on `shards_per_topic` change (operator changed `TIMEFUSION_WAL_SHARDS_PER_TOPIC`).
- Per-entry shard-length mismatches log a `warn!` rather than skipping silently.

## Assumptions documented in `CursorSnapshot` rustdoc

Correctness assumes this timefusion process is the **only** writer to its Delta tables. If you ever run a parallel writer (manual `OPTIMIZE`, external delta-rs client, sister process) between a clean-shutdown snapshot and the next boot, delete `cursor_snapshot.json` to force reconciliation — the `clean_shutdown` flag alone won't catch out-of-band commits.

## Shared helper

`WalManager::merge_persisted_positions` collapses the per-shard "advance only if ahead" logic now used by both snapshot restore and Delta reconciliation.

## How to test

1. Clean shutdown → fast boot: `docker service update --force srv-captain--timefusion`; expect `<30s` from container start to ready and `"Cursor snapshot restored … skipping Delta reconciliation"` in logs.
2. Dirty boot (snapshot missing): `docker exec` into running container, `rm .../cursor_snapshot.json`, force-update. Confirm it falls through to `derive_wal_cursors_from_delta` and finishes in seconds.
3. Dirty boot (hard kill): `docker kill -s KILL`. New container reads snapshot, seeds positions, runs shortened verifier.
4. Unit: `cargo test --lib -- wal:: --test-threads=1` (14 wal tests covering roundtrip, rescue, version/shard-mismatch rejection, dirty path, write-failure recovery, tmp sweep, delete idempotence).