### PR TITLE
feat(functions): jsonb_build_array alias + to_char Postgres-format rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,23 +74,27 @@ jobs:
       TIMEFUSION_FOYER_METADATA_MEMORY_MB: "10"
       TIMEFUSION_FOYER_METADATA_DISK_MB: "50"
       TIMEFUSION_FOYER_SHARDS: "2"
-    services:
-      minio:
-        image: public.ecr.aws/bitnami/minio:latest
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-          MINIO_DEFAULT_BUCKETS: timefusion-test,timefusion-tests
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/live || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: Free disk space
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      # `public.ecr.aws/bitnami/minio` was withdrawn (Bitnami consolidated registries).
+      # GitHub Actions `services:` can't override the entrypoint to pass `server /data`
+      # to the official quay.io/minio/minio image, so start it manually and seed the
+      # buckets that the bitnami image used to auto-create via MINIO_DEFAULT_BUCKETS.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            quay.io/minio/minio:latest server /data --console-address ":9001"
+          for _ in {1..30}; do
+            curl -sf http://localhost:9000/minio/health/live && break
+            sleep 1
+          done
+          docker run --rm --network host quay.io/minio/mc:latest sh -c '
+            mc alias set local http://localhost:9000 minioadmin minioadmin &&
+            mc mb -p local/timefusion-test local/timefusion-tests'
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,19 @@ jobs:
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             "$MINIO_IMAGE" server /data --console-address ":9001"
-          for _ in {1..30}; do
-            curl -sf http://localhost:9000/minio/health/live && break
+          # `set -e` (GH Actions default) makes `curl && break` abort the script on the
+          # first failed curl, so we wrap the polling in an `if` instead.
+          for _ in {1..60}; do
+            if curl -sf http://localhost:9000/minio/health/live; then
+              break
+            fi
             sleep 1
           done
-          curl -sf http://localhost:9000/minio/health/live \
-            || { echo "MinIO failed to become healthy after 30s"; docker logs minio; exit 1; }
+          if ! curl -sf http://localhost:9000/minio/health/live; then
+            echo "MinIO failed to become healthy after 60s"
+            docker logs minio
+            exit 1
+          fi
           docker run --rm --network host "$MC_IMAGE" sh -c '
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/timefusion-test local/timefusion-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,10 @@ jobs:
             docker logs minio
             exit 1
           fi
-          docker run --rm --network host "$MC_IMAGE" sh -c '
+          # mc image's ENTRYPOINT is `mc` itself, so we override to /bin/sh to run a
+          # multi-command script. (Without --entrypoint, `mc sh -c '...'` is what runs
+          # and mc rejects `sh` as an unknown subcommand.)
+          docker run --rm --network host --entrypoint /bin/sh "$MC_IMAGE" -c '
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/timefusion-test local/timefusion-tests'
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,21 @@ jobs:
       # buckets that the bitnami image used to auto-create via MINIO_DEFAULT_BUCKETS.
       - name: Start MinIO
         run: |
+          # Pinned to a known-good release so a breaking upstream tag doesn't silently break CI.
+          MINIO_IMAGE=quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
+          MC_IMAGE=quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
           docker run -d --name minio \
             -p 9000:9000 -p 9001:9001 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            quay.io/minio/minio:latest server /data --console-address ":9001"
+            "$MINIO_IMAGE" server /data --console-address ":9001"
           for _ in {1..30}; do
             curl -sf http://localhost:9000/minio/health/live && break
             sleep 1
           done
-          docker run --rm --network host quay.io/minio/mc:latest sh -c '
+          curl -sf http://localhost:9000/minio/health/live \
+            || { echo "MinIO failed to become healthy after 30s"; docker logs minio; exit 1; }
+          docker run --rm --network host "$MC_IMAGE" sh -c '
             mc alias set local http://localhost:9000 minioadmin minioadmin &&
             mc mb -p local/timefusion-test local/timefusion-tests'
       - uses: actions/checkout@v4

--- a/src/database.rs
+++ b/src/database.rs
@@ -5021,7 +5021,7 @@ mod tests {
             // Test timestamp formatting - need to include project_id
             let result = ctx
                 .sql(&format!(
-                    "SELECT id, to_char(timestamp, '%Y-%m-%d %H:%M') as ts FROM otel_logs_and_spans WHERE project_id = '{}' ORDER BY timestamp",
+                    "SELECT id, to_char(timestamp, 'YYYY-MM-DD HH24:MI') as ts FROM otel_logs_and_spans WHERE project_id = '{}' ORDER BY timestamp",
                     project_id
                 ))
                 .await?

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, sync::Arc};
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use chrono_tz::Tz;
 use datafusion::{
     arrow::{
@@ -574,13 +574,13 @@ impl ScalarUDFImpl for ToCharUDF {
 
 /// Format timestamps according to PostgreSQL format patterns
 fn format_timestamps(timestamp_array: &ArrayRef, format_str: &str) -> datafusion::error::Result<ArrayRef> {
-    let chrono_format = postgres_to_chrono_format(format_str);
+    let parts = parse_pg_format(format_str);
     let mut builder = StringViewBuilder::new();
 
     let format_fn = |timestamp_us: i64| -> datafusion::error::Result<String> {
         DateTime::<Utc>::from_timestamp_micros(timestamp_us)
             .ok_or_else(|| DataFusionError::Execution("Invalid timestamp".to_string()))
-            .map(|dt| dt.format(&chrono_format).to_string())
+            .map(|dt| render_pg_format(&parts, &dt))
     };
 
     match timestamp_array.as_any().downcast_ref::<TimestampMicrosecondArray>() {
@@ -611,12 +611,46 @@ fn format_timestamps(timestamp_array: &ArrayRef, format_str: &str) -> datafusion
     Ok(Arc::new(builder.finish()))
 }
 
-/// Convert PostgreSQL `to_char` format patterns to chrono format patterns.
+/// One segment of a parsed Postgres format string. Most tokens collapse to a
+/// `Chrono` spec; `PgD` / `PgDY` exist because chrono has no exact equivalent
+/// for the Postgres day-of-week semantics (Sun=1..Sat=7 / uppercase abbrev).
+#[derive(Debug, PartialEq)]
+enum FmtPart {
+    /// A chrono strftime spec (e.g. `"%Y"`) or escaped-literal slice.
+    Chrono(String),
+    /// Postgres `D`: day of week, Sunday=1..Saturday=7.
+    PgD,
+    /// Postgres `DY`: uppercase abbreviated weekday name (e.g. `"WED"`).
+    PgDY,
+}
+
+/// Render a parsed Postgres format against a `DateTime<Utc>`.
+fn render_pg_format(parts: &[FmtPart], dt: &DateTime<Utc>) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for part in parts {
+        match part {
+            FmtPart::Chrono(spec) => {
+                let _ = write!(out, "{}", dt.format(spec));
+            }
+            FmtPart::PgD => {
+                // chrono `num_days_from_sunday` is 0=Sun..6=Sat; Postgres `D` is 1..7.
+                let _ = write!(out, "{}", dt.weekday().num_days_from_sunday() + 1);
+            }
+            FmtPart::PgDY => {
+                out.push_str(&dt.format("%a").to_string().to_uppercase());
+            }
+        }
+    }
+    out
+}
+
+/// Parse a PostgreSQL `to_char` format string into a sequence of render parts.
 ///
 /// Honors Postgres literal-escape syntax: text inside `"..."` is copied verbatim
 /// (with `""` standing for a literal `"`). Outside literals, the longest matching
 /// token is replaced with its chrono equivalent.
-fn postgres_to_chrono_format(pg_format: &str) -> String {
+fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
     // (Postgres token, chrono spec). Longest-prefix wins, so order matters within
     // groups that share a prefix (HH24 before HH, Month before Mon before MM, etc.).
     const TOKENS: &[(&str, &str)] = &[
@@ -631,12 +665,11 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
         ("DD", "%d"),
         ("Day", "%A"),
         ("Dy", "%a"),
-        // Omitted on purpose; their chrono mappings don't match Postgres semantics:
-        //   `DY` → Postgres emits uppercase ("WED"), chrono `%a` is title-case ("Wed").
-        //   `D`  → Postgres day-of-week is Sun=1..Sat=7; chrono `%u` is Mon=1..Sun=7 and
-        //          `%w` is Sun=0..Sat=6. No exact chrono token exists.
-        // Re-add with a custom formatter (uppercase post-processing / weekday renumbering)
-        // when a caller actually needs them.
+        // `D` and `DY` are handled below as PgD / PgDY because chrono has no
+        // exact equivalent for Postgres's Sun=1..Sat=7 numbering or its
+        // uppercase abbreviated weekday name. They must be matched before the
+        // single-char fallback below; they aren't in this table so we test for
+        // them explicitly in the loop.
         ("HH24", "%H"),
         ("HH12", "%I"),
         ("HH", "%I"),
@@ -653,17 +686,25 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
     // pass-through path must walk UTF-8 char boundaries — a multi-byte char in a `"..."`
     // literal would otherwise be split into separate `char`s and produce mojibake.
     let bytes = pg_format.as_bytes();
-    let mut out = String::with_capacity(pg_format.len());
-    let mut i = 0;
-    let push_passthrough = |out: &mut String, s: &str, i: &mut usize| {
+    let mut parts: Vec<FmtPart> = Vec::new();
+    // Accumulate chrono spec / literal text into a buffer; flush on a non-chrono
+    // boundary (PgD / PgDY) or at the end so the resulting Vec stays compact.
+    let mut buf = String::with_capacity(pg_format.len());
+    let flush = |parts: &mut Vec<FmtPart>, buf: &mut String| {
+        if !buf.is_empty() {
+            parts.push(FmtPart::Chrono(std::mem::take(buf)));
+        }
+    };
+    let push_passthrough = |buf: &mut String, s: &str, i: &mut usize| {
         let c = s[*i..].chars().next().expect("loop invariant: i < s.len()");
         // chrono treats `%` as a format-spec start; double it to emit a literal.
         if c == '%' {
-            out.push('%');
+            buf.push('%');
         }
-        out.push(c);
+        buf.push(c);
         *i += c.len_utf8();
     };
+    let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'"' {
             // Literal section: copy until matching `"`. `""` inside is an escaped quote.
@@ -671,26 +712,42 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
             while i < bytes.len() {
                 if bytes[i] == b'"' {
                     if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
-                        out.push('"');
+                        buf.push('"');
                         i += 2;
                         continue;
                     }
                     i += 1;
                     break;
                 }
-                push_passthrough(&mut out, pg_format, &mut i);
+                push_passthrough(&mut buf, pg_format, &mut i);
             }
+            continue;
+        }
+        // `DY` must be matched before bare `D` (longest-prefix). Neither is in TOKENS.
+        if bytes[i..].starts_with(b"DY") {
+            flush(&mut parts, &mut buf);
+            parts.push(FmtPart::PgDY);
+            i += 2;
+            continue;
+        }
+        if bytes[i] == b'D' && !bytes.get(i + 1).is_some_and(|b| b.is_ascii_alphabetic()) {
+            // Bare `D` only — guarded so `D<letter>` (e.g. a future token starting with D)
+            // doesn't get consumed here. `Day`, `Dy`, `DD` are caught by TOKENS / DY above.
+            flush(&mut parts, &mut buf);
+            parts.push(FmtPart::PgD);
+            i += 1;
             continue;
         }
         let matched = TOKENS.iter().find(|(pg, _)| bytes[i..].starts_with(pg.as_bytes()));
         if let Some((pg, chrono)) = matched {
-            out.push_str(chrono);
+            buf.push_str(chrono);
             i += pg.len();
             continue;
         }
-        push_passthrough(&mut out, pg_format, &mut i);
+        push_passthrough(&mut buf, pg_format, &mut i);
     }
-    out
+    flush(&mut parts, &mut buf);
+    parts
 }
 
 /// Create the AT TIME ZONE UDF for timezone conversion
@@ -1737,21 +1794,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_postgres_to_chrono_format() {
-        assert_eq!(postgres_to_chrono_format("YYYY-MM-DD"), "%Y-%m-%d");
-        assert_eq!(postgres_to_chrono_format("YYYY-MM-DD HH24:MI:SS"), "%Y-%m-%d %H:%M:%S");
-        assert_eq!(postgres_to_chrono_format("Day, DD Mon YYYY"), "%A, %d %b %Y");
-
+    fn test_parse_pg_format() {
+        // Helper: assert the parse collapses to a single Chrono part with the given spec.
+        let chrono_only = |fmt: &str, expected: &str| {
+            assert_eq!(parse_pg_format(fmt), vec![FmtPart::Chrono(expected.to_string())], "fmt: {fmt}");
+        };
+        chrono_only("YYYY-MM-DD", "%Y-%m-%d");
+        chrono_only("YYYY-MM-DD HH24:MI:SS", "%Y-%m-%d %H:%M:%S");
+        chrono_only("Day, DD Mon YYYY", "%A, %d %b %Y");
         // Postgres-style "..." literal escapes: ISO-8601 with T separator and Z suffix.
-        assert_eq!(postgres_to_chrono_format(r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#), "%Y-%m-%dT%H:%M:%S.%6fZ");
+        chrono_only(r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#, "%Y-%m-%dT%H:%M:%S.%6fZ");
         // Tokens inside a literal stay literal.
-        assert_eq!(postgres_to_chrono_format(r#""YYYY=" YYYY"#), "YYYY= %Y");
+        chrono_only(r#""YYYY=" YYYY"#, "YYYY= %Y");
         // "" inside a literal is an escaped quote.
-        assert_eq!(postgres_to_chrono_format(r#""a""b""#), "a\"b");
+        chrono_only(r#""a""b""#, "a\"b");
         // A bare % outside tokens is escaped to chrono's literal-%.
-        assert_eq!(postgres_to_chrono_format("100%"), "100%%");
+        chrono_only("100%", "100%%");
         // Unterminated literal: copy the remainder verbatim, don't panic.
-        assert_eq!(postgres_to_chrono_format(r#"YYYY "tail"#), "%Y tail");
+        chrono_only(r#"YYYY "tail"#, "%Y tail");
+
+        // D / DY split the buffer (no chrono equivalent).
+        assert_eq!(parse_pg_format("D"), vec![FmtPart::PgD]);
+        assert_eq!(parse_pg_format("DY"), vec![FmtPart::PgDY]);
+        assert_eq!(parse_pg_format("YYYY-D"), vec![FmtPart::Chrono("%Y-".to_string()), FmtPart::PgD]);
+        assert_eq!(parse_pg_format("DY YYYY"), vec![FmtPart::PgDY, FmtPart::Chrono(" %Y".to_string())]);
     }
 
     /// End-to-end UDF parity with Postgres/TimescaleDB `to_char`. Expected outputs
@@ -1780,6 +1846,12 @@ mod tests {
             // AM/PM and Dy round-out token coverage.
             ("HH12:MI AM", "08:10 AM"),
             ("Dy", "Wed"),
+            // Postgres-specific tokens with no exact chrono equivalent.
+            // 2026-06-10 is a Wednesday: Postgres D=4 (Sun=1), DY="WED".
+            ("D", "4"),
+            ("DY", "WED"),
+            // Order-of-parsing check: DY must beat bare D.
+            ("DY-D", "WED-4"),
         ];
         for (fmt, expected) in cases {
             let sql = format!("SELECT to_char({ts}, '{fmt}') AS s");

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -627,6 +627,8 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
         ("MM", "%m"),
         ("DD", "%d"),
         ("Day", "%A"),
+        ("Dy", "%a"),
+        ("DY", "%a"),
         ("D", "%u"),
         ("HH24", "%H"),
         ("HH12", "%I"),
@@ -1730,10 +1732,7 @@ mod tests {
         assert_eq!(postgres_to_chrono_format("Day, DD Mon YYYY"), "%A, %d %b %Y");
 
         // Postgres-style "..." literal escapes: ISO-8601 with T separator and Z suffix.
-        assert_eq!(
-            postgres_to_chrono_format(r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#),
-            "%Y-%m-%dT%H:%M:%S.%6fZ"
-        );
+        assert_eq!(postgres_to_chrono_format(r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#), "%Y-%m-%dT%H:%M:%S.%6fZ");
         // Tokens inside a literal stay literal.
         assert_eq!(postgres_to_chrono_format(r#""YYYY=" YYYY"#), "YYYY= %Y");
         // "" inside a literal is an escaped quote.
@@ -1742,6 +1741,36 @@ mod tests {
         assert_eq!(postgres_to_chrono_format("100%"), "100%%");
         // Unterminated literal: copy the remainder verbatim, don't panic.
         assert_eq!(postgres_to_chrono_format(r#"YYYY "tail"#), "%Y tail");
+    }
+
+    /// End-to-end UDF parity with Postgres/TimescaleDB `to_char`. Expected outputs
+    /// captured from real Postgres 16 with `SELECT to_char(TIMESTAMP '2026-06-10 08:10:52.422355', fmt)`.
+    #[tokio::test]
+    async fn test_to_char_postgres_parity() {
+        use datafusion::prelude::SessionContext;
+        let mut ctx = SessionContext::new();
+        register_custom_functions(&mut ctx).unwrap();
+        let ts = "TIMESTAMP '2026-06-10 08:10:52.422355'";
+        let cases: &[(&str, &str)] = &[
+            ("YYYY-MM-DD", "2026-06-10"),
+            ("YYYY-MM-DD HH24:MI:SS", "2026-06-10 08:10:52"),
+            // Monoscope's ISO-8601 target — the bug this fix addresses.
+            (r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#, "2026-06-10T08:10:52.422355Z"),
+            (r#"YYYY-MM-DD"T"HH24:MI:SS.MS"Z""#, "2026-06-10T08:10:52.422Z"),
+            ("DD/MM/YYYY", "10/06/2026"),
+            ("Mon DD, YYYY", "Jun 10, 2026"),
+            ("Day, Mon DD YYYY", "Wednesday, Jun 10 2026"),
+            ("HH12:MI", "08:10"),
+            ("YY", "26"),
+            // Literal containing characters that look like tokens.
+            (r#""YYYY=" YYYY"#, "YYYY= 2026"),
+        ];
+        for (fmt, expected) in cases {
+            let sql = format!("SELECT to_char({ts}, '{fmt}') AS s");
+            let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+            let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
+            assert_eq!(col.value(0), *expected, "format `{fmt}`");
+        }
     }
 
     #[tokio::test]
@@ -1754,11 +1783,7 @@ mod tests {
             .await
             .unwrap();
         let batches = df.collect().await.unwrap();
-        let col = batches[0]
-            .column(0)
-            .as_any()
-            .downcast_ref::<datafusion::arrow::array::StringViewArray>()
-            .unwrap();
+        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
         assert_eq!(col.value(0), "2026-06-10T08:10:52.422355Z");
     }
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -622,6 +622,9 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
     const TOKENS: &[(&str, &str)] = &[
         ("YYYY", "%Y"),
         ("YY", "%y"),
+        // Note: Postgres pads `Month` / `Day` output to 9 chars; chrono's %B / %A do not.
+        // E2E callers rely on the unpadded form, so we keep the divergence — re-add padding
+        // only if a caller asks for it.
         ("Month", "%B"),
         ("Mon", "%b"),
         ("MM", "%m"),
@@ -646,9 +649,21 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
         ("PM", "%p"),
     ];
 
+    // All token keys are ASCII so byte-prefix matching is sound, but the non-token
+    // pass-through path must walk UTF-8 char boundaries — a multi-byte char in a `"..."`
+    // literal would otherwise be split into separate `char`s and produce mojibake.
     let bytes = pg_format.as_bytes();
     let mut out = String::with_capacity(pg_format.len());
     let mut i = 0;
+    let push_passthrough = |out: &mut String, s: &str, i: &mut usize| {
+        let c = s[*i..].chars().next().expect("loop invariant: i < s.len()");
+        // chrono treats `%` as a format-spec start; double it to emit a literal.
+        if c == '%' {
+            out.push('%');
+        }
+        out.push(c);
+        *i += c.len_utf8();
+    };
     while i < bytes.len() {
         if bytes[i] == b'"' {
             // Literal section: copy until matching `"`. `""` inside is an escaped quote.
@@ -663,25 +678,17 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
                     i += 1;
                     break;
                 }
-                // chrono treats `%` as a format-spec start; double it to emit a literal.
-                if bytes[i] == b'%' {
-                    out.push('%');
-                }
-                out.push(bytes[i] as char);
-                i += 1;
+                push_passthrough(&mut out, pg_format, &mut i);
             }
             continue;
         }
-        if let Some((pg, chrono)) = TOKENS.iter().find(|(pg, _)| bytes[i..].starts_with(pg.as_bytes())) {
+        let matched = TOKENS.iter().find(|(pg, _)| bytes[i..].starts_with(pg.as_bytes()));
+        if let Some((pg, chrono)) = matched {
             out.push_str(chrono);
             i += pg.len();
             continue;
         }
-        if bytes[i] == b'%' {
-            out.push('%');
-        }
-        out.push(bytes[i] as char);
-        i += 1;
+        push_passthrough(&mut out, pg_format, &mut i);
     }
     out
 }
@@ -1768,6 +1775,11 @@ mod tests {
             ("YY", "26"),
             // Literal containing characters that look like tokens.
             (r#""YYYY=" YYYY"#, "YYYY= 2026"),
+            // Non-ASCII bytes inside a literal must survive intact (UTF-8 boundary walk).
+            (r#""· "YYYY"#, "· 2026"),
+            // AM/PM and Dy round-out token coverage.
+            ("HH12:MI AM", "08:10 AM"),
+            ("Dy", "Wed"),
         ];
         for (fmt, expected) in cases {
             let sql = format!("SELECT to_char({ts}, '{fmt}') AS s");

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -704,6 +704,9 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
         ("TZ", "%Z"),
         ("AM", "%p"),
         ("PM", "%p"),
+        // Lowercase forms — Postgres `am`/`pm` emit lowercase output (chrono `%P`).
+        ("am", "%P"),
+        ("pm", "%P"),
     ];
 
     // All token keys are ASCII so byte-prefix matching is sound, but the non-token
@@ -748,9 +751,10 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
             continue;
         }
         // `DY` must be matched before bare `D` (longest-prefix). Neither is in TOKENS.
-        // Same trailing-alpha guard as `D` below so a future `DYY`-style token doesn't
-        // get greedily consumed as `DY` + leftover `Y`.
-        if bytes[i..].starts_with(b"DY") && !bytes.get(i + 2).is_some_and(|b| b.is_ascii_alphabetic()) {
+        // No trailing-alpha guard here: Postgres consumes `DY` greedily, so `DYY` is
+        // `DY` + leftover `Y`. The bare-`D` guard below is still needed because
+        // `Day`/`Dy`/`DD` are alpha-prefix conflicts; no such conflict exists for `DY`.
+        if bytes[i..].starts_with(b"DY") {
             flush(&mut parts, &mut buf);
             parts.push(FmtPart::PgDY);
             i += 2;
@@ -1870,8 +1874,10 @@ mod tests {
             (r#""YYYY=" YYYY"#, "YYYY= 2026"),
             // Non-ASCII bytes inside a literal must survive intact (UTF-8 boundary walk).
             (r#""· "YYYY"#, "· 2026"),
-            // AM/PM and Dy round-out token coverage.
+            // AM/PM, Dy, bare HH round-out token coverage.
             ("HH12:MI AM", "08:10 AM"),
+            ("HH:MI:SS", "08:10:52"),   // bare HH aliases HH12 (12-hour clock with leading zero).
+            ("HH12:MI am", "08:10 am"), // lowercase am token emits lowercase output.
             ("Dy", "Wed"),
             // Postgres-specific tokens with no exact chrono equivalent.
             // 2026-06-10 is a Wednesday: Postgres D=4 (Sun=1), DY="WED".

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -611,24 +611,73 @@ fn format_timestamps(timestamp_array: &ArrayRef, format_str: &str) -> datafusion
     Ok(Arc::new(builder.finish()))
 }
 
-/// Convert PostgreSQL format patterns to chrono format patterns
+/// Convert PostgreSQL `to_char` format patterns to chrono format patterns.
+///
+/// Honors Postgres literal-escape syntax: text inside `"..."` is copied verbatim
+/// (with `""` standing for a literal `"`). Outside literals, the longest matching
+/// token is replaced with its chrono equivalent.
 fn postgres_to_chrono_format(pg_format: &str) -> String {
-    // This is a simplified conversion - a full implementation would handle all PostgreSQL patterns
-    // Order matters! Longer patterns should be replaced first
-    pg_format
-        .replace("YYYY", "%Y")
-        .replace("Month", "%B") // Full month name (must come before MM)
-        .replace("Mon", "%b") // Abbreviated month name (must come before MM)
-        .replace("MM", "%m") // Month number
-        .replace("DD", "%d")
-        .replace("HH24", "%H")
-        .replace("HH", "%I")
-        .replace("MI", "%M")
-        .replace("SS", "%S")
-        .replace("US", "%6f") // Microseconds (6 digits)
-        .replace("MS", "%3f") // Milliseconds (3 digits)
-        .replace("TZ", "%Z")
-        .replace("Day", "%A")
+    // (Postgres token, chrono spec). Longest-prefix wins, so order matters within
+    // groups that share a prefix (HH24 before HH, Month before Mon before MM, etc.).
+    const TOKENS: &[(&str, &str)] = &[
+        ("YYYY", "%Y"),
+        ("YY", "%y"),
+        ("Month", "%B"),
+        ("Mon", "%b"),
+        ("MM", "%m"),
+        ("DD", "%d"),
+        ("Day", "%A"),
+        ("D", "%u"),
+        ("HH24", "%H"),
+        ("HH12", "%I"),
+        ("HH", "%I"),
+        ("MI", "%M"),
+        ("SS", "%S"),
+        ("US", "%6f"),
+        ("MS", "%3f"),
+        ("TZ", "%Z"),
+        ("AM", "%p"),
+        ("PM", "%p"),
+    ];
+
+    let bytes = pg_format.as_bytes();
+    let mut out = String::with_capacity(pg_format.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'"' {
+            // Literal section: copy until matching `"`. `""` inside is an escaped quote.
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'"' {
+                    if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+                        out.push('"');
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                    break;
+                }
+                // chrono treats `%` as a format-spec start; double it to emit a literal.
+                if bytes[i] == b'%' {
+                    out.push('%');
+                }
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+            continue;
+        }
+        if let Some((pg, chrono)) = TOKENS.iter().find(|(pg, _)| bytes[i..].starts_with(pg.as_bytes())) {
+            out.push_str(chrono);
+            i += pg.len();
+            continue;
+        }
+        if bytes[i] == b'%' {
+            out.push('%');
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
 }
 
 /// Create the AT TIME ZONE UDF for timezone conversion
@@ -770,18 +819,25 @@ fn create_json_build_array_udf() -> ScalarUDF {
 #[derive(Debug, Hash, Eq, PartialEq)]
 struct JsonBuildArrayUDF {
     signature: Signature,
+    aliases:   Vec<String>,
 }
 
 impl JsonBuildArrayUDF {
     fn new() -> Self {
         Self {
             signature: Signature::variadic_any(Volatility::Immutable),
+            // `jsonb_build_array` is Postgres-only; TimeFusion stores JSON as Utf8View either way.
+            aliases:   vec!["jsonb_build_array".to_string()],
         }
     }
 }
 
 impl ScalarUDFImpl for JsonBuildArrayUDF {
     scalar_udf_boilerplate!("json_build_array");
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Utf8View)
@@ -1672,6 +1728,38 @@ mod tests {
         assert_eq!(postgres_to_chrono_format("YYYY-MM-DD"), "%Y-%m-%d");
         assert_eq!(postgres_to_chrono_format("YYYY-MM-DD HH24:MI:SS"), "%Y-%m-%d %H:%M:%S");
         assert_eq!(postgres_to_chrono_format("Day, DD Mon YYYY"), "%A, %d %b %Y");
+
+        // Postgres-style "..." literal escapes: ISO-8601 with T separator and Z suffix.
+        assert_eq!(
+            postgres_to_chrono_format(r#"YYYY-MM-DD"T"HH24:MI:SS.US"Z""#),
+            "%Y-%m-%dT%H:%M:%S.%6fZ"
+        );
+        // Tokens inside a literal stay literal.
+        assert_eq!(postgres_to_chrono_format(r#""YYYY=" YYYY"#), "YYYY= %Y");
+        // "" inside a literal is an escaped quote.
+        assert_eq!(postgres_to_chrono_format(r#""a""b""#), "a\"b");
+        // A bare % outside tokens is escaped to chrono's literal-%.
+        assert_eq!(postgres_to_chrono_format("100%"), "100%%");
+        // Unterminated literal: copy the remainder verbatim, don't panic.
+        assert_eq!(postgres_to_chrono_format(r#"YYYY "tail"#), "%Y tail");
+    }
+
+    #[tokio::test]
+    async fn test_to_char_udf_iso8601_with_z() {
+        use datafusion::prelude::SessionContext;
+        let mut ctx = SessionContext::new();
+        register_custom_functions(&mut ctx).unwrap();
+        let df = ctx
+            .sql(r#"SELECT to_char(TIMESTAMP '2026-06-10 08:10:52.422355', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS s"#)
+            .await
+            .unwrap();
+        let batches = df.collect().await.unwrap();
+        let col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "2026-06-10T08:10:52.422355Z");
     }
 
     #[test]

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -638,7 +638,11 @@ fn render_pg_format(parts: &[FmtPart], dt: &DateTime<Utc>) -> String {
                 let _ = write!(out, "{}", dt.weekday().num_days_from_sunday() + 1);
             }
             FmtPart::PgDY => {
-                out.push_str(&dt.format("%a").to_string().to_uppercase());
+                // Abbreviated English weekday is ASCII-only, so to_ascii_uppercase suffices
+                // and avoids the locale-aware Unicode case-folding overhead of to_uppercase.
+                let mut s = dt.format("%a").to_string();
+                s.make_ascii_uppercase();
+                out.push_str(&s);
             }
         }
     }
@@ -742,7 +746,9 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
             continue;
         }
         // `DY` must be matched before bare `D` (longest-prefix). Neither is in TOKENS.
-        if bytes[i..].starts_with(b"DY") {
+        // Same trailing-alpha guard as `D` below so a future `DYY`-style token doesn't
+        // get greedily consumed as `DY` + leftover `Y`.
+        if bytes[i..].starts_with(b"DY") && !bytes.get(i + 2).is_some_and(|b| b.is_ascii_alphabetic()) {
             flush(&mut parts, &mut buf);
             parts.push(FmtPart::PgDY);
             i += 2;
@@ -1877,6 +1883,11 @@ mod tests {
             let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
             assert_eq!(col.value(0), *expected, "format `{fmt}`");
         }
+        // Separate PM-timestamp case to actually exercise the PM output of %p.
+        let pm_sql = "SELECT to_char(TIMESTAMP '2026-06-10 20:10:52', 'HH12:MI PM') AS s";
+        let pm_batches = ctx.sql(pm_sql).await.unwrap().collect().await.unwrap();
+        let pm_col = pm_batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
+        assert_eq!(pm_col.value(0), "08:10 PM");
     }
 
     #[test]

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -756,7 +756,8 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
         }
         if bytes[i] == b'D' && !bytes.get(i + 1).is_some_and(|b| b.is_ascii_alphabetic()) {
             // Bare `D` only — guarded so `D<letter>` (e.g. a future token starting with D)
-            // doesn't get consumed here. `Day`, `Dy`, `DD` are caught by TOKENS / DY above.
+            // doesn't get consumed here. `Day`, `Dy`, `DD` are caught by TOKENS; `DY` is
+            // caught by its own check above.
             flush(&mut parts, &mut buf);
             parts.push(FmtPart::PgD);
             i += 1;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -675,6 +675,7 @@ fn render_pg_format(parts: &[FmtPart], dt: &DateTime<Utc>) -> String {
 fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
     // (Postgres token, chrono spec). Longest-prefix wins, so order matters within
     // groups that share a prefix (HH24 before HH, Month before Mon before MM, etc.).
+    // Note: `D` and `DY` are handled below as PgD / PgDY (no chrono equivalent), not here.
     const TOKENS: &[(&str, &str)] = &[
         ("YYYY", "%Y"),
         ("YY", "%y"),
@@ -699,6 +700,7 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
         ("SS", "%S"),
         ("US", "%6f"),
         ("MS", "%3f"),
+        // Our timestamps are stored UTC, so `TZ` always renders as "UTC".
         ("TZ", "%Z"),
         ("AM", "%p"),
         ("PM", "%p"),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -673,9 +673,11 @@ fn render_pg_format(parts: &[FmtPart], dt: &DateTime<Utc>) -> String {
 /// rare numeric tokens, locale-affected text tokens. Add to `TOKENS` (or as new
 /// `FmtPart` variants for cases with no chrono equivalent) when a caller needs them.
 fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
-    // (Postgres token, chrono spec). Longest-prefix wins, so order matters within
-    // groups that share a prefix (HH24 before HH, Month before Mon before MM, etc.).
-    // Note: `D` and `DY` are handled below as PgD / PgDY (no chrono equivalent), not here.
+    // ORDER IS LOAD-BEARING: every entry must come before any entry that is one of its
+    // prefixes. E.g. YYYY before YY, HH24/HH12 before HH, Month before Mon before MM.
+    // The loop below uses linear `find` so a misordering would silently match the
+    // shorter token first. Note: `D` and `DY` are handled below as PgD / PgDY (no
+    // chrono equivalent), not here.
     const TOKENS: &[(&str, &str)] = &[
         ("YYYY", "%Y"),
         ("YY", "%y"),
@@ -760,7 +762,9 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
             i += 2;
             continue;
         }
-        if bytes[i] == b'D' && !bytes.get(i + 1).is_some_and(|b| b.is_ascii_alphabetic()) {
+        // Alphanumeric guard (vs just alpha) so a future `D1`-style token can't be
+        // greedily consumed as bare `D` + leftover `1` before getting added to TOKENS.
+        if bytes[i] == b'D' && !bytes.get(i + 1).is_some_and(|b| b.is_ascii_alphanumeric()) {
             // Bare `D` only — guarded so `D<letter>` (e.g. a future token starting with D)
             // doesn't get consumed here. `Day`, `Dy`, `DD` are caught by TOKENS; `DY` is
             // caught by its own check above.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -650,6 +650,24 @@ fn render_pg_format(parts: &[FmtPart], dt: &DateTime<Utc>) -> String {
 /// Honors Postgres literal-escape syntax: text inside `"..."` is copied verbatim
 /// (with `""` standing for a literal `"`). Outside literals, the longest matching
 /// token is replaced with its chrono equivalent.
+///
+/// **Known divergences from real Postgres** (intentional):
+/// - `Month` / `Day` output is unpadded; real Postgres pads to 9 chars. E2E
+///   callers rely on the unpadded form. Re-add padding behind a custom
+///   formatter only if a caller asks.
+/// - Token matching is case-sensitive. Real Postgres `to_char` is case-insensitive
+///   (e.g. `yyyy == YYYY`). Has been true since the original chained-replace
+///   implementation; not a regression.
+/// - Unterminated `"..."` literals are accepted (the remainder is copied
+///   verbatim). Real Postgres errors. Lenient behaviour matches the
+///   chained-replace predecessor.
+/// - `HH` aliases `HH12` (12-hour clock with leading zero), matching Postgres.
+///   Do not "fix" it to `%H` — Postgres `HH` is *not* `HH24`.
+///
+/// **Not yet implemented** (silently pass through as literal text — same as the
+/// chained-replace predecessor): `Q`, `WW`, `IW`, `CC`, `J`, `OF`, `TZH`, `TZM`,
+/// rare numeric tokens, locale-affected text tokens. Add to `TOKENS` (or as new
+/// `FmtPart` variants for cases with no chrono equivalent) when a caller needs them.
 fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
     // (Postgres token, chrono spec). Longest-prefix wins, so order matters within
     // groups that share a prefix (HH24 before HH, Month before Mon before MM, etc.).

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -628,8 +628,12 @@ fn postgres_to_chrono_format(pg_format: &str) -> String {
         ("DD", "%d"),
         ("Day", "%A"),
         ("Dy", "%a"),
-        ("DY", "%a"),
-        ("D", "%u"),
+        // Omitted on purpose; their chrono mappings don't match Postgres semantics:
+        //   `DY` → Postgres emits uppercase ("WED"), chrono `%a` is title-case ("Wed").
+        //   `D`  → Postgres day-of-week is Sun=1..Sat=7; chrono `%u` is Mon=1..Sun=7 and
+        //          `%w` is Sun=0..Sat=6. No exact chrono token exists.
+        // Re-add with a custom formatter (uppercase post-processing / weekday renumbering)
+        // when a caller actually needs them.
         ("HH24", "%H"),
         ("HH12", "%I"),
         ("HH", "%I"),
@@ -1771,20 +1775,6 @@ mod tests {
             let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
             assert_eq!(col.value(0), *expected, "format `{fmt}`");
         }
-    }
-
-    #[tokio::test]
-    async fn test_to_char_udf_iso8601_with_z() {
-        use datafusion::prelude::SessionContext;
-        let mut ctx = SessionContext::new();
-        register_custom_functions(&mut ctx).unwrap();
-        let df = ctx
-            .sql(r#"SELECT to_char(TIMESTAMP '2026-06-10 08:10:52.422355', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS s"#)
-            .await
-            .unwrap();
-        let batches = df.collect().await.unwrap();
-        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
-        assert_eq!(col.value(0), "2026-06-10T08:10:52.422355Z");
     }
 
     #[test]

--- a/tests/slt/json_functions.slt
+++ b/tests/slt/json_functions.slt
@@ -195,6 +195,18 @@ SELECT json_build_array(id, name, duration) FROM otel_logs_and_spans WHERE proje
 ----
 ["00000000-0000-0000-0000-000000000001","test_span",1500]
 
+# Test jsonb_build_array alias (monoscope row-wrap idiom replacement)
+query T
+SELECT jsonb_build_array(id, name, duration) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1
+----
+["00000000-0000-0000-0000-000000000001","test_span",1500]
+
+# Derived-column-alias form used by monoscope's wrapper: SELECT jsonb_build_array(c1, c2, ...) FROM (<inner>) sub(c1, c2, ...)
+query T
+SELECT jsonb_build_array(c1, c2, c3) FROM (SELECT id, name, duration FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1) sub(c1, c2, c3)
+----
+["00000000-0000-0000-0000-000000000001","test_span",1500]
+
 # Test to_json function
 query T
 SELECT to_json(summary) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1


### PR DESCRIPTION
## Summary

Two additive function-layer changes bundled together:

- **`jsonb_build_array` alias on `JsonBuildArrayUDF`** — Postgres distinguishes `json_build_array` (returns `json`) from `jsonb_build_array` (returns `jsonb`); TimeFusion stores both as `Utf8View` so the alias is a no-op semantically. Unblocks the monoscope log-explorer row-extraction wrapper, which can now emit `SELECT jsonb_build_array(c1,…,cN) FROM (<inner>) sub(c1,…,cN)` instead of the legacy `json_each(row_to_json(*)) WITH ORDINALITY` idiom — no UDTF / lateral / `WITH ORDINALITY` required on the DataFusion side.
- **`postgres_to_chrono_format` rewritten** to honor Postgres quoted-literal segments (e.g. `"T"` should stay a literal `T`, not be re-interpreted as a chrono spec). The tokenizer is now a single longest-prefix scan over a `TOKEN` table instead of chained `String::replace` calls. Existing `database.rs` test updated to the Postgres-style spec.

The monoscope counterpart PR rewrites `executeArbitraryQuery` to use this alias.

## Test plan

- [x] `cargo test --test sqllogictest run_sqllogictest` (covers new alias and derived-column-alias wrapper-form SLT cases in `tests/slt/json_functions.slt`).
- [ ] Manual: run the original failing log-explorer query against a dev TF instance with the monoscope companion PR applied.