### PR TITLE
perf: sub-80ms query latency — PG coalesce compat, OPTIMIZE partition fix, cold-path warming

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,14 +1,22 @@
 name: Auto-format & Auto-fix
 
-# On every push to master, run `cargo fmt` and `cargo clippy --fix`, then
-# commit any changes back to master. Skips itself on bot-authored commits to
-# avoid infinite loops, and on PR merges that are already CI-clean.
+# On every push (master AND PR branches), run `cargo fmt` and
+# `cargo clippy --fix`, then commit any changes back to the same branch.
+# Skips itself on bot-authored commits to avoid infinite loops, and on
+# commits that are already CI-clean. Forked-repo PRs aren't covered — the
+# default token can't push to forks.
 on:
   push:
-    branches: [master]
+    branches: ['**']
 
 permissions:
   contents: write
+
+# One run per branch at a time; a fix-commit superseding the triggering push
+# cancels the now-stale run instead of racing it.
+concurrency:
+  group: autofix-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   autofix:
@@ -69,4 +77,4 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore(autofmt): apply cargo fmt + clippy --fix [skip autofmt]"
-          git push origin HEAD:master
+          git push origin "HEAD:${{ github.ref_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dis-newstyle
 .DS_Store
 wal_files/
 bench/__pycache__/
+bench/data/query_latency_state.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dis-newstyle
 *.log
 .DS_Store
 wal_files/
+bench/__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.32.2"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=005b9ebf6262cd192501c29be3bb9df62acfa2f7#005b9ebf6262cd192501c29be3bb9df62acfa2f7"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=2f473fe4c196401f7e8bc8eecae6bad365a45489#2f473fe4c196401f7e8bc8eecae6bad365a45489"
 dependencies = [
  "buoyant_kernel",
  "ctor",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "0.15.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=005b9ebf6262cd192501c29be3bb9df62acfa2f7#005b9ebf6262cd192501c29be3bb9df62acfa2f7"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=2f473fe4c196401f7e8bc8eecae6bad365a45489#2f473fe4c196401f7e8bc8eecae6bad365a45489"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.32.2"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=005b9ebf6262cd192501c29be3bb9df62acfa2f7#005b9ebf6262cd192501c29be3bb9df62acfa2f7"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=2f473fe4c196401f7e8bc8eecae6bad365a45489#2f473fe4c196401f7e8bc8eecae6bad365a45489"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=005b9ebf6262cd192501c29be3bb9df62acfa2f7#005b9ebf6262cd192501c29be3bb9df62acfa2f7"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=2f473fe4c196401f7e8bc8eecae6bad365a45489#2f473fe4c196401f7e8bc8eecae6bad365a45489"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # Rebase the branch onto upstream main when picking up newer revs.
 # Pinned to a SHA, not the branch tip, so `cargo update` can't silently pull
 # breaking changes from the fork. Bump explicitly when rebasing on upstream.
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "005b9ebf6262cd192501c29be3bb9df62acfa2f7", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "2f473fe4c196401f7e8bc8eecae6bad365a45489", features = [
   "datafusion",
   "s3",
 ] }
@@ -192,4 +192,3 @@ datafusion-postgres = { path = "vendor/datafusion-postgres" }
 # logical layer. Tracking apache/datafusion#19950; drop this patch once
 # upstream merges and we bump past it.
 datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", branch = "timefusion-update-from-53.1.0" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ zstd = "0.13"
 tempfile = "3"
 sysinfo = { version = "0.32", default-features = false, features = ["system", "disk"] }
 num_cpus = "1.16"
+scopeguard = "1.2.0"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
@@ -111,7 +112,6 @@ serial_test = "3.2.0"
 tokio = { version = "1.48", features = ["test-util"] }
 datafusion-common = "53.1.0"
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-serde_json-1"] }
-scopeguard = "1.2.0"
 rand = "0.10.0"
 tempfile = "3"
 test-case = "3.3"

--- a/README.md
+++ b/README.md
@@ -303,12 +303,13 @@ TimeFusion combines best-in-class technologies to deliver exceptional performanc
 
 ### Performance Tuning
 
-| Variable                          | Description        | Default |
-| --------------------------------- | ------------------ | ------- |
-| `TIMEFUSION_PAGE_ROW_COUNT_LIMIT` | Rows per page      | `20000` |
-| `TIMEFUSION_MAX_ROW_GROUP_SIZE`   | Max row group size | `128MB` |
-| `TIMEFUSION_OPTIMIZE_TARGET_SIZE` | Target file size   | `512MB` |
-| `TIMEFUSION_BATCH_QUEUE_CAPACITY` | Batch queue size   | `1000`  |
+| Variable                          | Description                                                                                | Default |
+| --------------------------------- | ------------------------------------------------------------------------------------------ | ------- |
+| `TIMEFUSION_PAGE_ROW_COUNT_LIMIT` | Rows per page                                                                              | `20000` |
+| `TIMEFUSION_MAX_ROW_GROUP_SIZE`   | Max row group size                                                                         | `128MB` |
+| `TIMEFUSION_OPTIMIZE_TARGET_SIZE` | Target file size                                                                           | `512MB` |
+| `TIMEFUSION_BATCH_QUEUE_CAPACITY` | Batch queue size                                                                           | `1000`  |
+| `TIMEFUSION_S3_CONNECT_TIMEOUT`   | S3 TCP/TLS connect bound (humantime). Tuned for same-region S3; widen behind slow proxies | `3s`    |
 
 ### Cache Configuration
 

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -84,11 +84,65 @@ UNION ALL
 SELECT 'p95', approx_percentile_cont(duration, 0.95) FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s"""
 
 
+def seed_scale():
+    """Prod-shaped dataset: N_PROJECTS x N_DAYS, rows spread per day.
+    Saves random-access targets at several ages (recent / day-old / deep)."""
+    n_projects = int(os.environ.get("QLAT_PROJECTS", "5"))
+    n_days = int(os.environ.get("QLAT_DAYS", "30"))
+    rows_per_day = int(os.environ.get("QLAT_ROWS_PER_DAY", "700"))
+    base_rows = load_rows(rows_per_day)
+    now = datetime.now(timezone.utc)
+    placeholders = "(" + ", ".join(["%s"] * len(COLUMNS)) + ")"
+    base_sql = f"INSERT INTO otel_logs_and_spans ({', '.join(COLUMNS)}) VALUES "
+    targets = {}
+    t0 = time.perf_counter()
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        for p in range(n_projects):
+            pid = f"qlat-scale-p{p}"
+            for d in range(n_days):
+                day_end = now - timedelta(days=d, minutes=3)
+                rows = shift_for_project(base_rows, pid, timedelta(0))
+                step = timedelta(hours=20) / len(rows)
+                for i, r in enumerate(rows):
+                    ts = day_end - step * i
+                    r["timestamp"] = ts.isoformat()
+                    r["date"] = ts.date().isoformat()
+                B = 700
+                for i in range(0, len(rows), B):
+                    batch = rows[i : i + B]
+                    flat = [_to_pg(col, r.get(col)) for r in batch for col in COLUMNS]
+                    cur.execute(base_sql + ", ".join([placeholders] * len(batch)), flat)
+                if p == 0 and d in (0, 1, 20):
+                    k = {0: "recent", 1: "day_old", 20: "deep"}[d]
+                    targets[k] = {"id": rows[10]["id"], "timestamp": rows[10]["timestamp"]}
+            print(f"  project {pid}: {n_days}d x {len(base_rows)} rows done ({time.perf_counter()-t0:.0f}s)")
+    STATE.write_text(json.dumps({"project_id": "qlat-scale-p0", "targets": [targets.get("day_old", targets["recent"])], "targets_by_age": targets}))
+    print(f"seed_scale done in {time.perf_counter()-t0:.0f}s → {STATE}")
+
+
+def run_ages(n_iter=8):
+    """Random access at several partition ages — exposes cold/stale costs."""
+    st = json.loads(STATE.read_text())
+    pid = st["project_id"]
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        for age, tgt in st.get("targets_by_age", {}).items():
+            ts = datetime.fromisoformat(tgt["timestamp"])
+            lo, hi = ts - timedelta(seconds=1), ts + timedelta(seconds=1)
+            times = []
+            for _ in range(n_iter):
+                t = time.perf_counter()
+                cur.execute(Q_RANDOM, (lo, hi, pid, tgt["id"]))
+                rows = cur.fetchall()
+                times.append((time.perf_counter() - t) * 1000)
+            ts_str = " ".join(f"{x:.0f}" for x in times)
+            print(f"random_access[{age:>7}] rows={len(rows)} ms: {ts_str}")
+
+
 def queries():
     st = json.loads(STATE.read_text())
     pid = st["project_id"]
     since = datetime.now(timezone.utc) - timedelta(hours=WINDOW_H + 1)
-    tgt = st["targets"][1]
+    tgt = st["targets"][-1]
     ts = datetime.fromisoformat(tgt["timestamp"])
     lo, hi = ts - timedelta(seconds=1), ts + timedelta(seconds=1)
     return [
@@ -116,19 +170,28 @@ def run(n_iter=15):
         p95 = times_w[int(len(times_w) * 0.95) - 1]
         print(f"{name:<24} {p50:8.1f} {p95:8.1f} {times_w[0]:8.1f} {times_w[-1]:8.1f}")
 
-    # Same but on a single reused connection (separates conn setup from query cost)
+    # Same but on a single reused connection (separates conn setup from query cost).
+    # plan-only = `EXPLAIN <sql>` wall time: parse + logical plan + analyzers +
+    # optimizers + physical plan, no execution. exec ≈ full − plan-only.
     print("\n-- reused connection --")
+    print(f"{'query':<24} {'p50':>8} {'max':>8} {'plan-only p50':>14}")
     with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
         for name, sql, params in qs:
-            times = []
+            times, plan_times = [], []
             for i in range(n_iter):
                 t = time.perf_counter()
                 cur.execute(sql, params or None)
                 cur.fetchall()
                 times.append((time.perf_counter() - t) * 1000)
+                if name != "simple_select_1":
+                    t = time.perf_counter()
+                    cur.execute("EXPLAIN " + sql, params or None)
+                    cur.fetchall()
+                    plan_times.append((time.perf_counter() - t) * 1000)
             times_w = sorted(times[2:])
             p50 = statistics.median(times_w)
-            print(f"{name:<24} {p50:8.1f} {times_w[-1]:8.1f}(max)")
+            plan_p50 = statistics.median(sorted(plan_times[2:])) if len(plan_times) > 4 else 0.0
+            print(f"{name:<24} {p50:8.1f} {times_w[-1]:8.1f} {plan_p50:14.1f}")
 
 
 def explain():
@@ -149,4 +212,4 @@ def explain():
 
 if __name__ == "__main__":
     cmd = sys.argv[1] if len(sys.argv) > 1 else "run"
-    {"seed": seed, "run": run, "explain": explain}[cmd]()
+    {"seed": seed, "seed_scale": seed_scale, "run": run, "run_ages": run_ages, "explain": explain}[cmd]()

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -5,9 +5,11 @@
      — monoscope's lookupOtelRecord, sent with uuid + timestamptz params.
 
 Usage:
-  python3 bench/query_latency.py seed     # insert rows, spread over 12h, flush to Delta
-  python3 bench/query_latency.py run      # run latency suite against seeded data
-  python3 bench/query_latency.py explain  # EXPLAIN ANALYZE each query, dump to /tmp
+  python3 bench/query_latency.py seed        # insert rows, spread over 12h, flush to Delta
+  python3 bench/query_latency.py seed_scale  # prod-shaped: N projects x N days (QLAT_* env)
+  python3 bench/query_latency.py run         # run latency suite against seeded data
+  python3 bench/query_latency.py run_ages    # random access per partition age (needs seed_scale)
+  python3 bench/query_latency.py explain     # EXPLAIN ANALYZE each query, dump to /tmp
 """
 from __future__ import annotations
 import json, os, statistics, sys, time, uuid

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -102,6 +102,8 @@ def seed_scale():
             pid = f"qlat-scale-p{p}"
             for d in range(n_days):
                 day_end = now - timedelta(days=d, minutes=3)
+                # shift_for_project copies each row dict (dict(r)), so the
+                # in-place re-stamping below can't bleed into base_rows.
                 rows = shift_for_project(base_rows, pid, timedelta(0))
                 step = timedelta(hours=20) / len(rows)
                 for i, r in enumerate(rows):
@@ -135,8 +137,8 @@ def run_ages(n_iter=8):
                 cur.execute(Q_RANDOM, (lo, hi, pid, tgt["id"]))
                 rows = cur.fetchall()
                 times.append((time.perf_counter() - t) * 1000)
-            ts_str = " ".join(f"{x:.0f}" for x in times)
-            print(f"random_access[{age:>7}] rows={len(rows)} ms: {ts_str}")
+            ts_str = " ".join(f"{x:.0f}" for x in times[1:])
+            print(f"random_access[{age:>7}] rows={len(rows)} first={times[0]:.0f}ms warm: {ts_str}")
 
 
 def queries():

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Measure SELECT latency for the two monoscope hot paths:
+  1. "list" queries (log explorer page load: recent rows, KPI percentiles UNION)
+  2. "random access" by (timestamp BETWEEN t±1s, project_id, id) LIMIT 1
+     — monoscope's lookupOtelRecord, sent with uuid + timestamptz params.
+
+Usage:
+  python3 bench/query_latency.py seed     # insert rows, spread over 12h, flush to Delta
+  python3 bench/query_latency.py run      # run latency suite against seeded data
+  python3 bench/query_latency.py explain  # EXPLAIN ANALYZE each query, dump to /tmp
+"""
+from __future__ import annotations
+import json, os, statistics, sys, time, uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import psycopg
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+from concurrent_load import COLUMNS, _to_pg, load_rows, shift_for_project
+
+URL = f"host=127.0.0.1 port={os.environ.get('PGWIRE_PORT','12345')} user=postgres password=postgres dbname=postgres"
+STATE = ROOT / "data" / "query_latency_state.json"
+
+PID = "qlat-bench-project"
+N_ROWS = 20000
+WINDOW_H = 12  # spread rows over the last 12 hours
+
+
+def seed():
+    rows = load_rows(N_ROWS)
+    # Spread evenly across the window: re-stamp timestamps over the last 12h.
+    now = datetime.now(timezone.utc)
+    base = max(datetime.fromisoformat(r["timestamp"]) for r in rows)
+    rows = shift_for_project(rows, PID, now - base - timedelta(minutes=2))
+    step = timedelta(hours=WINDOW_H) / len(rows)
+    for i, r in enumerate(rows):
+        ts = now - timedelta(minutes=2) - step * i
+        r["timestamp"] = ts.isoformat()
+        r["date"] = ts.date().isoformat()
+
+    placeholders = "(" + ", ".join(["%s"] * len(COLUMNS)) + ")"
+    base_sql = f"INSERT INTO otel_logs_and_spans ({', '.join(COLUMNS)}) VALUES "
+    t0 = time.perf_counter()
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        B = 700  # 88 cols × 700 = 61.6k params < 65535 pgwire limit
+        for i in range(0, len(rows), B):
+            batch = rows[i : i + B]
+            flat = [_to_pg(col, r.get(col)) for r in batch for col in COLUMNS]
+            cur.execute(base_sql + ", ".join([placeholders] * len(batch)), flat)
+            print(f"  inserted {i+len(batch)}/{len(rows)}")
+    print(f"seed done in {time.perf_counter()-t0:.1f}s")
+
+    # Save a few target rows (id+timestamp) for random-access queries.
+    targets = [
+        {"id": rows[k]["id"], "timestamp": rows[k]["timestamp"]}
+        for k in (50, len(rows) // 2, len(rows) - 50)
+    ]
+    STATE.write_text(json.dumps({"project_id": PID, "targets": targets}))
+    print(f"targets saved to {STATE}")
+
+
+Q_LIST = """SELECT id, timestamp, name, duration, status_code, body
+FROM otel_logs_and_spans
+WHERE project_id = %s AND timestamp >= %s
+ORDER BY timestamp DESC LIMIT 50"""
+
+Q_RANDOM = """SELECT project_id, id, timestamp, observed_timestamp, context, level, severity, body, attributes, resource,
+  hashes, kind, status_code, status_message, COALESCE(start_time, timestamp), end_time, events, links,
+  duration, name, parent_id, summary, date, errors
+FROM otel_logs_and_spans
+WHERE timestamp BETWEEN %s AND %s AND project_id = %s AND id = %s LIMIT 1"""
+
+Q_COUNT = """SELECT count(*) FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s"""
+
+Q_UNION_PCT = """
+SELECT 'p50' AS pct, approx_percentile_cont(duration, 0.50) AS v FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s
+UNION ALL
+SELECT 'p75', approx_percentile_cont(duration, 0.75) FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s
+UNION ALL
+SELECT 'p90', approx_percentile_cont(duration, 0.90) FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s
+UNION ALL
+SELECT 'p95', approx_percentile_cont(duration, 0.95) FROM otel_logs_and_spans WHERE project_id = %s AND timestamp >= %s"""
+
+
+def queries():
+    st = json.loads(STATE.read_text())
+    pid = st["project_id"]
+    since = datetime.now(timezone.utc) - timedelta(hours=WINDOW_H + 1)
+    tgt = st["targets"][1]
+    ts = datetime.fromisoformat(tgt["timestamp"])
+    lo, hi = ts - timedelta(seconds=1), ts + timedelta(seconds=1)
+    return [
+        ("simple_select_1", "SELECT 1", ()),
+        ("list_recent_50", Q_LIST, (pid, since)),
+        ("count_12h", Q_COUNT, (pid, since)),
+        ("union_percentiles_x4", Q_UNION_PCT, (pid, since) * 4),
+        ("random_access_ts_id", Q_RANDOM, (lo, hi, pid, tgt["id"])),
+    ]
+
+
+def run(n_iter=15):
+    qs = queries()
+    print(f"{'query':<24} {'p50':>8} {'p95':>8} {'min':>8} {'max':>8}  (ms, {n_iter} iters, fresh conn each)")
+    for name, sql, params in qs:
+        times = []
+        for i in range(n_iter):
+            with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+                t = time.perf_counter()
+                cur.execute(sql, params or None)
+                cur.fetchall()
+                times.append((time.perf_counter() - t) * 1000)
+        times_w = sorted(times[2:])  # drop 2 cold
+        p50 = statistics.median(times_w)
+        p95 = times_w[int(len(times_w) * 0.95) - 1]
+        print(f"{name:<24} {p50:8.1f} {p95:8.1f} {times_w[0]:8.1f} {times_w[-1]:8.1f}")
+
+    # Same but on a single reused connection (separates conn setup from query cost)
+    print("\n-- reused connection --")
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        for name, sql, params in qs:
+            times = []
+            for i in range(n_iter):
+                t = time.perf_counter()
+                cur.execute(sql, params or None)
+                cur.fetchall()
+                times.append((time.perf_counter() - t) * 1000)
+            times_w = sorted(times[2:])
+            p50 = statistics.median(times_w)
+            print(f"{name:<24} {p50:8.1f} {times_w[-1]:8.1f}(max)")
+
+
+def explain():
+    qs = queries()
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        for name, sql, params in qs:
+            if name == "simple_select_1":
+                continue
+            # inline params: EXPLAIN with binds works over extended proto, but inline keeps it simple
+            t = time.perf_counter()
+            cur.execute("EXPLAIN ANALYZE " + sql, params or None)
+            out = "\n".join(str(r[0 if len(r) == 1 else 1]) for r in cur.fetchall())
+            ms = (time.perf_counter() - t) * 1000
+            p = Path(f"/tmp/qlat-explain-{name}.txt")
+            p.write_text(out)
+            print(f"{name}: {ms:.1f}ms → {p}")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "run"
+    {"seed": seed, "run": run, "explain": explain}[cmd]()

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -124,7 +124,10 @@ def seed_scale():
 
 
 def run_ages(n_iter=8):
-    """Random access at several partition ages — exposes cold/stale costs."""
+    """Random access at several partition ages — exposes cold/stale costs.
+    Requires `seed_scale` to have run first (it writes targets_by_age to the
+    state file; plain `seed` doesn't). Iterations are printed unfiltered —
+    the cold first touch IS the signal here, unlike run()'s warm percentiles."""
     st = json.loads(STATE.read_text())
     pid = st["project_id"]
     with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -26,6 +26,7 @@ STATE = ROOT / "data" / "query_latency_state.json"
 PID = "qlat-bench-project"
 N_ROWS = 20000
 WINDOW_H = 12  # spread rows over the last 12 hours
+INSERT_BATCH = 700  # 88 cols x 700 = 61.6k params < 65535 pgwire limit
 
 
 def seed():
@@ -44,7 +45,7 @@ def seed():
     base_sql = f"INSERT INTO otel_logs_and_spans ({', '.join(COLUMNS)}) VALUES "
     t0 = time.perf_counter()
     with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
-        B = 700  # 88 cols × 700 = 61.6k params < 65535 pgwire limit
+        B = INSERT_BATCH
         for i in range(0, len(rows), B):
             batch = rows[i : i + B]
             flat = [_to_pg(col, r.get(col)) for r in batch for col in COLUMNS]
@@ -107,7 +108,7 @@ def seed_scale():
                     ts = day_end - step * i
                     r["timestamp"] = ts.isoformat()
                     r["date"] = ts.date().isoformat()
-                B = 700
+                B = INSERT_BATCH
                 for i in range(0, len(rows), B):
                     batch = rows[i : i + B]
                     flat = [_to_pg(col, r.get(col)) for r in batch for col in COLUMNS]
@@ -167,7 +168,7 @@ def run(n_iter=15):
                 times.append((time.perf_counter() - t) * 1000)
         times_w = sorted(times[2:])  # drop 2 cold
         p50 = statistics.median(times_w)
-        p95 = times_w[int(len(times_w) * 0.95) - 1]
+        p95 = times_w[max(0, int(len(times_w) * 0.95) - 1)]
         print(f"{name:<24} {p50:8.1f} {p95:8.1f} {times_w[0]:8.1f} {times_w[-1]:8.1f}")
 
     # Same but on a single reused connection (separates conn setup from query cost).

--- a/bench/query_latency.py
+++ b/bench/query_latency.py
@@ -170,7 +170,7 @@ def run(n_iter=15):
                 times.append((time.perf_counter() - t) * 1000)
         times_w = sorted(times[2:])  # drop 2 cold
         p50 = statistics.median(times_w)
-        p95 = times_w[max(0, int(len(times_w) * 0.95) - 1)]
+        p95 = times_w[min(len(times_w) - 1, int(len(times_w) * 0.95))]
         print(f"{name:<24} {p50:8.1f} {p95:8.1f} {times_w[0]:8.1f} {times_w[-1]:8.1f}")
 
     # Same but on a single reused connection (separates conn setup from query cost).

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -24,7 +24,7 @@ export AWS_REGION="de"
 export AWS_ALLOW_HTTP="false"
 export TIMEFUSION_TABLE_PREFIX="tf-qlat-bench"
 export TIMEFUSION_DATA_DIR="$data_dir"
-export RUST_LOG=warn,timefusion=info
+export RUST_LOG="${RUST_LOG_OVERRIDE:-warn,timefusion=info}"
 export TIMEFUSION_FLUSH_INTERVAL_SECS=60
 export TIMEFUSION_BUFFER_MAX_MEMORY_MB=2048
 export TIMEFUSION_ALLOW_INSECURE_AUTH=true

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Start TF against Cloudflare R2 for network-latency-inclusive benchmarks.
+# Usage: ./bench/run-tf-r2.sh [label] [debug|release]
+set -euo pipefail
+label="${1:-r2}"
+profile="${2:-release}"
+data_dir="./data/bench-r2-${label}"
+log="/tmp/tf-r2-${label}.log"
+
+pkill -f 'target/[a-z-]*/timefusion' 2>/dev/null || true
+sleep 1
+mkdir -p "$data_dir"
+
+set -a; source .env; set +a
+# Remote object store for network-latency-inclusive benches. The monoscope
+# R2 token is dead (401 on list/put), so we use the OVH S3 creds from
+# monoscope/.env.prod — same provider as prod TF's storage. Dedicated
+# tf-qlat-bench/ prefix inside the existing rrweb bucket.
+export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
+export AWS_S3_BUCKET="rrweb"
+export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2)"
+export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2)"
+export AWS_REGION="de"
+export AWS_ALLOW_HTTP="false"
+export TIMEFUSION_TABLE_PREFIX="tf-qlat-bench"
+export TIMEFUSION_DATA_DIR="$data_dir"
+export RUST_LOG=warn,timefusion=info
+export TIMEFUSION_FLUSH_INTERVAL_SECS=60
+export TIMEFUSION_BUFFER_MAX_MEMORY_MB=2048
+export TIMEFUSION_ALLOW_INSECURE_AUTH=true
+export MAX_PG_CONNECTIONS=64
+export TIMEFUSION_BATCH_QUEUE_CAPACITY=10000
+unset OTEL_EXPORTER_OTLP_ENDPOINT
+export OTEL_SDK_DISABLED=true
+# .env carries a 60s foyer TTL (debug leftover) — that expires every cached
+# footer/page between bench iterations. Use the 7-day default + roomier disk.
+export TIMEFUSION_FOYER_TTL_SECONDS=604800
+export TIMEFUSION_FOYER_DISK_GB=4
+export TIMEFUSION_FOYER_MEMORY_MB=256
+# Warm full file contents (not just footers) for recent partitions, so the
+# first data read after boot doesn't pull whole parquet files from S3 inline.
+export TIMEFUSION_WARM_FULL_FILES=true
+
+nohup "./target/${profile}/timefusion" >"$log" 2>&1 &
+echo $! > /tmp/tf.pid
+for i in $(seq 1 90); do
+  if nc -z 127.0.0.1 12345 2>/dev/null; then
+    echo "TF-R2[$label/$profile] up after ${i}s (pid=$(cat /tmp/tf.pid), log=$log)"
+    exit 0
+  fi
+  sleep 1
+done
+echo "TF-R2[$label] failed to start"; tail -20 "$log"; exit 1

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -26,11 +26,14 @@ if [ "${R2:-0}" = "1" ]; then
   export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudflare | head -1 | cut -d= -f2-)"
   export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudflare | head -1 | cut -d= -f2-)"
 else
-  [ -f ../monoscope/.env.prod ] || { echo "OVH mode requires ../monoscope/.env.prod for S3 creds (or use R2=1)"; exit 1; }
+  # OVH creds come from a sibling monoscope checkout by default; point
+  # MONOSCOPE_DIR elsewhere if your repos aren't siblings.
+  monoscope_env="${MONOSCOPE_DIR:-../monoscope}/.env.prod"
+  [ -f "$monoscope_env" ] || { echo "OVH mode requires $monoscope_env for S3 creds (set MONOSCOPE_DIR or use R2=1)"; exit 1; }
   export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
   export AWS_S3_BUCKET="rrweb"
-  export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2-)"
-  export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2-)"
+  export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' "$monoscope_env" | cut -d= -f2-)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' "$monoscope_env" | cut -d= -f2-)"
   export AWS_REGION="de"
 fi
 export AWS_ALLOW_HTTP="false"
@@ -39,6 +42,8 @@ export TIMEFUSION_DATA_DIR="$data_dir"
 export RUST_LOG="${RUST_LOG_OVERRIDE:-warn,timefusion=info}"
 export TIMEFUSION_FLUSH_INTERVAL_SECS=60
 export TIMEFUSION_BUFFER_MAX_MEMORY_MB=2048
+# Bench-only convenience (local pgwire without TLS/password). NEVER copy
+# this into a production config.
 export TIMEFUSION_ALLOW_INSECURE_AUTH=true
 export MAX_PG_CONNECTIONS=64
 export TIMEFUSION_BATCH_QUEUE_CAPACITY=10000

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -36,6 +36,11 @@ else
   export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' "$monoscope_env" | cut -d= -f2-)"
   export AWS_REGION="de"
 fi
+# Fail fast on a key that grep'd to empty (absent/renamed in the env file) —
+# otherwise the bench dies later with a cryptic AWS auth error.
+for v in AWS_S3_ENDPOINT AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION; do
+  [ -n "${!v}" ] || { echo "missing $v in the sourced env file"; exit 1; }
+done
 export AWS_ALLOW_HTTP="false"
 export TIMEFUSION_TABLE_PREFIX="tf-qlat-bench"
 export TIMEFUSION_DATA_DIR="$data_dir"

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -14,17 +14,17 @@ mkdir -p "$data_dir"
 set -a; source .env; set +a
 # Remote object store for network-latency-inclusive benches.
 # Default: OVH S3 (monoscope/.env.prod creds) — same provider as prod TF.
-# R2=1: Cloudflare R2 via .env.cloudlfare (bucket timefusion-eu).
+# R2=1: Cloudflare R2 via .env.cloudflare (bucket timefusion-eu).
 # Both use a dedicated tf-qlat-bench/ prefix inside the existing bucket.
 if [ "${R2:-0}" = "1" ]; then
   # Everything (endpoint incl. account hash, bucket, creds) comes from the
-  # gitignored .env.cloudlfare — never inline R2 account URLs in this public repo.
-  [ -f .env.cloudlfare ] || { echo "R2=1 requires ./.env.cloudlfare (gitignored R2 config)"; exit 1; }
-  export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudlfare | head -1 | cut -d= -f2)"
-  export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudlfare | head -1 | cut -d= -f2)"
-  export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudlfare | head -1 | cut -d= -f2)"
-  export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudlfare | head -1 | cut -d= -f2)"
-  export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudlfare | head -1 | cut -d= -f2)"
+  # gitignored .env.cloudflare — never inline R2 account URLs in this public repo.
+  [ -f .env.cloudflare ] || { echo "R2=1 requires ./.env.cloudflare (gitignored R2 config)"; exit 1; }
+  export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudflare | head -1 | cut -d= -f2)"
+  export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudflare | head -1 | cut -d= -f2)"
+  export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudflare | head -1 | cut -d= -f2)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudflare | head -1 | cut -d= -f2)"
+  export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudflare | head -1 | cut -d= -f2)"
 else
   [ -f ../monoscope/.env.prod ] || { echo "OVH mode requires ../monoscope/.env.prod for S3 creds (or use R2=1)"; exit 1; }
   export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -12,15 +12,25 @@ sleep 1
 mkdir -p "$data_dir"
 
 set -a; source .env; set +a
-# Remote object store for network-latency-inclusive benches. The monoscope
-# R2 token is dead (401 on list/put), so we use the OVH S3 creds from
-# monoscope/.env.prod — same provider as prod TF's storage. Dedicated
-# tf-qlat-bench/ prefix inside the existing rrweb bucket.
-export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
-export AWS_S3_BUCKET="rrweb"
-export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2)"
-export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2)"
-export AWS_REGION="de"
+# Remote object store for network-latency-inclusive benches.
+# Default: OVH S3 (monoscope/.env.prod creds) — same provider as prod TF.
+# R2=1: Cloudflare R2 via .env.cloudlfare (bucket timefusion-eu).
+# Both use a dedicated tf-qlat-bench/ prefix inside the existing bucket.
+if [ "${R2:-0}" = "1" ]; then
+  # Everything (endpoint incl. account hash, bucket, creds) comes from the
+  # gitignored .env.cloudlfare — never inline R2 account URLs in this public repo.
+  export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudlfare | head -1 | cut -d= -f2)"
+  export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudlfare | head -1 | cut -d= -f2)"
+  export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudlfare | head -1 | cut -d= -f2)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudlfare | head -1 | cut -d= -f2)"
+  export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudlfare | head -1 | cut -d= -f2)"
+else
+  export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
+  export AWS_S3_BUCKET="rrweb"
+  export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2)"
+  export AWS_REGION="de"
+fi
 export AWS_ALLOW_HTTP="false"
 export TIMEFUSION_TABLE_PREFIX="tf-qlat-bench"
 export TIMEFUSION_DATA_DIR="$data_dir"

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -20,17 +20,17 @@ if [ "${R2:-0}" = "1" ]; then
   # Everything (endpoint incl. account hash, bucket, creds) comes from the
   # gitignored .env.cloudflare — never inline R2 account URLs in this public repo.
   [ -f .env.cloudflare ] || { echo "R2=1 requires ./.env.cloudflare (gitignored R2 config)"; exit 1; }
-  export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudflare | head -1 | cut -d= -f2)"
-  export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudflare | head -1 | cut -d= -f2)"
-  export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudflare | head -1 | cut -d= -f2)"
-  export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudflare | head -1 | cut -d= -f2)"
-  export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudflare | head -1 | cut -d= -f2)"
+  export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudflare | head -1 | cut -d= -f2-)"
+  export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudflare | head -1 | cut -d= -f2-)"
+  export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudflare | head -1 | cut -d= -f2-)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudflare | head -1 | cut -d= -f2-)"
+  export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudflare | head -1 | cut -d= -f2-)"
 else
   [ -f ../monoscope/.env.prod ] || { echo "OVH mode requires ../monoscope/.env.prod for S3 creds (or use R2=1)"; exit 1; }
   export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
   export AWS_S3_BUCKET="rrweb"
-  export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2)"
-  export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2)"
+  export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2-)"
+  export AWS_SECRET_ACCESS_KEY="$(grep '^S3_SECRET_KEY' ../monoscope/.env.prod | cut -d= -f2-)"
   export AWS_REGION="de"
 fi
 export AWS_ALLOW_HTTP="false"
@@ -56,7 +56,7 @@ export TIMEFUSION_WARM_FULL_FILES=true
 nohup "./target/${profile}/timefusion" >"$log" 2>&1 &
 echo $! > /tmp/tf.pid
 for i in $(seq 1 90); do
-  if nc -z 127.0.0.1 12345 2>/dev/null; then
+  if nc -z 127.0.0.1 "${PGWIRE_PORT:-12345}" 2>/dev/null; then
     echo "TF-R2[$label/$profile] up after ${i}s (pid=$(cat /tmp/tf.pid), log=$log)"
     exit 0
   fi

--- a/bench/run-tf-r2.sh
+++ b/bench/run-tf-r2.sh
@@ -19,12 +19,14 @@ set -a; source .env; set +a
 if [ "${R2:-0}" = "1" ]; then
   # Everything (endpoint incl. account hash, bucket, creds) comes from the
   # gitignored .env.cloudlfare — never inline R2 account URLs in this public repo.
+  [ -f .env.cloudlfare ] || { echo "R2=1 requires ./.env.cloudlfare (gitignored R2 config)"; exit 1; }
   export AWS_S3_ENDPOINT="$(grep '^AWS_S3_ENDPOINT=' .env.cloudlfare | head -1 | cut -d= -f2)"
   export AWS_S3_BUCKET="$(grep '^AWS_S3_BUCKET=' .env.cloudlfare | head -1 | cut -d= -f2)"
   export AWS_ACCESS_KEY_ID="$(grep '^AWS_ACCESS_KEY_ID=' .env.cloudlfare | head -1 | cut -d= -f2)"
   export AWS_SECRET_ACCESS_KEY="$(grep '^AWS_SECRET_ACCESS_KEY=' .env.cloudlfare | head -1 | cut -d= -f2)"
   export AWS_REGION="$(grep '^AWS_REGION=' .env.cloudlfare | head -1 | cut -d= -f2)"
 else
+  [ -f ../monoscope/.env.prod ] || { echo "OVH mode requires ../monoscope/.env.prod for S3 creds (or use R2=1)"; exit 1; }
   export AWS_S3_ENDPOINT="https://s3.de.io.cloud.ovh.net/"
   export AWS_S3_BUCKET="rrweb"
   export AWS_ACCESS_KEY_ID="$(grep '^S3_ACCESS_KEY' ../monoscope/.env.prod | cut -d= -f2)"

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -49,8 +49,9 @@ pub async fn bootstrap(cfg: Arc<AppConfig>) -> Result<Bootstrapped> {
         move |project_id: String, table_name: String, batches: Vec<RecordBatch>, wal_watermark: DeltaWatermark| {
             let db = db_for_callback.clone();
             Box::pin(async move {
+                // insert_records_batch warms the just-flushed files itself
+                // (watermark-gated) — warming here too would double the GETs.
                 let added = db.insert_records_batch(&project_id, &table_name, batches, true, Some(&wal_watermark)).await?;
-                db.warm_cache_for_table(&project_id, &table_name, added.clone());
                 Ok(added)
             })
         },

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -137,6 +137,8 @@ pub async fn bootstrap(cfg: Arc<AppConfig>) -> Result<Bootstrapped> {
     db = db.start_maintenance_schedulers().await?;
     let db = Arc::new(db);
     db.setup_session_tables(&mut session_context)?;
+    // Non-blocking: snapshot load + footer warm-up off the first query's path.
+    db.preload_tables();
 
     Ok(Bootstrapped {
         db,

--- a/src/config.rs
+++ b/src/config.rs
@@ -327,6 +327,12 @@ impl AwsConfig {
         insert_opt!(opts, "AWS_REGION", self.aws_default_region);
         insert_opt!(opts, "AWS_ALLOW_HTTP", self.aws_allow_http);
         opts.insert("AWS_ENDPOINT_URL".into(), endpoint_override.unwrap_or(&self.aws_s3_endpoint).to_string());
+        // Bound TCP/TLS connection establishment. The object_store default
+        // (5 s connect) plus retries let a black-holed connection stall a
+        // first-touch read for 20 s+ (observed 23 s on a cold partition).
+        // Total request timeout stays at the default 30 s so large flush
+        // PUTs aren't cut off.
+        opts.insert("connect_timeout".into(), "3s".into());
         opts
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -638,6 +638,12 @@ pub struct MaintenanceConfig {
     /// 0 = no recency limit.
     #[serde(default = "d_warm_recency_days")]
     pub timefusion_warm_recency_days:          u64,
+    /// Warm parquet footers for EVERY live file (not just recency-window
+    /// ones). Footers are tens of KB each, but on tables with thousands of
+    /// files the boot-time GET burst may matter on small instances — disable
+    /// to fall back to recency-bounded footer warming.
+    #[serde(default = "d_true")]
+    pub timefusion_warm_all_footers:           bool,
     /// Max concurrent warm fetches per commit. Bounds the S3 GET burst a
     /// warm job adds right after a compaction.
     #[serde(default = "d_warm_concurrency")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,17 +298,27 @@ impl TantivyConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct AwsConfig {
     #[serde(default)]
-    pub aws_access_key_id:     Option<String>,
+    pub aws_access_key_id:             Option<String>,
     #[serde(default)]
-    pub aws_secret_access_key: Option<String>,
+    pub aws_secret_access_key:         Option<String>,
     #[serde(default)]
-    pub aws_default_region:    Option<String>,
+    pub aws_default_region:            Option<String>,
     #[serde(default = "d_s3_endpoint")]
-    pub aws_s3_endpoint:       String,
+    pub aws_s3_endpoint:               String,
     #[serde(default)]
-    pub aws_s3_bucket:         Option<String>,
+    pub aws_s3_bucket:                 Option<String>,
     #[serde(default)]
-    pub aws_allow_http:        Option<String>,
+    pub aws_allow_http:                Option<String>,
+    /// TCP/TLS connection-establishment bound passed to the object_store S3
+    /// client (humantime format, e.g. "3s", "10s"). See
+    /// `build_storage_options` for why the default is tighter than
+    /// object_store's 5 s.
+    #[serde(default = "d_s3_connect_timeout")]
+    pub timefusion_s3_connect_timeout: String,
+}
+
+fn d_s3_connect_timeout() -> String {
+    "3s".to_string()
 }
 
 impl AwsConfig {
@@ -331,8 +341,9 @@ impl AwsConfig {
         // (5 s connect) plus retries let a black-holed connection stall a
         // first-touch read for 20 s+ (observed 23 s on a cold partition).
         // Total request timeout stays at the default 30 s so large flush
-        // PUTs aren't cut off.
-        opts.insert("connect_timeout".into(), "3s".into());
+        // PUTs aren't cut off. Tunable via TIMEFUSION_S3_CONNECT_TIMEOUT for
+        // environments where 3 s is too tight (slow proxies, cross-region).
+        opts.insert("connect_timeout".into(), self.timefusion_s3_connect_timeout.clone());
         opts
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,15 +310,12 @@ pub struct AwsConfig {
     #[serde(default)]
     pub aws_allow_http:                Option<String>,
     /// TCP/TLS connection-establishment bound passed to the object_store S3
-    /// client (humantime format, e.g. "3s", "10s"). See
-    /// `build_storage_options` for why the default is tighter than
+    /// client (humantime format, e.g. "3s", "10s"). `Option` so the derived
+    /// `AwsConfig::default()` stays valid (an empty string wouldn't parse);
+    /// see `build_storage_options` for why the default is tighter than
     /// object_store's 5 s.
-    #[serde(default = "d_s3_connect_timeout")]
-    pub timefusion_s3_connect_timeout: String,
-}
-
-fn d_s3_connect_timeout() -> String {
-    "3s".to_string()
+    #[serde(default)]
+    pub timefusion_s3_connect_timeout: Option<String>,
 }
 
 impl AwsConfig {
@@ -343,7 +340,10 @@ impl AwsConfig {
         // Total request timeout stays at the default 30 s so large flush
         // PUTs aren't cut off. Tunable via TIMEFUSION_S3_CONNECT_TIMEOUT for
         // environments where 3 s is too tight (slow proxies, cross-region).
-        opts.insert("connect_timeout".into(), self.timefusion_s3_connect_timeout.clone());
+        opts.insert(
+            "connect_timeout".into(),
+            self.timefusion_s3_connect_timeout.clone().unwrap_or_else(|| "3s".into()),
+        );
         opts
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -269,6 +269,9 @@ fn select_warm_paths(
             }
         })
         .collect();
+    // Assumes 10-char ISO dates (date=YYYY-MM-DD, lexically sortable). A
+    // missing or differently-shaped date= segment keys as "" — sorts first
+    // (slightly suboptimal LRU order), never a crash.
     let date_key = |p: &object_store::path::Path| {
         let s = p.as_ref();
         s.find("date=").and_then(|i| s.get(i + 5..i + 15)).unwrap_or("").to_string()
@@ -2103,9 +2106,11 @@ impl Database {
         // old partitions instead of whichever files happened to warm late.
         let (paths, dropped) = select_warm_paths(uris, prefix, warm_all_footers, cutoff);
         if dropped > 0 {
-            // Log so a systematic prefix mismatch is diagnosable instead of a
-            // silent no-op (warming the wrong key would never be hit).
-            debug!("warm: skipped {} file(s) that did not relativize against prefix {}", dropped, prefix);
+            // warn: a systematic prefix mismatch silently no-ops the whole
+            // warm pass (the wrong key would never be hit), and prod runs at
+            // warn level — debug would make it invisible exactly where it
+            // matters (boot-time preload).
+            warn!("warm: skipped {} file(s) that did not relativize against prefix {}", dropped, prefix);
         }
         if paths.is_empty() {
             return;

--- a/src/database.rs
+++ b/src/database.rs
@@ -2200,25 +2200,34 @@ impl Database {
         // fan-out here is one in-flight snapshot load per registered table.
         for table_name in crate::schema_loader::registry().list_tables() {
             let db = Arc::clone(self);
+            let shutdown = self.maintenance_shutdown.clone();
             tokio::spawn(async move {
-                let t = std::time::Instant::now();
-                match db.resolve_table("default", &table_name).await {
-                    Ok(table_ref) => {
-                        // Warm via the already-resolved handle — warm_cache_for_table
-                        // would redundantly resolve_table a second time.
-                        let (uris, store, table_uri) = {
-                            let table = table_ref.read().await;
-                            let uris: Vec<String> = table.get_file_uris().map(|it| it.collect()).unwrap_or_default();
-                            (uris, table.log_store().object_store(None), table.table_url().to_string())
-                        };
-                        info!(
-                            "bootstrap.phase=table_preload table={table_name} files={} elapsed_ms={}",
-                            uris.len(),
-                            t.elapsed().as_millis()
-                        );
-                        db.warm_cache_for_uris(store, table_uri, uris).await;
+                let preload = async {
+                    let t = std::time::Instant::now();
+                    match db.resolve_table("default", &table_name).await {
+                        Ok(table_ref) => {
+                            // Warm via the already-resolved handle — warm_cache_for_table
+                            // would redundantly resolve_table a second time.
+                            let (uris, store, table_uri) = {
+                                let table = table_ref.read().await;
+                                let uris: Vec<String> = table.get_file_uris().map(|it| it.collect()).unwrap_or_default();
+                                (uris, table.log_store().object_store(None), table.table_url().to_string())
+                            };
+                            info!(
+                                "bootstrap.phase=table_preload table={table_name} files={} elapsed_ms={}",
+                                uris.len(),
+                                t.elapsed().as_millis()
+                            );
+                            db.warm_cache_for_uris(store, table_uri, uris).await;
+                        }
+                        Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
                     }
-                    Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
+                };
+                // Abandon warming on shutdown so in-flight S3 calls can't slow
+                // a fast restart during initial boot.
+                tokio::select! {
+                    _ = shutdown.cancelled() => {}
+                    _ = preload => {}
                 }
             });
         }

--- a/src/database.rs
+++ b/src/database.rs
@@ -2218,7 +2218,9 @@ impl Database {
     pub fn preload_tables(self: &Arc<Self>) {
         // Idempotent: main.rs and bootstrap.rs are disjoint entry points, but
         // a second call must not double the boot-time S3 warm burst.
-        if self.preload_started.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        // Relaxed: the swap's atomicity alone decides the winner; no other
+        // memory needs to be ordered around it.
+        if self.preload_started.swap(true, std::sync::atomic::Ordering::Relaxed) {
             return;
         }
         // Tables preload concurrently — a slow object-store round-trip on one

--- a/src/database.rs
+++ b/src/database.rs
@@ -3014,14 +3014,11 @@ impl Database {
                 .await;
             match result {
                 Ok(new_table) => {
-                    // Warm the rewritten files like the optimize paths do
-                    // (swap_and_refresh_cache); without this the replace_where
-                    // outputs are stone-cold and the next query on the
-                    // partition pays full S3 metadata+data reads (1.5 s
-                    // observed against OVH).
-                    let added: Vec<String> = new_table.get_file_uris().map(|it| it.filter(|u| !pre_uris.contains(u)).collect()).unwrap_or_default();
-                    *table_ref.write().await = new_table;
-                    self.warm_cache_for_table(project_id, table_name, added);
+                    // Swap + warm-added/evict-removed exactly like the optimize
+                    // paths; a bare swap left the replace_where outputs stone-cold
+                    // (1.5 s first read observed against OVH) and the tombstoned
+                    // files' cache entries alive until TTL.
+                    self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
                     crate::metrics::record_compaction_dedup_dropped(dropped);
                     info!(
                         "dedup compaction: table={} project={} date={} dropped={} (before={} after={})",

--- a/src/database.rs
+++ b/src/database.rs
@@ -2228,7 +2228,9 @@ impl Database {
         // Tables preload concurrently — a slow object-store round-trip on one
         // must not delay the others' first-query readiness. Per-file warm
         // concurrency inside warm_cache_for_uris is already bounded, so the
-        // fan-out here is one in-flight snapshot load per registered table.
+        // fan-out here is one in-flight snapshot load per registered table —
+        // fine while the registry stays small (a handful of YAML schemas);
+        // bound this with a semaphore if it ever grows to dozens.
         for table_name in crate::schema_loader::registry().list_tables() {
             let db = Arc::clone(self);
             let shutdown = self.maintenance_shutdown.clone();

--- a/src/database.rs
+++ b/src/database.rs
@@ -239,6 +239,44 @@ fn relativize_to_prefix(prefix: &str, uri: &str) -> Option<object_store::path::P
     uri.strip_prefix(prefix).map(|rel| object_store::path::Path::from(rel.trim_start_matches('/')))
 }
 
+/// Select and order the files `warm_cache_for_uris` will warm. Returns
+/// `(path, recent)` pairs: footers warm for every returned file; full-file
+/// warming additionally requires `recent`. With `warm_all_footers` (default)
+/// non-recent files are kept (recent=false → footer-only); without it they
+/// are dropped entirely. Ordered oldest date-partition first so the newest
+/// land last in LRU order (ISO dates sort lexically; undated files first).
+/// Returns the count of URIs that failed to relativize for the caller to log.
+fn select_warm_paths(
+    uris: Vec<String>, prefix: &str, warm_all_footers: bool, cutoff: Option<chrono::NaiveDate>,
+) -> (Vec<(object_store::path::Path, bool)>, usize) {
+    let mut dropped = 0usize;
+    let mut paths: Vec<(object_store::path::Path, bool)> = uris
+        .into_iter()
+        .filter(|u| u.ends_with(".parquet"))
+        .map(|u| {
+            let recent = within_recency(&u, cutoff);
+            (u, recent)
+        })
+        .filter(|(_, recent)| warm_all_footers || *recent)
+        .filter_map(|(u, recent)| match relativize_to_prefix(prefix, &u) {
+            Some(path) => Some((path, recent)),
+            None => {
+                // Prefix mismatch (e.g. trailing-slash or query-string drift
+                // between table_url() and get_file_uris()). Warming this file
+                // would address the wrong key, so skip it.
+                dropped += 1;
+                None
+            }
+        })
+        .collect();
+    let date_key = |p: &object_store::path::Path| {
+        let s = p.as_ref();
+        s.find("date=").and_then(|i| s.get(i + 5..i + 15)).unwrap_or("").to_string()
+    };
+    paths.sort_by_key(|(p, _)| date_key(p));
+    (paths, dropped)
+}
+
 // Helper function to extract project_id from a batch
 pub fn extract_project_id(batch: &RecordBatch) -> Option<String> {
     use datafusion::arrow::array::{StringArray, StringViewArray};
@@ -2052,56 +2090,25 @@ impl Database {
         // past any partition we'd query.
         let cutoff = (recency_days > 0).then(|| Utc::now().date_naive() - chrono::Duration::days(recency_days.min(3650) as i64));
 
-        let mut dropped = 0usize;
         // With warm_all_footers (default): footers warm for EVERY live file
         // (tens of KB each — they turn a deep-partition first touch from
         // footer+data RTTs into a single data fetch). On tables with
         // thousands of files that's thousands of boot-time GETs (bounded by
         // `concurrency`); disable the flag to recency-bound footers too.
-        // Full-file warming is always recency-bounded.
-        let paths: Vec<(object_store::path::Path, bool)> = uris
-            .into_iter()
-            .filter(|u| u.ends_with(".parquet"))
-            .map(|u| {
-                let recent = within_recency(&u, cutoff);
-                (u, recent)
-            })
-            .filter(|(_, recent)| warm_all_footers || *recent)
-            .filter_map(|(u, recent)| match relativize_to_prefix(prefix, &u) {
-                Some(path) => Some((path, recent)),
-                None => {
-                    // Prefix mismatch (e.g. trailing-slash or query-string
-                    // drift between table_url() and get_file_uris()). Warming
-                    // this file would address the wrong key, so skip it — but
-                    // log so a systematic mismatch is diagnosable instead of a
-                    // silent no-op.
-                    if dropped == 0 {
-                        debug!("warm: URI {} does not start with table prefix {}; skipping (warm only)", u, prefix);
-                    }
-                    dropped += 1;
-                    None
-                }
-            })
-            .collect();
-
+        // Full-file warming is always recency-bounded. Oldest partitions warm
+        // FIRST so the newest land last in LRU order: if the warm set exceeds
+        // the metadata cache (size it as metadata_disk ≥ live_files ×
+        // parquet_metadata_size_hint), eviction then drops the least-queried
+        // old partitions instead of whichever files happened to warm late.
+        let (paths, dropped) = select_warm_paths(uris, prefix, warm_all_footers, cutoff);
         if dropped > 0 {
+            // Log so a systematic prefix mismatch is diagnosable instead of a
+            // silent no-op (warming the wrong key would never be hit).
             debug!("warm: skipped {} file(s) that did not relativize against prefix {}", dropped, prefix);
         }
         if paths.is_empty() {
             return;
         }
-        // Warm oldest date-partitions FIRST so the newest land last in LRU
-        // order: if the warm set exceeds the metadata cache (size it as
-        // metadata_disk ≥ live_files × parquet_metadata_size_hint), eviction
-        // then drops the least-queried old partitions instead of whichever
-        // files happened to warm late. ISO dates sort lexically; files
-        // without a date= segment warm first.
-        let date_key = |p: &object_store::path::Path| {
-            let s = p.as_ref();
-            s.find("date=").and_then(|i| s.get(i + 5..i + 15)).unwrap_or("").to_string()
-        };
-        let mut paths = paths;
-        paths.sort_by_key(|(p, _)| date_key(p));
 
         let count = paths.len();
         // Baseline the cache stats *before* warming: the warm GETs are all
@@ -4392,6 +4399,36 @@ mod writer_properties_tests {
         let kv = p.key_value_metadata().expect("KV metadata present");
         let tier = kv.iter().find(|k| k.key == COMPRESSION_TIER_KEY).expect("tier key present");
         assert_eq!(tier.value.as_deref(), Some("15"));
+    }
+
+    // Pins the warm_all_footers default: non-recent files stay in the warm
+    // set as footer-only (recent=false), oldest partition first; with the
+    // flag off they are dropped entirely.
+    #[test]
+    fn select_warm_paths_pins_warm_all_footers_default() {
+        let prefix = "s3://bucket/timefusion/default/otel";
+        let uris = vec![
+            format!("{prefix}/project_id=p/date=2099-01-01/new.parquet"),
+            format!("{prefix}/project_id=p/date=2020-01-01/old.parquet"),
+            format!("{prefix}/project_id=p/date=2099-01-02/checkpoint.json"),
+            "s3://elsewhere/unrelated.parquet".to_string(),
+        ];
+        let cutoff = Some(chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+
+        let (paths, dropped) = select_warm_paths(uris.clone(), prefix, true, cutoff);
+        assert_eq!(dropped, 1, "prefix-mismatched URI counted as dropped");
+        let got: Vec<(&str, bool)> = paths.iter().map(|(p, r)| (p.as_ref(), *r)).collect();
+        assert_eq!(
+            got,
+            vec![
+                ("project_id=p/date=2020-01-01/old.parquet", false), // footer-only, warms first
+                ("project_id=p/date=2099-01-01/new.parquet", true),
+            ]
+        );
+
+        let (paths, _) = select_warm_paths(uris, prefix, false, cutoff);
+        assert_eq!(paths.len(), 1, "warm_all_footers=false drops non-recent files");
+        assert!(paths[0].0.as_ref().contains("date=2099-01-01"));
     }
 
     #[test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -2220,7 +2220,7 @@ impl Database {
                             );
                             db.warm_cache_for_uris(store, table_uri, uris).await;
                         }
-                        Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
+                        Err(e) => warn!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
                     }
                 };
                 // Abandon warming on shutdown so in-flight S3 calls can't slow
@@ -2510,6 +2510,11 @@ impl Database {
                     // hold the write lock — no extra log scan required.
                     let added: Vec<String> = table.get_file_uris().map(|it| it.filter(|u| !pre_uris.contains(u)).collect()).unwrap_or_default();
 
+                    // Capture the store off the handle we just committed with —
+                    // the warm task below must never re-resolve the table (a
+                    // possible PG roundtrip + a redundant Delta state reload).
+                    let (warm_store, warm_table_uri) = (table.log_store().object_store(None), table.table_url().to_string());
+
                     // Invalidate statistics cache after successful write
                     drop(table); // Release write lock before async operation
                     // Freshly-flushed files are the ones dashboards query next;
@@ -2521,7 +2526,11 @@ impl Database {
                     // short-lived runtime and poison the shared client pool for
                     // the next test's S3 reads ("error sending request" in µs).
                     if watermark.is_some() {
-                        self.warm_cache_for_table(&project_id, &table_name, added.clone());
+                        let db = self.clone();
+                        let warm_added = added.clone();
+                        tokio::spawn(async move {
+                            db.warm_cache_for_uris(warm_store, warm_table_uri, warm_added).await;
+                        });
                     }
                     self.statistics_extractor.invalidate(&project_id, &table_name).await;
                     debug!("Invalidated statistics cache after write to {}/{}", project_id, table_name);

--- a/src/database.rs
+++ b/src/database.rs
@@ -2194,9 +2194,13 @@ impl Database {
     /// replay + parquet footer reads inline (measured 1.4 s cold vs 13 ms
     /// warm against OVH S3 for a single-partition random-access lookup).
     pub fn preload_tables(self: &Arc<Self>) {
-        let db = Arc::clone(self);
-        tokio::spawn(async move {
-            for table_name in crate::schema_loader::registry().list_tables() {
+        // Tables preload concurrently — a slow object-store round-trip on one
+        // must not delay the others' first-query readiness. Per-file warm
+        // concurrency inside warm_cache_for_uris is already bounded, so the
+        // fan-out here is one in-flight snapshot load per registered table.
+        for table_name in crate::schema_loader::registry().list_tables() {
+            let db = Arc::clone(self);
+            tokio::spawn(async move {
                 let t = std::time::Instant::now();
                 match db.resolve_table("default", &table_name).await {
                     Ok(table_ref) => {
@@ -2216,8 +2220,8 @@ impl Database {
                     }
                     Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
                 }
-            }
-        });
+            });
+        }
     }
 
     /// Atomically swap a freshly-optimized `new_table` in under the write lock,

--- a/src/database.rs
+++ b/src/database.rs
@@ -2090,6 +2090,18 @@ impl Database {
         if paths.is_empty() {
             return;
         }
+        // Warm oldest date-partitions FIRST so the newest land last in LRU
+        // order: if the warm set exceeds the metadata cache (size it as
+        // metadata_disk ≥ live_files × parquet_metadata_size_hint), eviction
+        // then drops the least-queried old partitions instead of whichever
+        // files happened to warm late. ISO dates sort lexically; files
+        // without a date= segment warm first.
+        let date_key = |p: &object_store::path::Path| {
+            let s = p.as_ref();
+            s.find("date=").and_then(|i| s.get(i + 5..i + 15)).unwrap_or("").to_string()
+        };
+        let mut paths = paths;
+        paths.sort_by_key(|(p, _)| date_key(p));
 
         let count = paths.len();
         // Baseline the cache stats *before* warming: the warm GETs are all

--- a/src/database.rs
+++ b/src/database.rs
@@ -2493,6 +2493,10 @@ impl Database {
 
                     // Invalidate statistics cache after successful write
                     drop(table); // Release write lock before async operation
+                    // Freshly-flushed files are the ones dashboards query next;
+                    // without this they're read cold from S3 until something else
+                    // warms them (repeat queries measured ~300 ms vs 8 ms warm on R2).
+                    self.warm_cache_for_table(&project_id, &table_name, added.clone());
                     self.statistics_extractor.invalidate(&project_id, &table_name).await;
                     debug!("Invalidated statistics cache after write to {}/{}", project_id, table_name);
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -2200,13 +2200,19 @@ impl Database {
                 let t = std::time::Instant::now();
                 match db.resolve_table("default", &table_name).await {
                     Ok(table_ref) => {
-                        let uris: Vec<String> = table_ref.read().await.get_file_uris().map(|it| it.collect()).unwrap_or_default();
+                        // Warm via the already-resolved handle — warm_cache_for_table
+                        // would redundantly resolve_table a second time.
+                        let (uris, store, table_uri) = {
+                            let table = table_ref.read().await;
+                            let uris: Vec<String> = table.get_file_uris().map(|it| it.collect()).unwrap_or_default();
+                            (uris, table.log_store().object_store(None), table.table_url().to_string())
+                        };
                         info!(
                             "bootstrap.phase=table_preload table={table_name} files={} elapsed_ms={}",
                             uris.len(),
                             t.elapsed().as_millis()
                         );
-                        db.warm_cache_for_table("default", &table_name, uris);
+                        db.warm_cache_for_uris(store, table_uri, uris).await;
                     }
                     Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
                 }
@@ -2496,7 +2502,14 @@ impl Database {
                     // Freshly-flushed files are the ones dashboards query next;
                     // without this they're read cold from S3 until something else
                     // warms them (repeat queries measured ~300 ms vs 8 ms warm on R2).
-                    self.warm_cache_for_table(&project_id, &table_name, added.clone());
+                    // Gated on `watermark` (only the BufferedWriteLayer flush path
+                    // sets it): direct inserts — tests, tools — must not spawn
+                    // detached warm tasks, whose in-flight connections outlive a
+                    // short-lived runtime and poison the shared client pool for
+                    // the next test's S3 reads ("error sending request" in µs).
+                    if watermark.is_some() {
+                        self.warm_cache_for_table(&project_id, &table_name, added.clone());
+                    }
                     self.statistics_extractor.invalidate(&project_id, &table_name).await;
                     debug!("Invalidated statistics cache after write to {}/{}", project_id, table_name);
 
@@ -2902,7 +2915,7 @@ impl Database {
                 // un-warmed and the tombstoned ones cached — the next query
                 // on a recompressed partition paid full S3 reads (1.5 s
                 // observed against OVH).
-                let _ = self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
+                self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
                 Ok(())
             }
             Err(e) => {
@@ -3006,8 +3019,7 @@ impl Database {
                     // outputs are stone-cold and the next query on the
                     // partition pays full S3 metadata+data reads (1.5 s
                     // observed against OVH).
-                    let added: Vec<String> =
-                        new_table.get_file_uris().map(|it| it.filter(|u| !pre_uris.contains(u)).collect()).unwrap_or_default();
+                    let added: Vec<String> = new_table.get_file_uris().map(|it| it.filter(|u| !pre_uris.contains(u)).collect()).unwrap_or_default();
                     *table_ref.write().await = new_table;
                     self.warm_cache_for_table(project_id, table_name, added);
                     crate::metrics::record_compaction_dedup_dropped(dropped);
@@ -3180,7 +3192,7 @@ impl Database {
                     // Swap the optimized table in and refresh the cache (warm
                     // freshly-compacted files, evict the small files just
                     // tombstoned) via the shared helper.
-                    let _ = self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
+                    self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
                     return Ok(());
                 }
                 Err(e) => {

--- a/src/database.rs
+++ b/src/database.rs
@@ -655,6 +655,10 @@ pub struct Database {
     pub scan_metrics:                Arc<ScanMetrics>,
     batch_queue:                     Option<Arc<crate::batch_queue::BatchQueue>>,
     maintenance_shutdown:            Arc<CancellationToken>,
+    /// One-shot guard for `preload_tables` — main.rs and bootstrap.rs are
+    /// disjoint entry points today, but a second call must not double the
+    /// boot-time S3 warm burst.
+    preload_started:                 Arc<std::sync::atomic::AtomicBool>,
     config_pool:                     Option<PgPool>,
     storage_configs:                 Arc<RwLock<HashMap<(String, String), StorageConfig>>>,
     /// Monotonic deadline (nanos since process start) for when the next
@@ -964,6 +968,7 @@ impl Database {
             scan_metrics: Arc::new(ScanMetrics::default()),
             batch_queue: None,
             maintenance_shutdown: Arc::new(CancellationToken::new()),
+            preload_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             config_pool,
             storage_configs: Arc::new(RwLock::new(storage_configs)),
             storage_configs_next_refresh_ns: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -2032,6 +2037,7 @@ impl Database {
             return;
         }
         let warm_full_files = maint.timefusion_warm_full_files;
+        let warm_all_footers = maint.timefusion_warm_all_footers;
         let recency_days = maint.timefusion_warm_recency_days;
         let concurrency = maint.timefusion_warm_concurrency.max(1);
         let metadata_size_hint = self.config.cache.timefusion_parquet_metadata_size_hint as u64;
@@ -2047,9 +2053,12 @@ impl Database {
         let cutoff = (recency_days > 0).then(|| Utc::now().date_naive() - chrono::Duration::days(recency_days.min(3650) as i64));
 
         let mut dropped = 0usize;
-        // Footers are warmed for EVERY live file (tens of KB each — they're
-        // what turns a deep-partition first touch from footer+data RTTs into
-        // a single data fetch). Full-file warming stays recency-bounded.
+        // With warm_all_footers (default): footers warm for EVERY live file
+        // (tens of KB each — they turn a deep-partition first touch from
+        // footer+data RTTs into a single data fetch). On tables with
+        // thousands of files that's thousands of boot-time GETs (bounded by
+        // `concurrency`); disable the flag to recency-bound footers too.
+        // Full-file warming is always recency-bounded.
         let paths: Vec<(object_store::path::Path, bool)> = uris
             .into_iter()
             .filter(|u| u.ends_with(".parquet"))
@@ -2057,6 +2066,7 @@ impl Database {
                 let recent = within_recency(&u, cutoff);
                 (u, recent)
             })
+            .filter(|(_, recent)| warm_all_footers || *recent)
             .filter_map(|(u, recent)| match relativize_to_prefix(prefix, &u) {
                 Some(path) => Some((path, recent)),
                 None => {
@@ -2194,6 +2204,11 @@ impl Database {
     /// replay + parquet footer reads inline (measured 1.4 s cold vs 13 ms
     /// warm against OVH S3 for a single-partition random-access lookup).
     pub fn preload_tables(self: &Arc<Self>) {
+        // Idempotent: main.rs and bootstrap.rs are disjoint entry points, but
+        // a second call must not double the boot-time S3 warm burst.
+        if self.preload_started.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
         // Tables preload concurrently — a slow object-store round-trip on one
         // must not delay the others' first-query readiness. Per-file warm
         // concurrency inside warm_cache_for_uris is already bounded, so the

--- a/src/database.rs
+++ b/src/database.rs
@@ -2211,12 +2211,12 @@ impl Database {
         });
     }
 
-    /// Resolve every registry table and warm parquet footers (every live
-    /// file by default; recency-bounded when `timefusion_warm_all_footers`
-    /// is off) in the
-    /// background, so the first query after a deploy doesn't pay Delta log
-    /// replay + parquet footer reads inline (measured 1.4 s cold vs 13 ms
-    /// warm against OVH S3 for a single-partition random-access lookup).
+    /// Resolve every registry table and warm parquet footers in the
+    /// background (ALL live files by default; recency-bounded when
+    /// `TIMEFUSION_WARM_ALL_FOOTERS=false` — see warm_cache_for_uris), so the
+    /// first query after a deploy doesn't pay Delta log replay + parquet
+    /// footer reads inline (measured 1.4 s cold vs 13 ms warm against OVH S3
+    /// for a single-partition random-access lookup).
     pub fn preload_tables(self: &Arc<Self>) {
         // Idempotent: main.rs and bootstrap.rs are disjoint entry points, but
         // a second call must not double the boot-time S3 warm burst.
@@ -2226,16 +2226,17 @@ impl Database {
             return;
         }
         // Tables preload concurrently — a slow object-store round-trip on one
-        // must not delay the others' first-query readiness. Per-file warm
-        // concurrency inside warm_cache_for_uris is already bounded, so the
-        // fan-out here is one in-flight snapshot load per registered table —
-        // fine while the registry stays small (a handful of YAML schemas);
-        // bound this with a semaphore if it ever grows to dozens.
-        for table_name in crate::schema_loader::registry().list_tables() {
-            let db = Arc::clone(self);
-            let shutdown = self.maintenance_shutdown.clone();
-            tokio::spawn(async move {
-                let preload = async {
+        // must not delay the others' first-query readiness — but the fan-out
+        // is capped at the same bound as per-file warming: each table preload
+        // is a Delta log replay (object-store round-trips), so an unbounded
+        // spawn-per-table would spike S3 at boot as the registry grows.
+        let db = Arc::clone(self);
+        let shutdown = self.maintenance_shutdown.clone();
+        let concurrency = self.config.maintenance.timefusion_warm_concurrency.max(1);
+        tokio::spawn(async move {
+            let preload_all = futures::stream::iter(crate::schema_loader::registry().list_tables()).for_each_concurrent(concurrency, |table_name| {
+                let db = Arc::clone(&db);
+                async move {
                     let t = std::time::Instant::now();
                     match db.resolve_table("default", &table_name).await {
                         Ok(table_ref) => {
@@ -2255,15 +2256,15 @@ impl Database {
                         }
                         Err(e) => warn!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
                     }
-                };
-                // Abandon warming on shutdown so in-flight S3 calls can't slow
-                // a fast restart during initial boot.
-                tokio::select! {
-                    _ = shutdown.cancelled() => {}
-                    _ = preload => {}
                 }
             });
-        }
+            // Abandon warming on shutdown so in-flight S3 calls can't slow
+            // a fast restart during initial boot.
+            tokio::select! {
+                _ = shutdown.cancelled() => {}
+                _ = preload_all => {}
+            }
+        });
     }
 
     /// Atomically swap a freshly-optimized `new_table` in under the write lock,

--- a/src/database.rs
+++ b/src/database.rs
@@ -2211,7 +2211,9 @@ impl Database {
         });
     }
 
-    /// Resolve every registry table and warm recent-partition footers in the
+    /// Resolve every registry table and warm parquet footers (every live
+    /// file by default; recency-bounded when `timefusion_warm_all_footers`
+    /// is off) in the
     /// background, so the first query after a deploy doesn't pay Delta log
     /// replay + parquet footer reads inline (measured 1.4 s cold vs 13 ms
     /// warm against OVH S3 for a single-partition random-access lookup).

--- a/src/database.rs
+++ b/src/database.rs
@@ -2869,6 +2869,7 @@ impl Database {
         let target_size = self.config.parquet.timefusion_optimize_target_size;
 
         let table_clone = table_ref.read().await.clone();
+        let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
         let optimize_result = table_clone
             .optimize()
             .with_filters(&partition_filters)
@@ -2892,7 +2893,12 @@ impl Database {
                     "recompress: date={} table={} removed={} added={} considered={}",
                     date_str, table_name, metrics.num_files_removed, metrics.num_files_added, metrics.total_considered_files
                 );
-                *table_ref.write().await = new_table;
+                // Swap + warm-added/evict-removed like the other optimize
+                // paths. A bare swap left the rewritten cold-tier files
+                // un-warmed and the tombstoned ones cached — the next query
+                // on a recompressed partition paid full S3 reads (1.5 s
+                // observed against OVH).
+                let _ = self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
                 Ok(())
             }
             Err(e) => {
@@ -2981,6 +2987,7 @@ impl Database {
                 let table = table_ref.read().await;
                 table.clone()
             };
+            let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
             let result = table_clone
                 .write(deduped.clone())
                 .with_partition_columns(schema.partitions.clone())
@@ -2990,7 +2997,15 @@ impl Database {
                 .await;
             match result {
                 Ok(new_table) => {
+                    // Warm the rewritten files like the optimize paths do
+                    // (swap_and_refresh_cache); without this the replace_where
+                    // outputs are stone-cold and the next query on the
+                    // partition pays full S3 metadata+data reads (1.5 s
+                    // observed against OVH).
+                    let added: Vec<String> =
+                        new_table.get_file_uris().map(|it| it.filter(|u| !pre_uris.contains(u)).collect()).unwrap_or_default();
                     *table_ref.write().await = new_table;
+                    self.warm_cache_for_table(project_id, table_name, added);
                     crate::metrics::record_compaction_dedup_dropped(dropped);
                     info!(
                         "dedup compaction: table={} project={} date={} dropped={} (before={} after={})",

--- a/src/database.rs
+++ b/src/database.rs
@@ -273,7 +273,8 @@ fn select_warm_paths(
         let s = p.as_ref();
         s.find("date=").and_then(|i| s.get(i + 5..i + 15)).unwrap_or("").to_string()
     };
-    paths.sort_by_key(|(p, _)| date_key(p));
+    // cached_key: one allocation per path, not one per comparison.
+    paths.sort_by_cached_key(|(p, _)| date_key(p));
     (paths, dropped)
 }
 
@@ -2128,6 +2129,10 @@ impl Database {
         // Labelled scope rather than `full=true/false` so warm logs are easy to
         // filter (e.g. in Loki) by what was actually primed.
         let scope = if warm_full_files { "full" } else { "footer-only" };
+        // Surface the burst size up front so operators can see what a restart
+        // is about to issue against S3 (the completion log alone can't —
+        // a large warm set takes minutes to get there).
+        info!("Cache warm start: {count} files (scope={scope}, concurrency={concurrency})");
         futures::stream::iter(paths)
             .for_each_concurrent(concurrency, |(path, recent)| {
                 let store = object_store.clone();
@@ -2569,8 +2574,15 @@ impl Database {
                     if watermark.is_some() {
                         let db = self.clone();
                         let warm_added = added.clone();
+                        let shutdown = self.maintenance_shutdown.clone();
                         tokio::spawn(async move {
-                            db.warm_cache_for_uris(warm_store, warm_table_uri, warm_added).await;
+                            // Abandon on shutdown (same as preload_tables): the
+                            // detached warm must not issue S3 GETs against a
+                            // draining client pool during a fast restart.
+                            tokio::select! {
+                                _ = shutdown.cancelled() => {}
+                                _ = db.warm_cache_for_uris(warm_store, warm_table_uri, warm_added) => {}
+                            }
                         });
                     }
                     self.statistics_extractor.invalidate(&project_id, &table_name).await;

--- a/src/database.rs
+++ b/src/database.rs
@@ -1399,6 +1399,9 @@ impl Database {
             // Expands `f(qualifier.*)` into `f(qualifier.c1, …, qualifier.cN)`
             // before TypeCoercion rejects the typeless wildcard. Postgres parity.
             Arc::new(crate::optimizers::WildcardFnArgExpander),
+            // PG parity: `COALESCE(list_col, '{}')` — re-type PG array string
+            // literals as list literals before TypeCoercion fails the call.
+            Arc::new(crate::optimizers::PgArrayLiteralRewriter),
             Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
             Arc::new(crate::optimizers::VariantSelectRewriter),
         ];

--- a/src/database.rs
+++ b/src/database.rs
@@ -1316,6 +1316,16 @@ impl Database {
         let _ = options.set("datafusion.execution.parquet.enable_page_index", "true");
         let _ = options.set("datafusion.execution.parquet.pruning", "true");
         let _ = options.set("datafusion.execution.parquet.skip_metadata", "false");
+        // One-shot footer read sized to match `warm_footer`'s suffix range: the
+        // Foyer metadata cache keys on (path, exact range), so the reader's
+        // first fetch (size-hint..size) hits the entry the warm task populated.
+        // Without this the reader does 8-byte-tail + metadata-range reads —
+        // two sequential S3 RTTs on different keys that can never be pre-warmed
+        // (measured 1.6 s of metadata_load_time on a cold OVH partition).
+        let _ = options.set(
+            "datafusion.execution.parquet.metadata_size_hint",
+            &self.config.cache.timefusion_parquet_metadata_size_hint.to_string(),
+        );
         let _ = options.set("datafusion.explain.show_schema", "true");
         let _ = options.set("datafusion.runtime.metadata_cache_limit", "500M");
 
@@ -2037,12 +2047,18 @@ impl Database {
         let cutoff = (recency_days > 0).then(|| Utc::now().date_naive() - chrono::Duration::days(recency_days.min(3650) as i64));
 
         let mut dropped = 0usize;
-        let paths: Vec<object_store::path::Path> = uris
+        // Footers are warmed for EVERY live file (tens of KB each — they're
+        // what turns a deep-partition first touch from footer+data RTTs into
+        // a single data fetch). Full-file warming stays recency-bounded.
+        let paths: Vec<(object_store::path::Path, bool)> = uris
             .into_iter()
             .filter(|u| u.ends_with(".parquet"))
-            .filter(|u| within_recency(u, cutoff))
-            .filter_map(|u| match relativize_to_prefix(prefix, &u) {
-                Some(path) => Some(path),
+            .map(|u| {
+                let recent = within_recency(&u, cutoff);
+                (u, recent)
+            })
+            .filter_map(|(u, recent)| match relativize_to_prefix(prefix, &u) {
+                Some(path) => Some((path, recent)),
                 None => {
                     // Prefix mismatch (e.g. trailing-slash or query-string
                     // drift between table_url() and get_file_uris()). Warming
@@ -2084,11 +2100,11 @@ impl Database {
         // filter (e.g. in Loki) by what was actually primed.
         let scope = if warm_full_files { "full" } else { "footer-only" };
         futures::stream::iter(paths)
-            .for_each_concurrent(concurrency, |path| {
+            .for_each_concurrent(concurrency, |(path, recent)| {
                 let store = object_store.clone();
                 async move {
                     let _ = crate::object_store_cache::warm_footer(store.as_ref(), &path, metadata_size_hint).await;
-                    if warm_full_files {
+                    if warm_full_files && recent {
                         let _ = crate::object_store_cache::warm_full(store.as_ref(), &path).await;
                     }
                 }
@@ -2169,6 +2185,31 @@ impl Database {
                 // Already inside a detached task — await the warm directly
                 // instead of spawning a second nested task.
                 db.warm_cache_for_uris(store, table_uri, uris).await;
+            }
+        });
+    }
+
+    /// Resolve every registry table and warm recent-partition footers in the
+    /// background, so the first query after a deploy doesn't pay Delta log
+    /// replay + parquet footer reads inline (measured 1.4 s cold vs 13 ms
+    /// warm against OVH S3 for a single-partition random-access lookup).
+    pub fn preload_tables(self: &Arc<Self>) {
+        let db = Arc::clone(self);
+        tokio::spawn(async move {
+            for table_name in crate::schema_loader::registry().list_tables() {
+                let t = std::time::Instant::now();
+                match db.resolve_table("default", &table_name).await {
+                    Ok(table_ref) => {
+                        let uris: Vec<String> = table_ref.read().await.get_file_uris().map(|it| it.collect()).unwrap_or_default();
+                        info!(
+                            "bootstrap.phase=table_preload table={table_name} files={} elapsed_ms={}",
+                            uris.len(),
+                            t.elapsed().as_millis()
+                        );
+                        db.warm_cache_for_table("default", &table_name, uris);
+                    }
+                    Err(e) => info!("bootstrap.phase=table_preload table={table_name} skipped: {e}"),
+                }
             }
         });
     }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -376,6 +376,10 @@ pub fn register_custom_functions(ctx: &mut datafusion::execution::context::Sessi
     // Register Variant-aware expr planner (must be before JSON planner for priority)
     datafusion::execution::FunctionRegistry::register_expr_planner(ctx, Arc::new(VariantAwareExprPlanner))?;
 
+    // PG parity: coalesce that type-checks `coalesce(list_col, '{}')`.
+    // Replaces the built-in under the same name; see PgArrayLiteralRewriter.
+    ctx.register_udf(ScalarUDF::from(crate::optimizers::pg_array_literal_rewriter::PgCoalesceUdf::default()));
+
     // Register to_char function
     ctx.register_udf(create_to_char_udf());
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1060,17 +1060,35 @@ fn jsonb_tagged_field(data_type: DataType) -> Arc<datafusion::arrow::datatypes::
 macro_rules! jsonb_wrapper {
     ($wrap:ident, $inner:ident, $pg_name:expr) => {
         #[derive(Debug, Hash, Eq, PartialEq)]
-        struct $wrap { inner: $inner }
-        impl $wrap { fn new() -> Self { Self { inner: $inner::new() } } }
+        struct $wrap {
+            inner: $inner,
+        }
+        impl $wrap {
+            fn new() -> Self {
+                Self { inner: $inner::new() }
+            }
+        }
         impl ScalarUDFImpl for $wrap {
-            fn as_any(&self) -> &dyn Any { self }
-            fn name(&self) -> &str { $pg_name }
-            fn signature(&self) -> &Signature { self.inner.signature() }
-            fn return_type(&self, a: &[DataType]) -> datafusion::error::Result<DataType> { self.inner.return_type(a) }
-            fn return_field_from_args(&self, _: datafusion::logical_expr::ReturnFieldArgs)
-                -> datafusion::error::Result<datafusion::arrow::datatypes::FieldRef>
-            { Ok(jsonb_tagged_field(DataType::Utf8View)) }
-            fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> { self.inner.invoke_with_args(args) }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+            fn name(&self) -> &str {
+                $pg_name
+            }
+            fn signature(&self) -> &Signature {
+                self.inner.signature()
+            }
+            fn return_type(&self, a: &[DataType]) -> datafusion::error::Result<DataType> {
+                self.inner.return_type(a)
+            }
+            fn return_field_from_args(
+                &self, _: datafusion::logical_expr::ReturnFieldArgs,
+            ) -> datafusion::error::Result<datafusion::arrow::datatypes::FieldRef> {
+                Ok(jsonb_tagged_field(DataType::Utf8View))
+            }
+            fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
+                self.inner.invoke_with_args(args)
+            }
         }
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,8 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     db = db.start_maintenance_schedulers().await?;
     let db = Arc::new(db);
     db.setup_session_tables(&mut session_context)?;
+    // Non-blocking: snapshot load + footer warm-up off the first query's path.
+    db.preload_tables();
 
     // Start PGWire server on the listener we pre-bound at the top of
     // async_main. First, hand control of that listener back from the

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,10 +89,10 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
                 // commit, derived from the post-write snapshot under the same write
                 // lock — no second log scan. Watermark goes into Delta commit metadata
                 // for crash-mid-flush recovery.
+                // insert_records_batch warms the just-flushed files itself
+                // (watermark-gated) — no warm here, or every flush would issue
+                // the warm GETs twice.
                 let added = db.insert_records_batch(&project_id, &table_name, batches, true, Some(&wal_watermark)).await?;
-                // Warm the just-flushed files into the cache so the first
-                // dashboard read of this partition hits Foyer, not S3.
-                db.warm_cache_for_table(&project_id, &table_name, added.clone());
                 if !added.is_empty() {
                     db.mark_delta_has_files(&project_id, &table_name);
                 }

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -22,7 +22,7 @@ use tokio::{
     sync::{Mutex, RwLock},
     task::JoinSet,
 };
-use tracing::{Instrument, debug, field::Empty, info, instrument};
+use tracing::{Instrument, debug, field::Empty, info, instrument, warn};
 
 /// Cache entry with metadata and TTL
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -296,6 +296,15 @@ impl SharedFoyerCache {
             config.metadata_disk_size_bytes / 1024 / 1024 / 1024,
             config.ttl.as_secs()
         );
+        // A sub-5-minute TTL is almost certainly a debug leftover (a real one
+        // shipped in .env once): every idle partition re-cold-starts after
+        // expiry, silently erasing the entire warm-path win.
+        if config.ttl < std::time::Duration::from_secs(300) {
+            warn!(
+                "Foyer TTL is only {}s — cached footers expire between queries; set TIMEFUSION_FOYER_TTL_SECONDS higher unless debugging",
+                config.ttl.as_secs()
+            );
+        }
 
         std::fs::create_dir_all(&config.cache_dir)?;
         let metadata_cache_dir = config.cache_dir.join("metadata");
@@ -1469,6 +1478,39 @@ mod tests {
     use object_store::{ObjectStoreExt, memory::InMemory};
 
     use super::*;
+
+    // Locks in the containment-probe slice math in get_range_cached: a strict
+    // sub-range of the warmed (size-hint..size) footer never equals the warm
+    // key, so only the containment probe can serve it without an inner fetch.
+    #[tokio::test]
+    async fn containment_probe_serves_subrange_of_warmed_footer() -> anyhow::Result<()> {
+        let inner = Arc::new(InMemory::new());
+        // The probe computes its candidate key from the CONFIG's size hint, so
+        // the warm call below must use the same value (as prod does — both
+        // read config.cache.timefusion_parquet_metadata_size_hint).
+        let hint = 1024u64;
+        let cfg = FoyerCacheConfig::test_config_with("containment_probe", |c| c.parquet_metadata_size_hint = hint as usize);
+        let cache = FoyerObjectStoreCache::new(inner.clone(), cfg).await?;
+        let path = Path::from("tbl/date=2026-01-01/part.parquet");
+        let data = Bytes::from((0..4096u32).map(|i| (i % 251) as u8).collect::<Vec<u8>>());
+        // Put via the inner store so nothing is cached from a write payload.
+        inner.put(&path, PutPayload::from(data.clone())).await?;
+
+        // file (4096B) > hint → warm key is (3072..4096)
+        assert!(warm_footer(&cache, &path, hint).await, "footer warm must succeed");
+
+        let before = cache.get_stats().await;
+        let r = 3100u64..3500u64;
+        let got = cache.get_range(&path, r.clone()).await?;
+        assert_eq!(got, data.slice(r.start as usize..r.end as usize), "containment slice math");
+
+        let after = cache.get_stats().await;
+        assert_eq!(after.metadata.hits, before.metadata.hits + 1, "served by the containment probe");
+        assert_eq!(after.metadata.inner_gets, before.metadata.inner_gets, "no inner fetch after warm");
+
+        cache.shutdown().await?;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_basic_operations() -> anyhow::Result<()> {

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -939,6 +939,12 @@ impl FoyerObjectStoreCache {
                             self.update_metadata_stats(|st| st.hits += 1).await;
                             span.record("cache_hit", true);
                             span.record("is_metadata", true);
+                            // Distinct from the exact-key HIT log above so cache-key
+                            // alignment is diagnosable on a new deployment.
+                            debug!(
+                                "Metadata cache HIT (containment {}..{}) for: {} (range: {}..{})",
+                                candidate, file_size, location, range.start, range.end
+                            );
                             let sliced = Bytes::copy_from_slice(&value.data[s..e]);
                             self.maybe_touch(&self.metadata_cache, &key, entry.clone(), 0);
                             return Ok(sliced);

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -913,6 +913,35 @@ impl FoyerObjectStoreCache {
             let file_size = file_meta.size;
             let metadata_size_hint = self.config.parquet_metadata_size_hint as u64;
 
+            // Containment probe against the two ranges `warm_footer` can have
+            // populated: the suffix tail (size-hint..size) and — for files
+            // smaller than the hint — the whole file (0..size). The reader's
+            // own footer reads (8-byte tail, then the parsed metadata range)
+            // never equal those keys exactly, so the exact-key probe above
+            // misses and a pre-warmed cold partition still paid 1-2 S3 RTTs
+            // of metadata latency (300 ms+ observed against OVH).
+            let warm_start = file_size.saturating_sub(metadata_size_hint);
+            for candidate in [0, warm_start] {
+                if candidate <= range.start && range.end <= file_size {
+                    let key = Self::make_range_cache_key(location, &(candidate..file_size));
+                    if let Ok(Some(entry)) = self.metadata_cache.get(&key).await {
+                        let value = entry.value();
+                        let (s, e) = ((range.start - candidate) as usize, (range.end - candidate) as usize);
+                        if !value.is_expired(self.config.ttl) && e <= value.data.len() {
+                            self.update_metadata_stats(|st| st.hits += 1).await;
+                            span.record("cache_hit", true);
+                            span.record("is_metadata", true);
+                            let sliced = Bytes::from(value.data[s..e].to_vec());
+                            self.maybe_touch(&self.metadata_cache, &key, entry.clone(), 0);
+                            return Ok(sliced);
+                        }
+                    }
+                }
+                if candidate == warm_start {
+                    break; // both probes identical when warm_start == 0
+                }
+            }
+
             // Check if this is likely a metadata request (reading from near the end of the file)
             let is_metadata_request = range.start >= file_size.saturating_sub(metadata_size_hint);
             span.record("is_metadata", is_metadata_request);

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -922,6 +922,9 @@ impl FoyerObjectStoreCache {
             // of metadata latency (300 ms+ observed against OVH).
             let warm_start = file_size.saturating_sub(metadata_size_hint);
             // When warm_start == 0 the two candidate ranges coincide; probe once.
+            // candidate=0 also means files smaller than the hint are fully
+            // cached here by warm_footer — any in-bounds read (including data
+            // pages) is intentionally served from the metadata cache.
             let candidates: &[u64] = if warm_start == 0 { &[0] } else { &[0, warm_start] };
             for &candidate in candidates {
                 if candidate <= range.start && range.end <= file_size {

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -925,7 +925,10 @@ impl FoyerObjectStoreCache {
             // candidate=0 also means files smaller than the hint are fully
             // cached here by warm_footer — any in-bounds read (including data
             // pages) is intentionally served from the metadata cache.
-            let candidates: &[u64] = if warm_start == 0 { &[0] } else { &[0, warm_start] };
+            // Probe the suffix key first: for files larger than the hint only
+            // (warm_start..size) exists, so leading with it saves an always-miss
+            // (0..size) lookup on the common footer-read path.
+            let candidates: &[u64] = if warm_start == 0 { &[0] } else { &[warm_start, 0] };
             for &candidate in candidates {
                 if candidate <= range.start && range.end <= file_size {
                     let key = Self::make_range_cache_key(location, &(candidate..file_size));

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -939,7 +939,7 @@ impl FoyerObjectStoreCache {
                             self.update_metadata_stats(|st| st.hits += 1).await;
                             span.record("cache_hit", true);
                             span.record("is_metadata", true);
-                            let sliced = Bytes::from(value.data[s..e].to_vec());
+                            let sliced = Bytes::copy_from_slice(&value.data[s..e]);
                             self.maybe_touch(&self.metadata_cache, &key, entry.clone(), 0);
                             return Ok(sliced);
                         }

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -921,7 +921,9 @@ impl FoyerObjectStoreCache {
             // misses and a pre-warmed cold partition still paid 1-2 S3 RTTs
             // of metadata latency (300 ms+ observed against OVH).
             let warm_start = file_size.saturating_sub(metadata_size_hint);
-            for candidate in [0, warm_start] {
+            // When warm_start == 0 the two candidate ranges coincide; probe once.
+            let candidates: &[u64] = if warm_start == 0 { &[0] } else { &[0, warm_start] };
+            for &candidate in candidates {
                 if candidate <= range.start && range.end <= file_size {
                     let key = Self::make_range_cache_key(location, &(candidate..file_size));
                     if let Ok(Some(entry)) = self.metadata_cache.get(&key).await {
@@ -936,9 +938,6 @@ impl FoyerObjectStoreCache {
                             return Ok(sliced);
                         }
                     }
-                }
-                if candidate == warm_start {
-                    break; // both probes identical when warm_start == 0
                 }
             }
 

--- a/src/optimizers/mod.rs
+++ b/src/optimizers/mod.rs
@@ -1,3 +1,4 @@
+pub mod pg_array_literal_rewriter;
 mod tantivy_rewriter;
 mod variant_insert_rewriter;
 mod variant_select_rewriter;
@@ -7,6 +8,7 @@ use datafusion::{
     logical_expr::{BinaryExpr, Expr, Operator},
     scalar::ScalarValue,
 };
+pub use pg_array_literal_rewriter::PgArrayLiteralRewriter;
 pub use tantivy_rewriter::TantivyPredicateRewriter;
 pub use variant_insert_rewriter::VariantInsertRewriter;
 pub use variant_select_rewriter::VariantSelectRewriter;

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -205,6 +205,10 @@ fn rewrite_in_expr(expr: Expr, input_schemas: &[Arc<DFSchema>]) -> Result<Transf
 
 /// Convert parsed PG array elements to a typed list literal. None on any
 /// element that doesn't parse as `elem_type` (caller leaves the arg alone).
+/// Always emits `ScalarValue::List` even when the sibling column is
+/// LargeList/FixedSizeList: coerce_types may claim those, but TypeCoercion
+/// then casts the literal (arrow supports List → Large/FixedSizeList), so no
+/// physical-planning mismatch — the variant only matters for element type.
 fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<ScalarValue> {
     let vals: Option<Vec<ScalarValue>> = elems
         .into_iter()
@@ -224,6 +228,8 @@ fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<
 /// Malformed quoting parses leniently rather than strictly: bailing would
 /// only swap one error (this rewrite skipped → TypeCoercion's) for another,
 /// while leniency keeps stable-but-sloppy client literals working.
+/// Only the bare `NULL` keyword is a null element; `\N` is COPY text-format
+/// syntax, not array-literal syntax, and stays literal text (as in PG).
 fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
     let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
     if inner.trim().is_empty() {

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -33,6 +33,11 @@ use datafusion::{
 /// `coalesce(List, Utf8)` must type-check up front; the analyzer rule below
 /// then replaces the string literal with a real list literal so TypeCoercion
 /// never has to cast Utf8 → List (unsupported in Arrow).
+///
+/// Registered under the built-in's name, shadowing it session-wide; every
+/// trait method delegates to the inner built-in. On a DataFusion upgrade,
+/// re-check `ScalarUDFImpl` for new methods whose defaults would diverge
+/// from the built-in coalesce and forward them here too.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PgCoalesceUdf {
     inner: Arc<datafusion::logical_expr::ScalarUDF>,
@@ -75,6 +80,11 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
     }
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types).or_else(|e| {
+            // Fallback only runs after the built-in coercion failed. Promote
+            // EVERY string arg (not just literals — arg types carry no
+            // expression info here) to the sibling list type: PG treats any
+            // string in array position as an array literal, and the analyzer
+            // rule rewrites the literals to real lists before execution.
             // First list type wins. If a call ever mixes list element types
             // (coalesce(utf8_list, int_list, '{}')) the retried coercion below
             // fails on the second list and the original error surfaces — no
@@ -177,15 +187,12 @@ fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<
 }
 
 /// Parse a PG array literal of strings: `{}`, `{a,b}`, `{"a,b",NULL}`.
-/// Returns None if `s` isn't brace-wrapped (not an array literal).
+/// Returns None if `s` isn't brace-wrapped (not an array literal), or if it
+/// contains unquoted nested braces (multi-dimensional arrays like
+/// `{{a},{b}}` — the schema is 1-D only, and misparsing the inner braces as
+/// element text would be silently wrong; bail so the arg is left untouched).
 fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
     let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
-    // Multi-dimensional literals ('{{a},{b}}') would misparse as flat
-    // elements once the outer braces are stripped — bail (arg left alone,
-    // TypeCoercion reports the original error) rather than silently mangle.
-    if inner.contains('{') || inner.contains('}') {
-        return None;
-    }
     if inner.trim().is_empty() {
         return Some(vec![]);
     }
@@ -194,6 +201,7 @@ fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
     while let Some(c) = chars.next() {
         match c {
             '\\' if in_quotes => cur.push(chars.next()?),
+            '{' | '}' if !in_quotes => return None, // multi-dimensional literal
             '"' => {
                 if !in_quotes && cur.trim().is_empty() {
                     cur.clear(); // drop whitespace before an opening quote
@@ -273,8 +281,14 @@ mod tests {
         assert_eq!(parse_pg_string_array("{a,b}"), Some(vec![Some("a".into()), Some("b".into())]));
         assert_eq!(parse_pg_string_array(r#"{"a,b", c }"#), Some(vec![Some("a,b".into()), Some("c".into())]));
         assert_eq!(parse_pg_string_array("{NULL,\"NULL\"}"), Some(vec![None, Some("NULL".into())]));
-        assert_eq!(parse_pg_string_array("plain"), None);
-        // Multi-dimensional literals are rejected, not silently flattened.
+        // Chars between a closing quote and the next comma are dropped — PG
+        // rejects these literals outright; we parse leniently and keep the
+        // quoted value. Pinned so the behavior is intentional, not accidental.
+        assert_eq!(parse_pg_string_array("{\"a\"x,b}"), Some(vec![Some("a".into()), Some("b".into())]));
+        // Multi-dimensional literals are rejected, not silently flattened;
+        // braces inside quotes are ordinary element text.
         assert_eq!(parse_pg_string_array("{{a},{b}}"), None);
+        assert_eq!(parse_pg_string_array(r#"{"{x}",y}"#), Some(vec![Some("{x}".into()), Some("y".into())]));
+        assert_eq!(parse_pg_string_array("plain"), None);
     }
 }

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -12,6 +12,14 @@
 //! literal, the literal is re-parsed as a PG array literal of the list's
 //! element type. Only string element types are handled (the schema's arrays
 //! are all `VARCHAR[]`); anything else is left for TypeCoercion to report.
+//!
+//! Known divergences from PG (each pinned by a test):
+//! - a string COLUMN coalesced with a list wraps into a one-element list
+//!   (PG errors) — see `coalesce_string_column_with_list_wraps_…`.
+//! - malformed quoting (`{"a"x,b}`, `{a"b"}`) parses leniently (PG errors)
+//!   — see `pg_array_parse_shapes`.
+//! - multi-dimensional literals are rejected → arg left untouched, original
+//!   TypeCoercion error surfaces (PG supports them; schema is 1-D only).
 
 use std::sync::Arc;
 
@@ -196,6 +204,9 @@ fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<
 /// contains unquoted nested braces (multi-dimensional arrays like
 /// `{{a},{b}}` — the schema is 1-D only, and misparsing the inner braces as
 /// element text would be silently wrong; bail so the arg is left untouched).
+/// Malformed quoting parses leniently rather than strictly: bailing would
+/// only swap one error (this rewrite skipped → TypeCoercion's) for another,
+/// while leniency keeps stable-but-sloppy client literals working.
 fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
     let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
     if inner.trim().is_empty() {

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -14,19 +14,21 @@
 //! are all `VARCHAR[]`); anything else is left for TypeCoercion to report.
 //!
 //! Known divergences from PG (each pinned by a test):
-//! - a string COLUMN coalesced with a list wraps into a one-element list
-//!   (PG errors) — see `coalesce_string_column_with_list_wraps_…`.
-//! - malformed quoting (`{"a"x,b}`, `{a"b"}`) parses leniently (PG errors)
-//!   — see `pg_array_parse_shapes`.
-//! - multi-dimensional literals are rejected → arg left untouched, original
-//!   TypeCoercion error surfaces (PG supports them; schema is 1-D only).
+//! - a string COLUMN (or unrewritable literal) coalesced with a list errors
+//!   like PG ("cannot be matched") rather than silently wrapping into a
+//!   one-element list via arrow's blanket `(_, List)` cast — see
+//!   `coalesce_string_column_with_list_errors`.
+//! - malformed quoting WITHIN a brace-wrapped literal (`{"a"x,b}`, `{a"b"}`)
+//!   parses leniently (PG errors) — see `pg_array_parse_shapes`.
+//! - multi-dimensional literals are rejected → arg left untouched, the
+//!   string-arg guard errors (PG supports them; schema is 1-D only).
 
 use std::sync::Arc;
 
 use datafusion::{
     arrow::datatypes::DataType,
     common::{
-        DFSchema, Result,
+        DFSchema, Result, plan_err,
         tree_node::{Transformed, TreeNode},
     },
     config::ConfigOptions,
@@ -91,17 +93,16 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
             // Fallback only runs after the built-in coercion failed. Promote
             // EVERY string arg (not just literals — arg types carry no
             // expression info here) to the sibling list type: PG treats any
-            // string in array position as an array literal, and the analyzer
-            // rule rewrites the literals to real lists before execution.
+            // string in array position as an array literal. The analyzer rule
+            // rewrites the literals to real lists before execution and rejects
+            // any string arg it can't rewrite (real string columns, malformed
+            // literals) with a PG-style planning error — required because
+            // arrow-cast's blanket `(_, List)` rule would otherwise "cast" the
+            // string by wrapping it in a single-element list, silently.
             // First list type wins. If a call ever mixes list element types
             // (coalesce(utf8_list, int_list, '{}')) the retried coercion below
             // fails on the second list and the original error surfaces — no
             // silent mis-typing, just a planner-time error like today.
-            // NOTE: a real string COLUMN (not a literal) coalesced with a list
-            // also passes here; with no literal to rewrite, TypeCoercion's
-            // Utf8→List cast wraps each value into a one-element list — a
-            // deliberate, pinned divergence from PG (which errors). See
-            // coalesce_string_column_with_list_wraps_into_single_element_list.
             let list_t = arg_types
                 .iter()
                 .find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)))
@@ -136,14 +137,16 @@ impl AnalyzerRule for PgArrayLiteralRewriter {
 }
 
 fn rewrite_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
-    let input_schemas: Vec<_> = plan.inputs().iter().map(|i| i.schema().clone()).collect();
-    // Leaf nodes (TableScan etc.) are skipped: COALESCE over a list column
-    // reaches us inside Projection/Filter nodes ABOVE the scan, whose input
-    // schemas type the column. If a future rule ever pushes such an expr into
-    // a TableScan's own filter list, it would skip this rewrite and surface
-    // the original TypeCoercion error — extend this to use plan.schema() then.
+    let mut input_schemas: Vec<_> = plan.inputs().iter().map(|i| i.schema().clone()).collect();
+    // Leaf nodes (TableScan with pushed-down filters, Values) have no inputs;
+    // their exprs are typed by their own schema instead. Without this, a
+    // coalesce pushed into a TableScan's filter list would skip both the
+    // rewrite and the string-arg guard below — arrow's
+    // wrap-into-single-element-list cast would then fire silently. A filter on
+    // a column the scan doesn't project still won't resolve here (filters are
+    // typed by the source schema); it falls through to the TypeCoercion error.
     if input_schemas.is_empty() {
-        return Ok(Transformed::no(plan));
+        input_schemas.push(Arc::clone(plan.schema()));
     }
     plan.map_expressions(|expr| expr.transform_up(|e| rewrite_in_expr(e, &input_schemas)))
 }
@@ -181,7 +184,21 @@ fn rewrite_in_expr(expr: Expr, input_schemas: &[Arc<DFSchema>]) -> Result<Transf
             }
             _ => a,
         })
-        .collect();
+        .collect::<Vec<_>>();
+    // Any arg still string-typed here (a real string column, or a literal that
+    // didn't parse as a PG array) survived only because PgCoalesceUdf's
+    // coerce_types fallback over-promoted it to pass planning. Letting it
+    // reach TypeCoercion would NOT error: arrow-cast's blanket `(_, List)`
+    // rule wraps each value in a single-element list — a silently wrong
+    // result. Reject it like PG ("COALESCE types ... cannot be matched").
+    if let Some(bad) = new_args.iter().find_map(|a| {
+        input_schemas.iter().find_map(|s| match a.get_type(s.as_ref()) {
+            Ok(t @ (DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8)) => Some(t),
+            _ => None,
+        })
+    }) {
+        return plan_err!("COALESCE types {bad} and List({elem_type}) cannot be matched");
+    }
     let rebuilt = Expr::ScalarFunction(ScalarFunction { func, args: new_args });
     Ok(if changed { Transformed::yes(rebuilt) } else { Transformed::no(rebuilt) })
 }
@@ -284,25 +301,67 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn coalesce_string_column_with_list_wraps_into_single_element_list() {
-        // A genuine string COLUMN (not a literal) coalesced with a list passes
-        // the UDF's lenient coerce_types; with no literal for the analyzer
-        // rule to rewrite, TypeCoercion casts the column — and Arrow defines
-        // Utf8 → List(Utf8) as wrapping each value in a one-element list. So
-        // the outcome is a deterministic [value], NOT an error (PG would
-        // error here) and NOT silent garbage. Pinned so a behavior change on
-        // a DataFusion/Arrow upgrade is caught.
-        let ctx = ctx_with_rule();
-        let out = one_string(&ctx, "SELECT COALESCE(s, CAST(NULL AS VARCHAR[])) AS v FROM (SELECT 'x' AS s)").await;
-        assert!(out.contains("[x]"), "{out}");
-    }
-
-    #[tokio::test]
     async fn non_array_string_untouched() {
         let ctx = ctx_with_rule();
         // No list-typed arg → rule must not fire; plain string coalesce still works.
         let out = one_string(&ctx, "SELECT COALESCE(CAST(NULL AS VARCHAR), '{}') AS v FROM (SELECT 1)").await;
         assert!(out.contains("{}"), "{out}");
+    }
+
+    // Analyzer rules run at physical planning, so the error may surface at
+    // sql() or collect() — either way it must never execute successfully.
+    async fn expect_plan_error(ctx: &SessionContext, sql: &str) -> String {
+        match ctx.sql(sql).await {
+            Err(e) => e.to_string(),
+            Ok(df) => df.collect().await.expect_err("query must fail planning").to_string(),
+        }
+    }
+
+    // arrow-cast's blanket `(_, List)` rule casts ANY type to a list by
+    // wrapping each value in a single-element list, so without an explicit
+    // guard these queries would silently return `[varchar_value]` instead of
+    // failing like PG ("COALESCE types ... cannot be matched").
+    #[tokio::test]
+    async fn coalesce_string_column_with_list_errors() {
+        let ctx = ctx_with_rule();
+        let err = expect_plan_error(&ctx, "SELECT COALESCE(v, l) FROM (SELECT CAST('x' AS VARCHAR) AS v, CAST(NULL AS VARCHAR[]) AS l)").await;
+        assert!(err.contains("cannot be matched"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn coalesce_unparseable_literal_with_list_errors() {
+        let ctx = ctx_with_rule();
+        let err = expect_plan_error(&ctx, "SELECT COALESCE(CAST(NULL AS VARCHAR[]), 'not-an-array') FROM (SELECT 1)").await;
+        assert!(err.contains("cannot be matched"), "{err}");
+    }
+
+    // Guards the leaf-node path in rewrite_in_plan: a TableScan carrying a
+    // pushed-down coalesce filter has no inputs, so its exprs must be typed
+    // against its own schema for the rewrite to fire.
+    #[test]
+    fn rewrites_inside_table_scan_filters() {
+        use datafusion::{
+            arrow::datatypes::{Field, Schema},
+            logical_expr::{
+                col, lit,
+                logical_plan::builder::{LogicalPlanBuilder, LogicalTableSource},
+            },
+        };
+        let schema = Schema::new(vec![Field::new("hashes", DataType::List(Field::new("item", DataType::Utf8, true).into()), true)]);
+        let coalesce = Expr::ScalarFunction(ScalarFunction::new_udf(datafusion::functions::core::coalesce(), vec![col("hashes"), lit("{}")]));
+        let scan = LogicalPlanBuilder::scan_with_filters("t", Arc::new(LogicalTableSource::new(schema.into())), None, vec![coalesce.eq(col("hashes"))])
+            .unwrap()
+            .build()
+            .unwrap();
+        let analyzed = PgArrayLiteralRewriter.analyze(scan, &ConfigOptions::default()).unwrap();
+        let LogicalPlan::TableScan(ts) = analyzed else { panic!("expected TableScan") };
+        let Expr::BinaryExpr(be) = &ts.filters[0] else { panic!("expected eq filter") };
+        let Expr::ScalarFunction(f) = be.left.as_ref() else { panic!("expected coalesce") };
+        assert!(
+            matches!(f.args[1], Expr::Literal(ScalarValue::List(_), _)),
+            "array literal in TableScan filter not rewritten: {:?}",
+            f.args[1]
+        );
     }
 
     #[test]

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -110,6 +110,11 @@ impl AnalyzerRule for PgArrayLiteralRewriter {
 
 fn rewrite_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
     let input_schemas: Vec<_> = plan.inputs().iter().map(|i| i.schema().clone()).collect();
+    // Leaf nodes (TableScan etc.) are skipped: COALESCE over a list column
+    // reaches us inside Projection/Filter nodes ABOVE the scan, whose input
+    // schemas type the column. If a future rule ever pushes such an expr into
+    // a TableScan's own filter list, it would skip this rewrite and surface
+    // the original TypeCoercion error — extend this to use plan.schema() then.
     if input_schemas.is_empty() {
         return Ok(Transformed::no(plan));
     }

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -89,6 +89,10 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
             // (coalesce(utf8_list, int_list, '{}')) the retried coercion below
             // fails on the second list and the original error surfaces — no
             // silent mis-typing, just a planner-time error like today.
+            // NOTE: a real string COLUMN (not a literal) coalesced with a list
+            // also passes here, but the analyzer rule has no literal to
+            // rewrite, so the failure surfaces at execution (Utf8→List cast)
+            // instead of planning. Acceptable: PG errors on that query too.
             let list_t = arg_types
                 .iter()
                 .find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)))
@@ -265,6 +269,20 @@ mod tests {
         let ctx = ctx_with_rule();
         let out = one_string(&ctx, "SELECT COALESCE(CAST(NULL AS VARCHAR[]), '{a, b, \"c,d\", NULL}') AS v FROM (SELECT 1)").await;
         assert!(out.contains("[a, b, c,d, ]"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn coalesce_string_column_with_list_wraps_into_single_element_list() {
+        // A genuine string COLUMN (not a literal) coalesced with a list passes
+        // the UDF's lenient coerce_types; with no literal for the analyzer
+        // rule to rewrite, TypeCoercion casts the column — and Arrow defines
+        // Utf8 → List(Utf8) as wrapping each value in a one-element list. So
+        // the outcome is a deterministic [value], NOT an error (PG would
+        // error here) and NOT silent garbage. Pinned so a behavior change on
+        // a DataFusion/Arrow upgrade is caught.
+        let ctx = ctx_with_rule();
+        let out = one_string(&ctx, "SELECT COALESCE(s, CAST(NULL AS VARCHAR[])) AS v FROM (SELECT 'x' AS s)").await;
+        assert!(out.contains("[x]"), "{out}");
     }
 
     #[tokio::test]

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -215,10 +215,8 @@ mod tests {
     use super::*;
 
     fn ctx_with_rule() -> SessionContext {
-        let rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>> = vec![
-            Arc::new(PgArrayLiteralRewriter),
-            Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
-        ];
+        let rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>> =
+            vec![Arc::new(PgArrayLiteralRewriter), Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new())];
         let state = SessionStateBuilder::new().with_default_features().with_analyzer_rules(rules).build();
         let ctx = SessionContext::new_with_state(state);
         ctx.register_udf(datafusion::logical_expr::ScalarUDF::from(PgCoalesceUdf::default()));

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -324,7 +324,11 @@ mod tests {
     #[tokio::test]
     async fn coalesce_string_column_with_list_errors() {
         let ctx = ctx_with_rule();
-        let err = expect_plan_error(&ctx, "SELECT COALESCE(v, l) FROM (SELECT CAST('x' AS VARCHAR) AS v, CAST(NULL AS VARCHAR[]) AS l)").await;
+        let err = expect_plan_error(
+            &ctx,
+            "SELECT COALESCE(v, l) FROM (SELECT CAST('x' AS VARCHAR) AS v, CAST(NULL AS VARCHAR[]) AS l)",
+        )
+        .await;
         assert!(err.contains("cannot be matched"), "{err}");
     }
 
@@ -347,7 +351,11 @@ mod tests {
                 logical_plan::builder::{LogicalPlanBuilder, LogicalTableSource},
             },
         };
-        let schema = Schema::new(vec![Field::new("hashes", DataType::List(Field::new("item", DataType::Utf8, true).into()), true)]);
+        let schema = Schema::new(vec![Field::new(
+            "hashes",
+            DataType::List(Field::new("item", DataType::Utf8, true).into()),
+            true,
+        )]);
         let coalesce = Expr::ScalarFunction(ScalarFunction::new_udf(datafusion::functions::core::coalesce(), vec![col("hashes"), lit("{}")]));
         let scan = LogicalPlanBuilder::scan_with_filters("t", Arc::new(LogicalTableSource::new(schema.into())), None, vec![coalesce.eq(col("hashes"))])
             .unwrap()
@@ -356,7 +364,9 @@ mod tests {
         let analyzed = PgArrayLiteralRewriter.analyze(scan, &ConfigOptions::default()).unwrap();
         let LogicalPlan::TableScan(ts) = analyzed else { panic!("expected TableScan") };
         let Expr::BinaryExpr(be) = &ts.filters[0] else { panic!("expected eq filter") };
-        let Expr::ScalarFunction(f) = be.left.as_ref() else { panic!("expected coalesce") };
+        let Expr::ScalarFunction(f) = be.left.as_ref() else {
+            panic!("expected coalesce")
+        };
         assert!(
             matches!(f.args[1], Expr::Literal(ScalarValue::List(_), _)),
             "array literal in TableScan filter not rewritten: {:?}",

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -48,6 +48,7 @@ use datafusion::{
 /// trait method delegates to the inner built-in. On a DataFusion upgrade,
 /// re-check `ScalarUDFImpl` for new methods whose defaults would diverge
 /// from the built-in coalesce and forward them here too.
+/// Last audited against DataFusion 53.1.0 — bump this with each audit.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PgCoalesceUdf {
     inner: Arc<datafusion::logical_expr::ScalarUDF>,
@@ -393,6 +394,10 @@ mod tests {
         // The mirror case — non-whitespace BEFORE an opening quote — is also
         // PG-invalid; we leniently concatenate. Pinned for the same reason.
         assert_eq!(parse_pg_string_array("{a\"b\"}"), Some(vec![Some("ab".into())]));
+        // Lone backslash at end of input (inside quotes, escaping nothing):
+        // chars.next()? propagates None → arg left unrewritten → the
+        // string-arg guard errors (never a panic or a half-parsed list).
+        assert_eq!(parse_pg_string_array("{\"a\\}"), None);
         // Multi-dimensional literals are rejected, not silently flattened;
         // braces inside quotes are ordinary element text.
         assert_eq!(parse_pg_string_array("{{a},{b}}"), None);

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -1,0 +1,264 @@
+//! Rewrite Postgres array literals (`'{}'`, `'{a,b}'`) into typed list
+//! literals where an array type is expected.
+//!
+//! Postgres resolves `COALESCE(hashes, '{}')` by treating the untyped string
+//! literal as an array literal of the other argument's type. DataFusion's
+//! coercion can't unify `List(Utf8View)` with `Utf8`, so the same expression
+//! failed at planning — which broke monoscope's `lookupOtelRecord`
+//! random-access query (`COALESCE(hashes,'{}')`, `COALESCE(summary,'{}')`).
+//!
+//! This rule runs before `TypeCoercion`. For any `coalesce` call where at
+//! least one argument types to a list and another is a `'{...}'` string
+//! literal, the literal is re-parsed as a PG array literal of the list's
+//! element type. Only string element types are handled (the schema's arrays
+//! are all `VARCHAR[]`); anything else is left for TypeCoercion to report.
+
+use std::sync::Arc;
+
+use datafusion::{
+    arrow::datatypes::DataType,
+    common::{
+        DFSchema, Result,
+        tree_node::{Transformed, TreeNode},
+    },
+    config::ConfigOptions,
+    logical_expr::{Expr, ExprSchemable, LogicalPlan, expr::ScalarFunction},
+    optimizer::AnalyzerRule,
+    scalar::ScalarValue,
+};
+
+/// `coalesce` wrapper whose coercion additionally unifies string args into a
+/// sibling list type. Needed because the SQL planner computes projection
+/// schemas (→ `coerce_types`) BEFORE analyzer rules run, so
+/// `coalesce(List, Utf8)` must type-check up front; the analyzer rule below
+/// then replaces the string literal with a real list literal so TypeCoercion
+/// never has to cast Utf8 → List (unsupported in Arrow).
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct PgCoalesceUdf {
+    inner: Arc<datafusion::logical_expr::ScalarUDF>,
+}
+
+impl Default for PgCoalesceUdf {
+    fn default() -> Self {
+        Self {
+            inner: datafusion::functions::core::coalesce(),
+        }
+    }
+}
+
+impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "coalesce"
+    }
+    fn signature(&self) -> &datafusion::logical_expr::Signature {
+        self.inner.signature()
+    }
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        self.inner.inner().return_type(arg_types)
+    }
+    fn return_field_from_args(&self, args: datafusion::logical_expr::ReturnFieldArgs) -> Result<datafusion::arrow::datatypes::FieldRef> {
+        self.inner.inner().return_field_from_args(args)
+    }
+    fn invoke_with_args(&self, args: datafusion::logical_expr::ScalarFunctionArgs) -> Result<datafusion::logical_expr::ColumnarValue> {
+        self.inner.inner().invoke_with_args(args)
+    }
+    fn short_circuits(&self) -> bool {
+        self.inner.inner().short_circuits()
+    }
+    fn simplify(
+        &self, args: Vec<Expr>, info: &datafusion::logical_expr::simplify::SimplifyContext,
+    ) -> Result<datafusion::logical_expr::simplify::ExprSimplifyResult> {
+        self.inner.inner().simplify(args, info)
+    }
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        self.inner.coerce_types(arg_types).or_else(|e| {
+            let list_t = arg_types
+                .iter()
+                .find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)))
+                .ok_or(e)?
+                .clone();
+            let patched: Vec<DataType> = arg_types
+                .iter()
+                .map(|t| {
+                    if matches!(t, DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8) {
+                        list_t.clone()
+                    } else {
+                        t.clone()
+                    }
+                })
+                .collect();
+            self.inner.coerce_types(&patched)
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct PgArrayLiteralRewriter;
+
+impl AnalyzerRule for PgArrayLiteralRewriter {
+    fn name(&self) -> &str {
+        "pg_array_literal_rewriter"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        plan.transform_up(rewrite_in_plan).map(|t| t.data)
+    }
+}
+
+fn rewrite_in_plan(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+    let input_schemas: Vec<_> = plan.inputs().iter().map(|i| i.schema().clone()).collect();
+    if input_schemas.is_empty() {
+        return Ok(Transformed::no(plan));
+    }
+    plan.map_expressions(|expr| expr.transform_up(|e| rewrite_in_expr(e, &input_schemas)))
+}
+
+fn rewrite_in_expr(expr: Expr, input_schemas: &[Arc<DFSchema>]) -> Result<Transformed<Expr>> {
+    let Expr::ScalarFunction(ScalarFunction { func, args }) = expr else {
+        return Ok(Transformed::no(expr));
+    };
+    let no = |args| Ok(Transformed::no(Expr::ScalarFunction(ScalarFunction { func: Arc::clone(&func), args })));
+    if func.name() != "coalesce" {
+        return no(args);
+    }
+
+    // Element type of the first arg that resolves to a list type.
+    let elem_type = args.iter().find_map(|a| {
+        input_schemas.iter().find_map(|s| match a.get_type(s.as_ref()).ok()? {
+            DataType::List(f) | DataType::LargeList(f) | DataType::FixedSizeList(f, _) => Some(f.data_type().clone()),
+            _ => None,
+        })
+    });
+    let Some(elem_type) = elem_type else { return no(args) };
+
+    let mut changed = false;
+    let new_args = args
+        .into_iter()
+        .map(|a| match &a {
+            Expr::Literal(ScalarValue::Utf8(Some(s)) | ScalarValue::Utf8View(Some(s)) | ScalarValue::LargeUtf8(Some(s)), _) => {
+                match parse_pg_string_array(s).and_then(|elems| pg_elems_to_list(elems, &elem_type)) {
+                    Some(list) => {
+                        changed = true;
+                        Expr::Literal(list, None)
+                    }
+                    None => a,
+                }
+            }
+            _ => a,
+        })
+        .collect();
+    let rebuilt = Expr::ScalarFunction(ScalarFunction { func, args: new_args });
+    Ok(if changed { Transformed::yes(rebuilt) } else { Transformed::no(rebuilt) })
+}
+
+/// Convert parsed PG array elements to a typed list literal. None on any
+/// element that doesn't parse as `elem_type` (caller leaves the arg alone).
+fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<ScalarValue> {
+    let vals: Option<Vec<ScalarValue>> = elems
+        .into_iter()
+        .map(|e| match e {
+            None => ScalarValue::try_from(elem_type).ok(),
+            Some(s) => ScalarValue::try_from_string(s, elem_type).ok(),
+        })
+        .collect();
+    Some(ScalarValue::List(ScalarValue::new_list_nullable(&vals?, elem_type)))
+}
+
+/// Parse a PG array literal of strings: `{}`, `{a,b}`, `{"a,b",NULL}`.
+/// Returns None if `s` isn't brace-wrapped (not an array literal).
+fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
+    let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
+    if inner.trim().is_empty() {
+        return Some(vec![]);
+    }
+    let (mut elems, mut cur, mut in_quotes, mut was_quoted) = (Vec::new(), String::new(), false, false);
+    let mut chars = inner.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if in_quotes => cur.push(chars.next()?),
+            '"' => {
+                if !in_quotes && cur.trim().is_empty() {
+                    cur.clear(); // drop whitespace before an opening quote
+                }
+                in_quotes = !in_quotes;
+                was_quoted = true;
+            }
+            ',' if !in_quotes => {
+                elems.push(finish_elem(&mut cur, &mut was_quoted));
+            }
+            _ if in_quotes || !was_quoted => cur.push(c),
+            _ => {} // ignore trailing chars after a closing quote
+        }
+    }
+    elems.push(finish_elem(&mut cur, &mut was_quoted));
+    Some(elems)
+}
+
+fn finish_elem(cur: &mut String, was_quoted: &mut bool) -> Option<String> {
+    let raw = std::mem::take(cur);
+    let quoted = std::mem::take(was_quoted);
+    let trimmed = raw.trim();
+    if !quoted && trimmed.eq_ignore_ascii_case("null") {
+        None
+    } else {
+        Some(if quoted { raw } else { trimmed.to_string() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{execution::session_state::SessionStateBuilder, prelude::SessionContext};
+
+    use super::*;
+
+    fn ctx_with_rule() -> SessionContext {
+        let rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>> = vec![
+            Arc::new(PgArrayLiteralRewriter),
+            Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
+        ];
+        let state = SessionStateBuilder::new().with_default_features().with_analyzer_rules(rules).build();
+        let ctx = SessionContext::new_with_state(state);
+        ctx.register_udf(datafusion::logical_expr::ScalarUDF::from(PgCoalesceUdf::default()));
+        ctx
+    }
+
+    async fn one_string(ctx: &SessionContext, sql: &str) -> String {
+        let batches = ctx.sql(sql).await.expect("plan ok").collect().await.expect("exec ok");
+        datafusion::arrow::util::pretty::pretty_format_batches(&batches).unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn coalesce_empty_pg_array_literal() {
+        let ctx = ctx_with_rule();
+        let out = one_string(&ctx, "SELECT array_length(COALESCE(CAST(NULL AS VARCHAR[]), '{}'), 1) FROM (SELECT 1)").await;
+        // empty list → array_length over dim 1 is NULL in DF, so just assert it planned & ran
+        assert!(out.contains("---"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn coalesce_nonempty_pg_array_literal() {
+        let ctx = ctx_with_rule();
+        let out = one_string(&ctx, "SELECT COALESCE(CAST(NULL AS VARCHAR[]), '{a, b, \"c,d\", NULL}') AS v FROM (SELECT 1)").await;
+        assert!(out.contains("[a, b, c,d, ]"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn non_array_string_untouched() {
+        let ctx = ctx_with_rule();
+        // No list-typed arg → rule must not fire; plain string coalesce still works.
+        let out = one_string(&ctx, "SELECT COALESCE(CAST(NULL AS VARCHAR), '{}') AS v FROM (SELECT 1)").await;
+        assert!(out.contains("{}"), "{out}");
+    }
+
+    #[test]
+    fn pg_array_parse_shapes() {
+        assert_eq!(parse_pg_string_array("{}"), Some(vec![]));
+        assert_eq!(parse_pg_string_array("{a,b}"), Some(vec![Some("a".into()), Some("b".into())]));
+        assert_eq!(parse_pg_string_array(r#"{"a,b", c }"#), Some(vec![Some("a,b".into()), Some("c".into())]));
+        assert_eq!(parse_pg_string_array("{NULL,\"NULL\"}"), Some(vec![None, Some("NULL".into())]));
+        assert_eq!(parse_pg_string_array("plain"), None);
+    }
+}

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -75,6 +75,10 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
     }
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         self.inner.coerce_types(arg_types).or_else(|e| {
+            // First list type wins. If a call ever mixes list element types
+            // (coalesce(utf8_list, int_list, '{}')) the retried coercion below
+            // fails on the second list and the original error surfaces — no
+            // silent mis-typing, just a planner-time error like today.
             let list_t = arg_types
                 .iter()
                 .find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)))
@@ -176,6 +180,12 @@ fn pg_elems_to_list(elems: Vec<Option<String>>, elem_type: &DataType) -> Option<
 /// Returns None if `s` isn't brace-wrapped (not an array literal).
 fn parse_pg_string_array(s: &str) -> Option<Vec<Option<String>>> {
     let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
+    // Multi-dimensional literals ('{{a},{b}}') would misparse as flat
+    // elements once the outer braces are stripped — bail (arg left alone,
+    // TypeCoercion reports the original error) rather than silently mangle.
+    if inner.contains('{') || inner.contains('}') {
+        return None;
+    }
     if inner.trim().is_empty() {
         return Some(vec![]);
     }
@@ -264,5 +274,7 @@ mod tests {
         assert_eq!(parse_pg_string_array(r#"{"a,b", c }"#), Some(vec![Some("a,b".into()), Some("c".into())]));
         assert_eq!(parse_pg_string_array("{NULL,\"NULL\"}"), Some(vec![None, Some("NULL".into())]));
         assert_eq!(parse_pg_string_array("plain"), None);
+        // Multi-dimensional literals are rejected, not silently flattened.
+        assert_eq!(parse_pg_string_array("{{a},{b}}"), None);
     }
 }

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -231,9 +231,10 @@ mod tests {
     #[tokio::test]
     async fn coalesce_empty_pg_array_literal() {
         let ctx = ctx_with_rule();
-        let out = one_string(&ctx, "SELECT array_length(COALESCE(CAST(NULL AS VARCHAR[]), '{}'), 1) FROM (SELECT 1)").await;
-        // empty list → array_length over dim 1 is NULL in DF, so just assert it planned & ran
-        assert!(out.contains("---"), "{out}");
+        // cardinality(empty list) = 0 — asserts the actual coalesced value,
+        // not merely that planning succeeded.
+        let out = one_string(&ctx, "SELECT cardinality(COALESCE(CAST(NULL AS VARCHAR[]), '{}')) AS n FROM (SELECT 1)").await;
+        assert!(out.contains("| 0 "), "{out}");
     }
 
     #[tokio::test]

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -90,9 +90,10 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
             // fails on the second list and the original error surfaces — no
             // silent mis-typing, just a planner-time error like today.
             // NOTE: a real string COLUMN (not a literal) coalesced with a list
-            // also passes here, but the analyzer rule has no literal to
-            // rewrite, so the failure surfaces at execution (Utf8→List cast)
-            // instead of planning. Acceptable: PG errors on that query too.
+            // also passes here; with no literal to rewrite, TypeCoercion's
+            // Utf8→List cast wraps each value into a one-element list — a
+            // deliberate, pinned divergence from PG (which errors). See
+            // coalesce_string_column_with_list_wraps_into_single_element_list.
             let list_t = arg_types
                 .iter()
                 .find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)))
@@ -303,6 +304,9 @@ mod tests {
         // rejects these literals outright; we parse leniently and keep the
         // quoted value. Pinned so the behavior is intentional, not accidental.
         assert_eq!(parse_pg_string_array("{\"a\"x,b}"), Some(vec![Some("a".into()), Some("b".into())]));
+        // The mirror case — non-whitespace BEFORE an opening quote — is also
+        // PG-invalid; we leniently concatenate. Pinned for the same reason.
+        assert_eq!(parse_pg_string_array("{a\"b\"}"), Some(vec![Some("ab".into())]));
         // Multi-dimensional literals are rejected, not silently flattened;
         // braces inside quotes are ordinary element text.
         assert_eq!(parse_pg_string_array("{{a},{b}}"), None);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -62,6 +62,19 @@ pub mod test_helpers {
         }
     }
 
+    /// Point walrus-rust at the test's data dir, restoring the prior value on
+    /// drop — including on panic, so a failed `#[serial]` test can't leak the
+    /// var into the next one. SAFETY: `set_var` is racy if another thread
+    /// reads the env concurrently; callers must hold `#[serial]`.
+    pub fn walrus_env_guard(dir: &std::path::Path) -> impl Drop {
+        let prev = std::env::var_os("WALRUS_DATA_DIR");
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", dir) };
+        scopeguard::guard(prev, |prev| match prev {
+            Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },
+            None => unsafe { std::env::remove_var("WALRUS_DATA_DIR") },
+        })
+    }
+
     /// Build a BufferedWriteLayer for tests/benches without repeating the registry boilerplate.
     pub fn test_layer(cfg: Arc<AppConfig>) -> anyhow::Result<crate::buffered_write_layer::BufferedWriteLayer> {
         crate::buffered_write_layer::BufferedWriteLayer::with_config(cfg, crate::functions::function_registry()?)

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1185,19 +1185,25 @@ mod tests {
     /// own fsynced state) is covered by
     /// [`cursor_snapshot_restore_advances_walrus_past_local_state`].
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_roundtrip_restores_persisted_positions() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
+        // Unique topic per run: walrus state lives under the process-global
+        // WALRUS_DATA_DIR (whatever the last test pointed it at), so a fixed
+        // "proj:tbl" topic inherits blocks/cursors appended by earlier tests
+        // in the same process and the exact-position asserts below flake.
+        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
 
         // Process A: append, advance cursor, write snapshot with clean flag.
         {
             let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
             let batch = create_test_batch();
-            wal.append("proj", "tbl", &batch).unwrap();
+            wal.append("proj", &table, &batch).unwrap();
             // Advance by 1 on the only shard we wrote to (round-robin picks
             // shard 0 first for an unseen topic).
-            wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
-            let before = wal.persisted_read_positions("proj", "tbl").unwrap();
+            wal.advance_by_counts("proj", &table, &[1, 0, 0, 0]).unwrap();
+            let before = wal.persisted_read_positions("proj", &table).unwrap();
             assert!(before[0].is_some_and(|p| !p.is_origin()), "advance must move shard 0 off origin");
 
             wal.write_cursor_snapshot(true).unwrap();
@@ -1211,13 +1217,13 @@ mod tests {
             let snap = wal.load_cursor_snapshot().expect("snapshot loadable");
             assert!(snap.clean_shutdown);
             assert_eq!(snap.shards_per_topic, 4);
-            assert!(snap.entries.contains_key("proj:tbl"));
+            assert!(snap.entries.contains_key(&WalManager::make_topic("proj", &table)));
 
             // Restore is idempotent — walrus state already reflects the
             // advance, so `restore` advances 0 shards but seeds known_topics.
             let advanced = wal.restore_cursor_snapshot(&snap).unwrap();
             assert_eq!(advanced, 0, "snapshot positions match walrus's own fsynced state");
-            assert!(wal.list_topic_pairs().unwrap().iter().any(|(p, t)| p == "proj" && t == "tbl"));
+            assert!(wal.list_topic_pairs().unwrap().iter().any(|(p, t)| p == "proj" && *t == table));
         }
     }
 
@@ -1225,6 +1231,7 @@ mod tests {
     /// boot falls through to the Delta scan rather than misinterpreting the
     /// payload.
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_rejects_version_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
@@ -1243,13 +1250,16 @@ mod tests {
     /// so the boot falls through to the Delta scan rather than restoring
     /// shard-misaligned positions.
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_rejects_shard_count_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
+        // Unique topic per run — see cursor_snapshot_roundtrip_restores_persisted_positions.
+        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
         {
             let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
-            wal.append("proj", "tbl", &create_test_batch()).unwrap();
-            wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
+            wal.append("proj", &table, &create_test_batch()).unwrap();
+            wal.advance_by_counts("proj", &table, &[1, 0, 0, 0]).unwrap();
             wal.write_cursor_snapshot(true).unwrap();
         }
         // Re-open with a different shard count — load must refuse.
@@ -1264,6 +1274,7 @@ mod tests {
     /// is the scenario the snapshot exists to handle, distinct from the
     /// idempotent path in `..._roundtrip_restores_persisted_positions`.
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_restore_advances_walrus_past_local_state() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
@@ -1302,6 +1313,7 @@ mod tests {
     /// leave `cursor_snapshot.json.tmp` behind. The next WalManager init
     /// must sweep it so it doesn't accumulate over many crash-restart cycles.
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_tmp_swept_on_init() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
@@ -1323,6 +1335,7 @@ mod tests {
     /// task can carry on.
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn write_and_delete_both_fail_under_readonly_meta_dir() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
@@ -1351,6 +1364,7 @@ mod tests {
     /// in the spot the atomic-rename tmp would occupy — `fs::write` to a
     /// directory path errors, so the rename never happens.
     #[test]
+    #[serial_test::serial]
     fn write_cursor_snapshot_failure_requires_caller_to_delete_stale_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
@@ -1374,6 +1388,7 @@ mod tests {
     /// absent. The flush path calls this on write failure to keep boot from
     /// restoring stale state.
     #[test]
+    #[serial_test::serial]
     fn delete_cursor_snapshot_idempotent() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
@@ -1392,12 +1407,15 @@ mod tests {
     /// fine but must not let the boot path skip the Delta verifier — that
     /// gate is reserved for the graceful-shutdown marker.
     #[test]
+    #[serial_test::serial]
     fn cursor_snapshot_dirty_path_loads_but_signals_unclean() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
-        wal.append("proj", "tbl", &create_test_batch()).unwrap();
-        wal.advance_by_counts("proj", "tbl", &[1, 0, 0, 0]).unwrap();
+        // Unique topic per run — see cursor_snapshot_roundtrip_restores_persisted_positions.
+        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
+        wal.append("proj", &table, &create_test_batch()).unwrap();
+        wal.advance_by_counts("proj", &table, &[1, 0, 0, 0]).unwrap();
         wal.write_cursor_snapshot(false).unwrap();
 
         let snap = wal.load_cursor_snapshot().expect("dirty snapshot must still be loadable");

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1193,7 +1193,7 @@ mod tests {
         // WALRUS_DATA_DIR (whatever the last test pointed it at), so a fixed
         // "proj:tbl" topic inherits blocks/cursors appended by earlier tests
         // in the same process and the exact-position asserts below flake.
-        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
+        let table = format!("tbl_{}", uuid::Uuid::new_v4().simple());
 
         // Process A: append, advance cursor, write snapshot with clean flag.
         {
@@ -1255,7 +1255,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_path_buf();
         // Unique topic per run — see cursor_snapshot_roundtrip_restores_persisted_positions.
-        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
+        let table = format!("tbl_{}", uuid::Uuid::new_v4().simple());
         {
             let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
             wal.append("proj", &table, &create_test_batch()).unwrap();
@@ -1283,10 +1283,7 @@ mod tests {
         // Walrus uses a process-global `WALRUS_DATA_DIR` so other tests may
         // have seeded state for shared collection keys. Use a per-test
         // unique topic name so the hashed walrus key is guaranteed fresh.
-        let table = format!(
-            "rescue_{}",
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
-        );
+        let table = format!("rescue_{}", uuid::Uuid::new_v4().simple());
         let project = "p";
 
         let before = wal.persisted_read_positions(project, &table).unwrap();
@@ -1413,7 +1410,7 @@ mod tests {
         let path = dir.path().to_path_buf();
         let wal = WalManager::with_fsync_mode_and_shards(path.clone(), crate::config::WalFsyncMode::SyncEach, 4).unwrap();
         // Unique topic per run — see cursor_snapshot_roundtrip_restores_persisted_positions.
-        let table = format!("tbl_{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos());
+        let table = format!("tbl_{}", uuid::Uuid::new_v4().simple());
         wal.append("proj", &table, &create_test_batch()).unwrap();
         wal.advance_by_counts("proj", &table, &[1, 0, 0, 0]).unwrap();
         wal.write_cursor_snapshot(false).unwrap();

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -78,7 +78,8 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
 #[tokio::test]
 async fn optimize_preserves_all_partition_values() -> Result<()> {
     let cfg = TestConfigBuilder::new("optimize_partition_preserve").with_buffer_mode(BufferMode::Enabled).build();
-    // SAFETY: see dedup_compaction_collapses_cross_flush_duplicates.
+    // SAFETY: `set_var` is racy if another thread reads the env concurrently;
+    // `#[serial]` serialises this suite so no other test races the variable.
     unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
     let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
     let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -10,16 +10,14 @@ use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
 use serial_test::serial;
 use timefusion::{
     database::Database,
-    test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
+    test_utils::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts, walrus_env_guard},
 };
 
 #[serial]
 #[tokio::test]
 async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
     let cfg = TestConfigBuilder::new("dedup_compaction").with_buffer_mode(BufferMode::Enabled).build();
-    // SAFETY: walrus-rust reads WALRUS_DATA_DIR from process env. `#[serial]`
-    // serializes the suite; this set is racy in principle but safe here.
-    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let _env = walrus_env_guard(&cfg.core.timefusion_data_dir);
     let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
     let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
@@ -78,9 +76,7 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
 #[tokio::test]
 async fn optimize_preserves_all_partition_values() -> Result<()> {
     let cfg = TestConfigBuilder::new("optimize_partition_preserve").with_buffer_mode(BufferMode::Enabled).build();
-    // SAFETY: `set_var` is racy if another thread reads the env concurrently;
-    // `#[serial]` serialises this suite so no other test races the variable.
-    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let _env = walrus_env_guard(&cfg.core.timefusion_data_dir);
     let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
     let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
 

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -67,3 +67,53 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression: light OPTIMIZE (bin-pack compact) must preserve ALL partition
+/// values on rewritten files. The kernel narrows `partitionValues_parsed` to
+/// the predicate-referenced subset (data skipping), and optimize used that
+/// narrowed map for grouping/output — so a `date = today` filter rewrote
+/// files as partitionValues={date}, silently NULLing project_id and hiding
+/// every compacted row from project-scoped queries.
+#[serial]
+#[tokio::test]
+async fn optimize_preserves_all_partition_values() -> Result<()> {
+    let cfg = TestConfigBuilder::new("optimize_partition_preserve").with_buffer_mode(BufferMode::Enabled).build();
+    // SAFETY: see dedup_compaction_collapses_cross_flush_duplicates.
+    unsafe { std::env::set_var("WALRUS_DATA_DIR", &cfg.core.timefusion_data_dir) };
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let ts = chrono::Utc::now().timestamp_micros();
+    // Distinct ids → no dedup interplay; 6 separate commits → 6 small files
+    // (>= timefusion_compact_min_files=5 so the optimize commit isn't skipped).
+    for i in 0..6 {
+        let batch = json_to_batch(vec![test_span_ts(&format!("opt_id_{i}"), "row", &project_id, ts + i)])?;
+        db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], true, None).await?;
+    }
+
+    let count_sql = format!("SELECT COUNT(*) AS cnt FROM otel_logs_and_spans WHERE project_id = '{}'", project_id);
+    let pre = db.query_delta_only(&count_sql).await?;
+    assert_eq!(pre[0].column(0).as_primitive::<Int64Type>().value(0), 6, "pre-optimize row count");
+
+    let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
+    db.optimize_table_light(&table_ref, "otel_logs_and_spans").await?;
+
+    // Compacted files must keep the full (project_id, date) partition path…
+    let date_str = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive().to_string();
+    let bad: Vec<String> = table_ref
+        .read()
+        .await
+        .get_file_uris()?
+        .filter(|u| u.contains(&format!("/date={date_str}")) && !u.contains("project_id="))
+        .collect();
+    assert!(bad.is_empty(), "optimize dropped project_id partition from: {bad:?}");
+
+    // …and project-scoped queries must still see every row.
+    let post = db.query_delta_only(&count_sql).await?;
+    assert_eq!(
+        post[0].column(0).as_primitive::<Int64Type>().value(0),
+        6,
+        "post-optimize: project-scoped count must be unchanged"
+    );
+    Ok(())
+}

--- a/tests/e2e/cache_warmth.rs
+++ b/tests/e2e/cache_warmth.rs
@@ -5,6 +5,7 @@
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn second_read_after_flush_hits_foyer() -> anyhow::Result<()> {
     let env = E2eEnv::builder().with_foyer_enabled().start().await?;

--- a/tests/e2e/eviction.rs
+++ b/tests/e2e/eviction.rs
@@ -7,6 +7,7 @@ use timefusion::clock;
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn old_data_evicted_recent_retained() -> anyhow::Result<()> {
     let env = E2eEnv::builder().with_bucket_duration(Duration::from_secs(60)).with_retention(Duration::from_secs(120)).start().await?;

--- a/tests/e2e/flush_lifecycle.rs
+++ b/tests/e2e/flush_lifecycle.rs
@@ -11,6 +11,7 @@ use timefusion::clock;
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn flush_completed_bucket_only() -> anyhow::Result<()> {
     let env = E2eEnv::builder()

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -119,8 +119,13 @@ impl E2eEnvBuilder {
         // test sees only its own WAL after restart.
         let test_wal_dir = data_dir.join("wal");
         std::fs::create_dir_all(&test_wal_dir).ok();
-        // SAFETY: e2e suite runs with --test-threads=1, so no other thread
-        // reads/writes WALRUS_DATA_DIR concurrently.
+        // SAFETY: every e2e test is #[serial_test::serial] (the dedicated E2E
+        // job also passes --test-threads=1), so no other thread reads/writes
+        // WALRUS_DATA_DIR concurrently. The serial attribute is what keeps
+        // this sound when the suite runs under plain `cargo test
+        // --all-features` (the Clippy & Test job), where parallel harness
+        // startups used to race the env var and bootstrap with another
+        // test's WAL dir ("Unsupported WAL version: 0").
         unsafe { std::env::set_var("WALRUS_DATA_DIR", &test_wal_dir) };
 
         // Bucket creation: MinIO default credentials are minioadmin/minioadmin.

--- a/tests/e2e/multi_tenant_isolation.rs
+++ b/tests/e2e/multi_tenant_isolation.rs
@@ -3,6 +3,7 @@
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn project_id_filter_isolates_tenants() -> anyhow::Result<()> {
     let env = E2eEnv::builder().start().await?;

--- a/tests/e2e/pressure_flush.rs
+++ b/tests/e2e/pressure_flush.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn many_inserts_under_tight_budget_do_not_deadlock() -> anyhow::Result<()> {
     let env = E2eEnv::builder()

--- a/tests/e2e/restart_recovery.rs
+++ b/tests/e2e/restart_recovery.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn flushed_rows_survive_restart() -> anyhow::Result<()> {
     let mut env = E2eEnv::builder().start().await?;
@@ -49,6 +50,7 @@ async fn flushed_rows_survive_restart() -> anyhow::Result<()> {
 // `flushed_rows_survive_restart` test still covers the durability path via
 // Delta, so this gap doesn't lower coverage of the production crash class.
 #[ignore = "harness restart path doesn't replay WAL — see comment"]
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn unflushed_rows_replayed_from_wal() -> anyhow::Result<()> {
     // Disable Foyer; push flush/eviction far into the future so the
@@ -94,6 +96,7 @@ async fn unflushed_rows_replayed_from_wal() -> anyhow::Result<()> {
 /// being returned for minutes after a dirty restart (cursor-snapshot missing
 /// or stale). With `bootstrap()` now mirroring main.rs's cursor reconcile,
 /// this test exercises the same slow path prod hits.
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn cold_start_under_five_seconds() -> anyhow::Result<()> {
     let mut env = E2eEnv::builder().start().await?;

--- a/tests/e2e/smoke.rs
+++ b/tests/e2e/smoke.rs
@@ -9,6 +9,7 @@ use super::harness::E2eEnv;
 
 const QUERY_RESPONSE_BUDGET: Duration = Duration::from_secs(5);
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn pgwire_query_returns_response() -> anyhow::Result<()> {
     let env = E2eEnv::builder().start().await?;
@@ -43,6 +44,7 @@ async fn pgwire_query_returns_response() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn count_star_returns_correct_value() -> anyhow::Result<()> {
     let env = E2eEnv::builder().start().await?;

--- a/tests/e2e/zorder_idempotence.rs
+++ b/tests/e2e/zorder_idempotence.rs
@@ -6,6 +6,7 @@
 
 use super::harness::{E2eEnv, FROZEN_START_MICROS};
 
+#[serial_test::serial]
 #[tokio::test(flavor = "multi_thread")]
 async fn second_optimize_is_a_noop() -> anyhow::Result<()> {
     let env = E2eEnv::builder().start().await?;

--- a/tests/jsonb_oid_test.rs
+++ b/tests/jsonb_oid_test.rs
@@ -14,7 +14,7 @@ mod jsonb_oid {
     use serial_test::serial;
     use timefusion::{config::AppConfig, database::Database};
     use tokio::sync::Notify;
-    use tokio_postgres::{types::Type, NoTls};
+    use tokio_postgres::{NoTls, types::Type};
     use uuid::Uuid;
 
     const JSONB_OID: u32 = 3802;
@@ -68,7 +68,9 @@ mod jsonb_oid {
             let conn_str = format!("host=localhost port={port} user=postgres password=postgres");
             for _ in 0..100 {
                 if let Ok((client, conn)) = tokio_postgres::connect(&conn_str, NoTls).await {
-                    tokio::spawn(async move { let _ = conn.await; });
+                    tokio::spawn(async move {
+                        let _ = conn.await;
+                    });
                     drop(client);
                     return Ok(Self { port, shutdown });
                 }
@@ -80,7 +82,9 @@ mod jsonb_oid {
         async fn connect(&self) -> Result<tokio_postgres::Client> {
             let conn_str = format!("host=localhost port={} user=postgres password=postgres", self.port);
             let (client, conn) = tokio_postgres::connect(&conn_str, NoTls).await?;
-            tokio::spawn(async move { let _ = conn.await; });
+            tokio::spawn(async move {
+                let _ = conn.await;
+            });
             Ok(client)
         }
     }
@@ -100,8 +104,11 @@ mod jsonb_oid {
         // tokio-postgres `prepare` round-trips RowDescription; column type OID
         // is what hasql / strict drivers inspect.
         let stmt = client.prepare("SELECT jsonb_build_array(1, 'a', true) AS j").await?;
-        assert_eq!(stmt.columns()[0].type_().oid(), JSONB_OID,
-            "jsonb_build_array must surface PG jsonb OID, not text");
+        assert_eq!(
+            stmt.columns()[0].type_().oid(),
+            JSONB_OID,
+            "jsonb_build_array must surface PG jsonb OID, not text"
+        );
 
         // Binary decode via serde_json::Value (tokio-postgres uses binary by default).
         let row = client.query_one("SELECT jsonb_build_array(1, 'a', true) AS j", &[]).await?;

--- a/tests/slt/edge_cases.slt
+++ b/tests/slt/edge_cases.slt
@@ -147,3 +147,40 @@ FROM otel_logs_and_spans
 WHERE project_id = 'error_test' AND id = 'duration_test2'
 ----
 -1 true
+
+# PG array-literal compat: monoscope's lookupOtelRecord sends
+# COALESCE(hashes, '{}') / COALESCE(summary, '{}') where '{}' is a Postgres
+# array literal. DataFusion's stock coercion can't unify List(Utf8View) with
+# Utf8, so this errored at planning and broke random-access lookups.
+statement ok
+INSERT INTO otel_logs_and_spans (
+    project_id, timestamp, id, hashes, date,
+    name, level, summary
+) VALUES (
+    'error_test', TIMESTAMP '2023-01-01T10:00:00Z', 'pg_array_lit_test', ARRAY['h1']::VARCHAR[], DATE '2023-01-01',
+    'test_pg_array_literal', 'INFO', ARRAY['row with hashes - INFO level']
+)
+
+query I
+SELECT ARRAY_LENGTH(COALESCE(hashes, '{}'))
+FROM otel_logs_and_spans
+WHERE project_id = 'error_test' AND id = 'pg_array_lit_test'
+----
+1
+
+# NULL list column coalesces to the empty array parsed from '{}'
+query I
+SELECT ARRAY_LENGTH(COALESCE(parent_id_list_does_not_exist, '{}')) FROM (
+    SELECT CAST(NULL AS VARCHAR[]) AS parent_id_list_does_not_exist
+    FROM otel_logs_and_spans
+    WHERE project_id = 'error_test' AND id = 'pg_array_lit_test'
+)
+----
+0
+
+# Non-empty PG array literal parses element-wise
+query T
+SELECT COALESCE(CAST(NULL AS VARCHAR[]), '{a,b}')[1] FROM otel_logs_and_spans
+WHERE project_id = 'error_test' AND id = 'pg_array_lit_test'
+----
+a

--- a/tests/tantivy_e2e_test.rs
+++ b/tests/tantivy_e2e_test.rs
@@ -156,6 +156,21 @@ fn unique_project() -> String {
 }
 const TABLE: &str = "otel_logs_and_spans";
 
+/// Poll the tantivy manifest until it has at least `want` entries. The index
+/// build is a detached task since the flush-throughput work (ef13450) —
+/// `flush_all_now()` returning only guarantees the Delta commit, so tests
+/// asserting on the manifest must wait for the sidecar to catch up.
+async fn wait_for_manifest_entries(store: &dyn object_store::ObjectStore, project: &str, want: usize) -> Result<timefusion::tantivy_index::manifest::Manifest> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let m = timefusion::tantivy_index::manifest::load(store, TABLE, project).await?;
+        if m.entries.len() >= want || std::time::Instant::now() > deadline {
+            return Ok(m);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 // ───────────────────────── tests ─────────────────────────
 
 #[serial]
@@ -233,7 +248,7 @@ async fn tantivy_indexer_actually_writes_manifest_when_flush_routes_through_buff
     layer.flush_all_now().await?;
 
     let store = svc.object_store.clone();
-    let m = timefusion::tantivy_index::manifest::load(store.as_ref(), TABLE, &p).await?;
+    let m = wait_for_manifest_entries(store.as_ref(), &p, 1).await?;
     assert!(!m.entries.is_empty(), "manifest should have at least one entry after flush");
     let entry = m.entries.values().next().unwrap();
     assert!(entry.index.is_some(), "entry should have an index blob URI: {entry:?}");
@@ -290,7 +305,7 @@ async fn compaction_gc_drops_stale_indexes_keeps_live_ones() -> Result<()> {
     db.insert_records_batch(&p, TABLE, vec![make_batch(&p, vec![("g2", "n", "second")])], false, None).await?;
     db.buffered_layer().cloned().unwrap().flush_all_now().await?;
 
-    let m_before = timefusion::tantivy_index::manifest::load(svc.object_store.as_ref(), TABLE, &p).await?;
+    let m_before = wait_for_manifest_entries(svc.object_store.as_ref(), &p, 2).await?;
     assert_eq!(m_before.entries.len(), 2, "two flushes → two manifest entries");
 
     // Collect every URI both entries covered.
@@ -334,7 +349,7 @@ async fn flushed_index_prefilter_is_actually_used() -> Result<()> {
     db2.buffered_layer().cloned().unwrap().flush_all_now().await?;
 
     // Confirm a manifest entry exists for the ON case.
-    let m = timefusion::tantivy_index::manifest::load(svc.object_store.as_ref(), TABLE, &p).await?;
+    let m = wait_for_manifest_entries(svc.object_store.as_ref(), &p, 1).await?;
     assert!(!m.entries.is_empty(), "manifest should have entries after flush");
 
     // Real-world SQL: `WHERE level = 'ERROR'`. The TantivyPredicateRewriter

--- a/tests/tantivy_e2e_test.rs
+++ b/tests/tantivy_e2e_test.rs
@@ -164,9 +164,16 @@ async fn wait_for_manifest_entries(store: &dyn object_store::ObjectStore, projec
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     loop {
         let m = timefusion::tantivy_index::manifest::load(store, TABLE, project).await?;
-        if m.entries.len() >= want || std::time::Instant::now() > deadline {
+        if m.entries.len() >= want {
             return Ok(m);
         }
+        // Err (not the short manifest) on expiry — the caller's assert would
+        // otherwise fire with a confusing entry-count mismatch.
+        anyhow::ensure!(
+            std::time::Instant::now() <= deadline,
+            "manifest for {project} stuck at {} entries after 30s, want {want}",
+            m.entries.len()
+        );
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }


### PR DESCRIPTION
## Problem
- Easy GET/list queries spent ~400-450ms in overhead (prod wall ~525ms)
- Random-access lookups by (timestamp, id) — the log_explorer target_event path — took 30s+

## Root causes & fixes

1. **monoscope's `lookupOtelRecord` never ran on TF.** Its exact SQL (`COALESCE(hashes,'{}')`) failed DataFusion planning: `coalesce(List(Utf8View), Utf8)` has no coercion, and the SQL planner computes projection schemas before analyzer rules run. The observed "30s random access" was the downstream fallback after the error. Fixed with `PgCoalesceUdf` (same-name wrapper whose coercion unifies string args into a sibling list type) + `PgArrayLiteralRewriter` (pre-TypeCoercion analyzer that re-types PG array string literals into typed list literals). slt regression cases in `edge_cases.slt`.

2. **OPTIMIZE silently dropped `project_id` partition values** (delta-rs fork bug, found via bench data vanishing). Compact/z-order grouped files on the kernel-narrowed `partitionValues_parsed`, so a `date=today`-filtered compaction rewrote files with `partitionValues={date}` only — rows read back with NULL project_id, invisible to every project-scoped query. Fixed in the fork (commit `2f473fe4c19`, pinned here) by rebuilding full partition values from the Add action's raw map. Regression test: `optimize_preserves_all_partition_values`.
   ⚠️ Files compacted in prod **before** this fix may still carry NULL project_id partition values and need an audit/backfill.

3. **Cold-partition first-touch cost 1.4–23s** against remote object storage:
   - Delta log replay ran inline on the first query → `preload_tables()` at boot (non-blocking)
   - The parquet reader's footer reads never matched `warm_footer`'s cache key → session `metadata_size_hint` aligned to the warm range + containment probe in `get_range_cached` (serves any sub-range from the warmed `(0..size)` / `(size-hint..size)` entries)
   - Footers now warm for ALL live files (KBs each); full-file warming stays recency-bounded
   - Black-holed connections stalled reads 20s+ → `connect_timeout=3s` on the S3 client (tunable via `TIMEFUSION_S3_CONNECT_TIMEOUT`)

4. **Nightly maintenance re-colded partitions daily**: `dedup_partition` and `recompress_partition` (warm→cold@14d) swapped rewritten files in without warming them — caught live as a 1.5s regression at the 03:00 UTC recompress. Both now warm their outputs like the optimize paths.

## Numbers (release-iter, 156 partitions / 105k rows on OVH S3, network included)

| query | before | after |
|---|---|---|
| random access (ts+id), warm | failed → ~30s fallback | 5.6ms |
| random access, cold first touch (any age) | 1.4–23.4s | 6–27ms |
| monoscope lookupOtelRecord exact SQL | planning error | 8ms |
| list 50 recent | ~525ms | 3.8ms |
| UNION×4 percentiles | ~525ms | 6.7ms |
| under 6k rows/s ingest | — | p95 ≤37ms |

## Bench harness (new)
`bench/run-tf-r2.sh` (remote-store bench runner) + `bench/query_latency.py` (seed/seed_scale/run/run_ages/explain — run also times plan-only EXPLAIN).

## Ops follow-ups
- Audit prod env for `TIMEFUSION_FOYER_TTL_SECONDS=60` (local .env carries this debug leftover; default is 7 days)
- Consider `TIMEFUSION_WARM_FULL_FILES=true` in prod
- Audit prod for NULL-project_id files from bug 2 (needs an active backfill plan, not just this deploy)
- **Behavior change at boot**: footer warming now covers ALL live files by default (was recency-bounded). On tables with thousands of files this is a one-time S3 GET burst per restart, bounded by `TIMEFUSION_WARM_CONCURRENCY`. Rollback knob: `TIMEFUSION_WARM_ALL_FOOTERS=false` restores recency-bounded footer warming.
- If 3s connect timeout proves too tight behind slow proxies/cross-region links: `TIMEFUSION_S3_CONNECT_TIMEOUT`