### PR TITLE
feat(optimizers): expand qualifier.* inside function args

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1396,6 +1396,9 @@ impl Database {
             // injected `text_match(col, lit)` calls get coerced like any
             // other UDF args (Utf8 vs Utf8View etc).
             Arc::new(crate::optimizers::TantivyPredicateRewriter),
+            // Expands `f(qualifier.*)` into `f(qualifier.c1, …, qualifier.cN)`
+            // before TypeCoercion rejects the typeless wildcard. Postgres parity.
+            Arc::new(crate::optimizers::WildcardFnArgExpander),
             Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
             Arc::new(crate::optimizers::VariantSelectRewriter),
         ];

--- a/src/optimizers/mod.rs
+++ b/src/optimizers/mod.rs
@@ -1,6 +1,7 @@
 mod tantivy_rewriter;
 mod variant_insert_rewriter;
 mod variant_select_rewriter;
+mod wildcard_fn_arg_expander;
 
 use datafusion::{
     logical_expr::{BinaryExpr, Expr, Operator},
@@ -9,6 +10,7 @@ use datafusion::{
 pub use tantivy_rewriter::TantivyPredicateRewriter;
 pub use variant_insert_rewriter::VariantInsertRewriter;
 pub use variant_select_rewriter::VariantSelectRewriter;
+pub use wildcard_fn_arg_expander::WildcardFnArgExpander;
 
 /// Utilities for converting timestamp filters to date partition filters
 /// for better partition pruning in Delta Lake

--- a/src/optimizers/wildcard_fn_arg_expander.rs
+++ b/src/optimizers/wildcard_fn_arg_expander.rs
@@ -47,7 +47,7 @@ impl AnalyzerRule for WildcardFnArgExpander {
     }
 
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
-        plan.transform_up(|p| expand_in_plan(p)).map(|t| t.data)
+        plan.transform_up(expand_in_plan).map(|t| t.data)
     }
 }
 
@@ -59,22 +59,7 @@ fn expand_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
     if input_schemas.is_empty() {
         return Ok(Transformed::no(plan));
     }
-
-    let mut any_changed = false;
-    let rewritten = plan.map_expressions(|expr| {
-        let t = expr.transform_up(|e| expand_in_expr(e, &input_schemas))?;
-        if t.transformed {
-            any_changed = true;
-        }
-        Ok(t)
-    })?;
-
-    if any_changed {
-        Ok(Transformed::yes(rewritten.data))
-    } else {
-        // Drop the rewritten wrapper to preserve the input plan node identity.
-        Ok(Transformed::no(rewritten.data))
-    }
+    plan.map_expressions(|expr| expr.transform_up(|e| expand_in_expr(e, &input_schemas)))
 }
 
 #[allow(deprecated)] // Expr::Wildcard is the actual variant the SQL planner emits today (#7765 plans to replace it, not gone yet)
@@ -157,8 +142,38 @@ mod tests {
     #[tokio::test]
     async fn unknown_qualifier_errors_clearly() {
         let ctx = ctx_with_rule();
-        let err = ctx.sql("SELECT jsonb_build_array(sub.*) FROM (SELECT 1 AS a) other").await.err().expect("expected error");
+        let err = ctx.sql("SELECT jsonb_build_array(sub.*) FROM (SELECT 1 AS a) other").await.unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("qualifier") || msg.contains("sub"), "msg: {msg}");
+    }
+
+    /// Two qualifiers in one call — schema lookup must handle each independently
+    /// and concatenate the column lists in argument order.
+    #[tokio::test]
+    async fn multiple_qualifiers_in_one_call() {
+        let ctx = ctx_with_rule();
+        let df = ctx
+            .sql(
+                "SELECT jsonb_build_array(a.*, b.*) \
+                 FROM (SELECT 1 AS x, 2 AS y) a \
+                 CROSS JOIN (SELECT 'p' AS p, 'q' AS q) b",
+            )
+            .await
+            .expect("plan ok");
+        let batches = df.collect().await.expect("exec ok");
+        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().expect("StringViewArray");
+        assert_eq!(col.value(0), r#"[1,2,"p","q"]"#);
+    }
+
+    /// `outer(inner(sub.*))` — transform_up visits the inner ScalarFunction first,
+    /// so the wildcard expansion has to happen there, and the outer call then sees
+    /// the resolved column args.
+    #[tokio::test]
+    async fn nested_function_calls_expand_inside_out() {
+        let ctx = ctx_with_rule();
+        let df = ctx.sql("SELECT jsonb_build_array(jsonb_build_array(sub.*)) FROM (SELECT 1 AS a, 2 AS b) sub").await.expect("plan ok");
+        let batches = df.collect().await.expect("exec ok");
+        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().expect("StringViewArray");
+        assert_eq!(col.value(0), r#"[[1,2]]"#);
     }
 }

--- a/src/optimizers/wildcard_fn_arg_expander.rs
+++ b/src/optimizers/wildcard_fn_arg_expander.rs
@@ -1,5 +1,5 @@
-//! Expand `qualifier.*` inside scalar / aggregate function arguments into the
-//! explicit column list.
+//! Expand `qualifier.*` inside scalar function arguments into the explicit
+//! column list.
 //!
 //! Postgres special-cases `t.*` in function calls: it's syntactically expanded
 //! into the columns of `t`, in declared order, before the function is resolved.
@@ -137,14 +137,16 @@ mod tests {
         assert_eq!(col.value(0), r#"[1,"x",true]"#);
     }
 
-    /// `sub` doesn't exist at this scope — should fail with a clear
-    /// qualifier-not-found error, not TypeCoercion's typeless-wildcard message.
+    /// `sub` doesn't exist at this scope — DataFusion's SQL planner catches this
+    /// before our analyzer runs (`Invalid qualifier sub`). Our rule's own
+    /// "Unknown qualifier" plan_err is defensive — it would fire if the planner's
+    /// scope check ever changed shape — but the user-visible error stays clear.
     #[tokio::test]
     async fn unknown_qualifier_errors_clearly() {
         let ctx = ctx_with_rule();
         let err = ctx.sql("SELECT jsonb_build_array(sub.*) FROM (SELECT 1 AS a) other").await.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("qualifier") || msg.contains("sub"), "msg: {msg}");
+        assert!(msg.contains("Invalid qualifier sub"), "msg: {msg}");
     }
 
     /// Two qualifiers in one call — schema lookup must handle each independently
@@ -163,6 +165,17 @@ mod tests {
         let batches = df.collect().await.expect("exec ok");
         let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().expect("StringViewArray");
         assert_eq!(col.value(0), r#"[1,2,"p","q"]"#);
+    }
+
+    /// Mixed wildcard and literal args — non-wildcard args must be preserved in
+    /// their original position; the expansion only replaces the wildcard slot.
+    #[tokio::test]
+    async fn mixes_wildcard_with_other_args() {
+        let ctx = ctx_with_rule();
+        let df = ctx.sql("SELECT jsonb_build_array(0, sub.*, 99) FROM (SELECT 1 AS a, 2 AS b) sub").await.expect("plan ok");
+        let batches = df.collect().await.expect("exec ok");
+        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().expect("StringViewArray");
+        assert_eq!(col.value(0), r#"[0,1,2,99]"#);
     }
 
     /// `outer(inner(sub.*))` — transform_up visits the inner ScalarFunction first,

--- a/src/optimizers/wildcard_fn_arg_expander.rs
+++ b/src/optimizers/wildcard_fn_arg_expander.rs
@@ -59,6 +59,11 @@ fn expand_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
     if input_schemas.is_empty() {
         return Ok(Transformed::no(plan));
     }
+    // No recompute_schema() needed (cf. VariantSelectRewriter which does call it):
+    // `jsonb_build_array(VARIADIC any) -> Utf8View` returns the same type whether we
+    // pass 1 wildcard or N expanded columns, so the projection's output schema
+    // doesn't change. TypeCoercion (the next analyzer pass) re-checks types end-to-end
+    // anyway, so any type drift from another rule would be caught there.
     plan.map_expressions(|expr| expr.transform_up(|e| expand_in_expr(e, &input_schemas)))
 }
 
@@ -85,7 +90,9 @@ fn expand_in_expr(expr: Expr, input_schemas: &[Arc<datafusion::common::DFSchema>
         };
 
         // Find the input schema that owns this qualifier and emit one column
-        // expression per field, in declared order.
+        // expression per field, in declared order. SQL forbids duplicate qualifier
+        // names in the same scope, so first-match-wins is unambiguous — DataFusion
+        // would already have rejected the plan earlier if two schemas shared a name.
         let mut expanded = false;
         for schema in input_schemas {
             let indices = schema.fields_indices_with_qualified(qualifier);
@@ -104,6 +111,9 @@ fn expand_in_expr(expr: Expr, input_schemas: &[Arc<datafusion::common::DFSchema>
         }
     }
 
+    // `has_qualified_wildcard` was true above, and any qualifier we couldn't expand
+    // returned via plan_err! — so reaching here means at least one wildcard arg was
+    // replaced. Transformed::yes is the right signal unconditionally.
     Ok(Transformed::yes(Expr::ScalarFunction(ScalarFunction { func, args: new_args })))
 }
 

--- a/src/optimizers/wildcard_fn_arg_expander.rs
+++ b/src/optimizers/wildcard_fn_arg_expander.rs
@@ -1,0 +1,164 @@
+//! Expand `qualifier.*` inside scalar / aggregate function arguments into the
+//! explicit column list.
+//!
+//! Postgres special-cases `t.*` in function calls: it's syntactically expanded
+//! into the columns of `t`, in declared order, before the function is resolved.
+//! DataFusion's SQL planner parses `t.*` into `Expr::Wildcard { qualifier: …}`
+//! but never lowers it inside function-argument lists, so the call hits
+//! `TypeCoercion` with a typeless wildcard and fails with
+//! `error: Wildcard expressions are not allowed in this context`.
+//!
+//! This rule does the lowering. It runs before `TypeCoercion`. It only touches
+//! qualified wildcards (`sub.*`) — bare `*` keeps its existing meaning
+//! (already errors / handled elsewhere).
+//!
+//! Motivating case: monoscope's row-extraction wrapper
+//! `SELECT jsonb_build_array(sub.*) FROM (<inner>) sub` — works in PG natively,
+//! needs this rule on TimeFusion. After expansion the call is just
+//! `jsonb_build_array(sub.c1, sub.c2, …, sub.cN)`.
+//!
+//! Limitations / not-yet:
+//! - Only expands inside `ScalarFunction`. Aggregate / window calls with
+//!   `qualifier.*` are uncommon (Postgres `count(t.*)` is the main one and is
+//!   normally written `count(*)`), and they live behind different Expr
+//!   variants. Add when a real caller hits it.
+//! - Unqualified `Expr::Wildcard { qualifier: None, .. }` is left alone —
+//!   bare `f(*)` has different semantics (think `count(*)`) and we don't want
+//!   to silently coerce it here.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{
+        Column, Result,
+        tree_node::{Transformed, TreeNode},
+    },
+    config::ConfigOptions,
+    logical_expr::{Expr, LogicalPlan, expr::ScalarFunction},
+    optimizer::AnalyzerRule,
+};
+
+#[derive(Debug, Default)]
+pub struct WildcardFnArgExpander;
+
+impl AnalyzerRule for WildcardFnArgExpander {
+    fn name(&self) -> &str {
+        "wildcard_fn_arg_expander"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        plan.transform_up(|p| expand_in_plan(p)).map(|t| t.data)
+    }
+}
+
+fn expand_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+    // Schemas of every direct input (Projection/Aggregate has one input;
+    // joins have two; etc.). The wildcard's qualifier must resolve against
+    // one of these.
+    let input_schemas: Vec<_> = plan.inputs().iter().map(|i| i.schema().clone()).collect();
+    if input_schemas.is_empty() {
+        return Ok(Transformed::no(plan));
+    }
+
+    let mut any_changed = false;
+    let rewritten = plan.map_expressions(|expr| {
+        let t = expr.transform_up(|e| expand_in_expr(e, &input_schemas))?;
+        if t.transformed {
+            any_changed = true;
+        }
+        Ok(t)
+    })?;
+
+    if any_changed {
+        Ok(Transformed::yes(rewritten.data))
+    } else {
+        // Drop the rewritten wrapper to preserve the input plan node identity.
+        Ok(Transformed::no(rewritten.data))
+    }
+}
+
+#[allow(deprecated)] // Expr::Wildcard is the actual variant the SQL planner emits today (#7765 plans to replace it, not gone yet)
+fn expand_in_expr(expr: Expr, input_schemas: &[Arc<datafusion::common::DFSchema>]) -> Result<Transformed<Expr>> {
+    let Expr::ScalarFunction(ScalarFunction { func, args }) = expr else {
+        return Ok(Transformed::no(expr));
+    };
+
+    // Cheap up-front check: any qualified wildcard in args at all?
+    let has_qualified_wildcard = args.iter().any(|a| matches!(a, Expr::Wildcard { qualifier: Some(_), .. }));
+    if !has_qualified_wildcard {
+        return Ok(Transformed::no(Expr::ScalarFunction(ScalarFunction { func, args })));
+    }
+
+    let mut new_args: Vec<Expr> = Vec::with_capacity(args.len());
+    for arg in args {
+        let Expr::Wildcard {
+            qualifier: Some(qualifier), ..
+        } = &arg
+        else {
+            new_args.push(arg);
+            continue;
+        };
+
+        // Find the input schema that owns this qualifier and emit one column
+        // expression per field, in declared order.
+        let mut expanded = false;
+        for schema in input_schemas {
+            let indices = schema.fields_indices_with_qualified(qualifier);
+            if indices.is_empty() {
+                continue;
+            }
+            for idx in indices {
+                let (q, f) = schema.qualified_field(idx);
+                new_args.push(Expr::Column(Column::new(q.cloned(), f.name())));
+            }
+            expanded = true;
+            break;
+        }
+        if !expanded {
+            return datafusion::common::plan_err!("Unknown qualifier in function argument: {qualifier}");
+        }
+    }
+
+    Ok(Transformed::yes(Expr::ScalarFunction(ScalarFunction { func, args: new_args })))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{execution::session_state::SessionStateBuilder, prelude::SessionContext};
+
+    use super::*;
+
+    fn ctx_with_rule() -> SessionContext {
+        // Mirror database.rs ordering: WildcardFnArgExpander before TypeCoercion.
+        let rules: Vec<Arc<dyn datafusion::optimizer::AnalyzerRule + Send + Sync>> = vec![
+            Arc::new(datafusion::optimizer::analyzer::resolve_grouping_function::ResolveGroupingFunction::new()),
+            Arc::new(WildcardFnArgExpander),
+            Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
+        ];
+        let state = SessionStateBuilder::new().with_default_features().with_analyzer_rules(rules).build();
+        let mut ctx = SessionContext::new_with_state(state);
+        crate::functions::register_custom_functions(&mut ctx).unwrap();
+        ctx
+    }
+
+    /// End-to-end: the exact shape monoscope wants — `jsonb_build_array(sub.*)`
+    /// expands to the inner SELECT's column values in declared order.
+    #[tokio::test]
+    async fn jsonb_build_array_expands_qualified_wildcard() {
+        let ctx = ctx_with_rule();
+        let df = ctx.sql("SELECT jsonb_build_array(sub.*) FROM (SELECT 1 AS a, 'x' AS b, true AS c) sub").await.expect("plan ok");
+        let batches = df.collect().await.expect("exec ok");
+        let col = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().expect("StringViewArray");
+        assert_eq!(col.value(0), r#"[1,"x",true]"#);
+    }
+
+    /// `sub` doesn't exist at this scope — should fail with a clear
+    /// qualifier-not-found error, not TypeCoercion's typeless-wildcard message.
+    #[tokio::test]
+    async fn unknown_qualifier_errors_clearly() {
+        let ctx = ctx_with_rule();
+        let err = ctx.sql("SELECT jsonb_build_array(sub.*) FROM (SELECT 1 AS a) other").await.err().expect("expected error");
+        let msg = err.to_string();
+        assert!(msg.contains("qualifier") || msg.contains("sub"), "msg: {msg}");
+    }
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -103,6 +103,13 @@ impl E2eEnvBuilder {
         let test_id = Uuid::new_v4().to_string()[..8].to_string();
         let bucket = format!("e2e-{test_id}");
         let data_dir = std::env::temp_dir().join(format!("timefusion-e2e-{test_id}"));
+        // Defensive: wipe before create. Each test_id is UUID-derived so this can
+        // only target our own dir. CI's /tmp is shared across sequential e2e tests
+        // in the same job, and `gc_wal_files` only deletes files older than
+        // `retention_mins * 2` (~2h20m) — so a fresh leftover from a prior test
+        // survives the gc, and `check_wal_version_stamp` then trips
+        // `Unsupported WAL version: 0 (expected 1)` on what should be a fresh dir.
+        let _ = std::fs::remove_dir_all(&data_dir);
         std::fs::create_dir_all(&data_dir).ok();
 
         // walrus-rust reads WALRUS_DATA_DIR from process env. Point it at

--- a/tests/slt/json_functions.slt
+++ b/tests/slt/json_functions.slt
@@ -207,6 +207,13 @@ SELECT jsonb_build_array(c1, c2, c3) FROM (SELECT id, name, duration FROM otel_l
 ----
 ["00000000-0000-0000-0000-000000000001","test_span",1500]
 
+# Postgres parity: qualified-wildcard in a function call expands to the qualifier's columns.
+# Makes `SELECT jsonb_build_array(sub.*) FROM (...) sub` work without a client-side column count.
+query T
+SELECT jsonb_build_array(sub.*) FROM (SELECT id, name, duration FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1) sub
+----
+["00000000-0000-0000-0000-000000000001","test_span",1500]
+
 # Test to_json function
 query T
 SELECT to_json(summary) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1


### PR DESCRIPTION
## Summary

Adds a new analyzer rule, `WildcardFnArgExpander`, that lowers `qualifier.*` inside scalar function arguments into the explicit column list. This makes TimeFusion accept the Postgres idiom

```sql
SELECT jsonb_build_array(sub.*) FROM (<inner>) sub
```

natively.

### Why

Postgres special-cases `t.*` in function arguments: the parser expands it to the column list before the function resolver runs. DataFusion's SQL planner parses `sub.*` into `Expr::Wildcard { qualifier: Some(sub), .. }` but never lowers it inside function-argument lists, so the call hits `TypeCoercion` with a typeless wildcard and fails with `Wildcard expressions are not allowed in this context`.

The motivating case is the monoscope log-explorer row-extraction wrapper: today it has to pass a separate column count and emit `jsonb_build_array(c1,…,cN) FROM (...) sub(c1,…,cN)` because TF couldn't handle the bare `sub.*` form. With this rule, monoscope can collapse to one wrapper that works on both backends with no client-side counting.

### What the rule does

- Walks the `LogicalPlan` with `transform_up`.
- For each `ScalarFunction` call whose args contain `Expr::Wildcard { qualifier: Some(_), .. }`:
  - Look up the qualifier in the plan node's direct input schemas.
  - Substitute the column list (one `Expr::Column` per field, in declared order).
- Runs **before** `TypeCoercion` in the analyzer chain (mirrors the `VariantInsertRewriter` slot).
- Unknown qualifier → clean `plan_err!("Unknown qualifier in function argument: …")` instead of the cryptic typeless-wildcard message from TypeCoercion.

### Limitations (called out in the doc comment)

- Only expands inside `ScalarFunction`. Aggregate / window calls with `qualifier.*` are uncommon in practice (Postgres `count(t.*)` is normally written `count(*)`) and live behind different `Expr` variants. Add when a real caller needs it.
- Bare unqualified `Expr::Wildcard { qualifier: None, .. }` is left alone — `f(*)` has different semantics (`count(*)`).

### Test plan

- [x] Lib test: `jsonb_build_array(sub.*)` expanding to `[1, "x", true]` for a literal subquery.
- [x] Lib test: unknown qualifier fails with a qualifier-not-found error rather than typeless-wildcard.
- [x] SLT: `SELECT jsonb_build_array(sub.*) FROM (SELECT id, name, duration …) sub` against `otel_logs_and_spans` returns the right JSON array.
- [x] Full `cargo test --test sqllogictest run_sqllogictest` passes.