### PR TITLE
fix CI + followup: unblock master (DeltaOps, stale to_json SLTs); review fixes orphaned by the #50 squash

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -2209,7 +2209,7 @@ impl Database {
                         let _ = crate::object_store_cache::warm_full(store.as_ref(), &path).await;
                     }
                     let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    if n % 500 == 0 {
+                    if n.is_multiple_of(500) {
                         info!("Cache warm progress: {n}/{count} files");
                     }
                 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -2193,7 +2193,9 @@ impl Database {
         info!("Cache warm start: {count} files (scope={scope}, concurrency={concurrency})");
         let t0 = std::time::Instant::now();
         // Progress heartbeat: a 10k-file boot warm runs minutes; without one
-        // operators can't tell warming from a hang.
+        // operators can't tell warming from a hang. The {count} denominator
+        // is the selected warm set (footer warms); full-file warming covers
+        // only the `recent` subset of it.
         const WARM_PROGRESS_INTERVAL: usize = 500;
         let done = std::sync::atomic::AtomicUsize::new(0);
         let done = &done;

--- a/src/database.rs
+++ b/src/database.rs
@@ -2211,7 +2211,9 @@ impl Database {
                     }
                     let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                     if n.is_multiple_of(WARM_PROGRESS_INTERVAL) {
-                        info!("Cache warm progress: {n}/{count} files");
+                        // Elapsed on the heartbeat lets operators extrapolate
+                        // time-remaining without waiting for completion.
+                        info!("Cache warm progress: {n}/{count} files ({:.1}s elapsed)", t0.elapsed().as_secs_f64());
                     }
                 }
             })

--- a/src/database.rs
+++ b/src/database.rs
@@ -2196,8 +2196,9 @@ impl Database {
         // a large warm set takes minutes to get there).
         info!("Cache warm start: {count} files (scope={scope}, concurrency={concurrency})");
         let t0 = std::time::Instant::now();
-        // Progress every 500 files: a 10k-file boot warm runs minutes; without
-        // a heartbeat operators can't tell warming from a hang.
+        // Progress heartbeat: a 10k-file boot warm runs minutes; without one
+        // operators can't tell warming from a hang.
+        const WARM_PROGRESS_INTERVAL: usize = 500;
         let done = std::sync::atomic::AtomicUsize::new(0);
         let done = &done;
         futures::stream::iter(paths)
@@ -2209,20 +2210,20 @@ impl Database {
                         let _ = crate::object_store_cache::warm_full(store.as_ref(), &path).await;
                     }
                     let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    if n.is_multiple_of(500) {
+                    if n.is_multiple_of(WARM_PROGRESS_INTERVAL) {
                         info!("Cache warm progress: {n}/{count} files");
                     }
                 }
             })
             .await;
 
-        let elapsed_ms = t0.elapsed().as_millis();
+        let elapsed_s = t0.elapsed().as_secs_f64();
         match baseline {
             Some(rate) => info!(
-                "Cache warm complete: {} files warmed (scope={}) in {}ms; foyer main hit rate before warm was {:.2}% (next query benefits)",
-                count, scope, elapsed_ms, rate
+                "Cache warm complete: {} files warmed (scope={}) in {:.1}s; foyer main hit rate before warm was {:.2}% (next query benefits)",
+                count, scope, elapsed_s, rate
             ),
-            None => info!("Cache warm complete: {} files warmed (scope={}) in {}ms", count, scope, elapsed_ms),
+            None => info!("Cache warm complete: {} files warmed (scope={}) in {:.1}s", count, scope, elapsed_s),
         }
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -249,11 +249,7 @@ pub(crate) async fn ensure_deleted_file_retention(table: DeltaTable, retention_h
     if current.as_deref() == Some(desired.as_str()) {
         return table;
     }
-    match deltalake::DeltaOps(table.clone())
-        .set_tbl_properties()
-        .with_properties(HashMap::from([(KEY.to_string(), desired.clone())]))
-        .await
-    {
+    match table.clone().set_tbl_properties().with_properties(HashMap::from([(KEY.to_string(), desired.clone())])).await {
         Ok(updated) => {
             info!("Set {KEY}={desired} (was {current:?}) — bounds Remove tombstones kept in checkpoints");
             updated
@@ -4810,7 +4806,7 @@ mod tests {
         let mem = Arc::new(object_store::memory::InMemory::new());
         let url = Url::parse("memory:///convoy_tbl")?;
         let fast = DeltaTableBuilder::from_url(url.clone())?.with_storage_backend(mem.clone(), url.clone()).build()?;
-        let table = deltalake::DeltaOps(fast).create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
+        let table = fast.create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
         assert_eq!(table.version(), Some(0));
 
         // Same store, but every list/get pays a delay — makes update_state
@@ -4864,7 +4860,7 @@ mod tests {
         let mem = Arc::new(object_store::memory::InMemory::new());
         let url = Url::parse("memory:///retention_tbl")?;
         let t = DeltaTableBuilder::from_url(url.clone())?.with_storage_backend(mem, url).build()?;
-        let table = deltalake::DeltaOps(t).create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
+        let table = t.create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
         assert!(
             !table.snapshot()?.metadata().configuration().contains_key(KEY),
             "fresh table has no retention property"

--- a/src/database.rs
+++ b/src/database.rs
@@ -2195,6 +2195,11 @@ impl Database {
         // is about to issue against S3 (the completion log alone can't —
         // a large warm set takes minutes to get there).
         info!("Cache warm start: {count} files (scope={scope}, concurrency={concurrency})");
+        let t0 = std::time::Instant::now();
+        // Progress every 500 files: a 10k-file boot warm runs minutes; without
+        // a heartbeat operators can't tell warming from a hang.
+        let done = std::sync::atomic::AtomicUsize::new(0);
+        let done = &done;
         futures::stream::iter(paths)
             .for_each_concurrent(concurrency, |(path, recent)| {
                 let store = object_store.clone();
@@ -2203,16 +2208,21 @@ impl Database {
                     if warm_full_files && recent {
                         let _ = crate::object_store_cache::warm_full(store.as_ref(), &path).await;
                     }
+                    let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    if n % 500 == 0 {
+                        info!("Cache warm progress: {n}/{count} files");
+                    }
                 }
             })
             .await;
 
+        let elapsed_ms = t0.elapsed().as_millis();
         match baseline {
             Some(rate) => info!(
-                "Cache warm complete: {} files warmed (scope={}); foyer main hit rate before warm was {:.2}% (next query benefits)",
-                count, scope, rate
+                "Cache warm complete: {} files warmed (scope={}) in {}ms; foyer main hit rate before warm was {:.2}% (next query benefits)",
+                count, scope, elapsed_ms, rate
             ),
-            None => info!("Cache warm complete: {} files warmed (scope={})", count, scope),
+            None => info!("Cache warm complete: {} files warmed (scope={}) in {}ms", count, scope, elapsed_ms),
         }
     }
 

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -1513,6 +1513,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn containment_probe_serves_data_reads_on_small_fully_warmed_files() -> anyhow::Result<()> {
+        // Files smaller than the size hint are cached WHOLE under (0..size) by
+        // warm_footer — the candidate=0 probe then deliberately serves even
+        // data-page reads near the file START from the metadata cache. This is
+        // the other probe branch (candidate 0), distinct from the suffix-key
+        // case covered above.
+        let inner = Arc::new(InMemory::new());
+        let hint = 1024u64;
+        let cfg = FoyerCacheConfig::test_config_with("containment_probe_small", |c| c.parquet_metadata_size_hint = hint as usize);
+        let cache = FoyerObjectStoreCache::new(inner.clone(), cfg).await?;
+        let path = Path::from("tbl/date=2026-01-01/part-small.parquet");
+        let data = Bytes::from((0..512u32).map(|i| (i % 13) as u8).collect::<Vec<u8>>());
+        inner.put(&path, PutPayload::from(data.clone())).await?;
+
+        // file (512B) <= hint → warm key is the whole file (0..512)
+        assert!(warm_footer(&cache, &path, hint).await, "footer warm must succeed");
+
+        let before = cache.get_stats().await;
+        let r = 16u64..96u64; // nowhere near the footer
+        let got = cache.get_range(&path, r.clone()).await?;
+        assert_eq!(got, data.slice(r.start as usize..r.end as usize), "candidate-0 slice math");
+
+        let after = cache.get_stats().await;
+        assert_eq!(after.metadata.hits, before.metadata.hits + 1, "served by the candidate-0 probe");
+        assert_eq!(after.metadata.inner_gets, before.metadata.inner_gets, "no inner fetch after warm");
+
+        cache.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_basic_operations() -> anyhow::Result<()> {
         let inner = Arc::new(InMemory::new());
         let cache = FoyerObjectStoreCache::new(inner, FoyerCacheConfig::test_config("basic_ops")).await?;

--- a/src/object_store_cache.rs
+++ b/src/object_store_cache.rs
@@ -1496,7 +1496,9 @@ mod tests {
         // Put via the inner store so nothing is cached from a write payload.
         inner.put(&path, PutPayload::from(data.clone())).await?;
 
-        // file (4096B) > hint → warm key is (3072..4096)
+        // file (4096B) > hint → warm key is (3072..4096). Warm through &cache
+        // (not &*inner) deliberately: prod warms through the caching layer, so
+        // this also covers the suffix-GET path that populates the range key.
         assert!(warm_footer(&cache, &path, hint).await, "footer warm must succeed");
 
         let before = cache.get_stats().await;

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -64,6 +64,8 @@ pub struct PgCoalesceUdf {
 /// same token, fork upgrades that keep the version string still need the
 /// manual audit — the tripwire only catches plain `cargo update`s.
 const AUDITED_DATAFUSION_VERSION: &str = "53.1.0";
+// Byte loop because `&str` equality (PartialEq) isn't const-callable on
+// stable — assert!(a == b) won't compile in a const block.
 const _: () = {
     let (a, b) = (datafusion::DATAFUSION_VERSION.as_bytes(), AUDITED_DATAFUSION_VERSION.as_bytes());
     assert!(

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -60,7 +60,9 @@ pub struct PgCoalesceUdf {
 /// re-audit `ScalarUDFImpl` for new methods, forward them above, then bump.
 /// Maintenance invariant: DATAFUSION_VERSION resolves through the delta-rs
 /// fork's patched graph — the fork must not bump it independently of the
-/// workspace pin, or this check would pass against the wrong version.
+/// workspace pin, or this check would pass against the wrong version. By the
+/// same token, fork upgrades that keep the version string still need the
+/// manual audit — the tripwire only catches plain `cargo update`s.
 const AUDITED_DATAFUSION_VERSION: &str = "53.1.0";
 const _: () = {
     let (a, b) = (datafusion::DATAFUSION_VERSION.as_bytes(), AUDITED_DATAFUSION_VERSION.as_bytes());

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -55,7 +55,8 @@ pub struct PgCoalesceUdf {
 }
 
 /// DataFusion version `PgCoalesceUdf`'s method forwarding was last audited
-/// against. A `cargo update` of datafusion breaks the build here on purpose:
+/// against, compared at compile time to `datafusion::DATAFUSION_VERSION`.
+/// A `cargo update` of datafusion breaks the build here on purpose:
 /// re-audit `ScalarUDFImpl` for new methods, forward them above, then bump.
 const AUDITED_DATAFUSION_VERSION: &str = "53.1.0";
 const _: () = {

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -47,12 +47,32 @@ use datafusion::{
 /// Registered under the built-in's name, shadowing it session-wide; every
 /// trait method delegates to the inner built-in. On a DataFusion upgrade,
 /// re-check `ScalarUDFImpl` for new methods whose defaults would diverge
-/// from the built-in coalesce and forward them here too.
-/// Last audited against DataFusion 53.1.0 — bump this with each audit.
+/// from the built-in coalesce and forward them here too — the const assert
+/// below fails the build on a version bump until that audit happens.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PgCoalesceUdf {
     inner: Arc<datafusion::logical_expr::ScalarUDF>,
 }
+
+/// DataFusion version `PgCoalesceUdf`'s method forwarding was last audited
+/// against. A `cargo update` of datafusion breaks the build here on purpose:
+/// re-audit `ScalarUDFImpl` for new methods, forward them above, then bump.
+const AUDITED_DATAFUSION_VERSION: &str = "53.1.0";
+const _: () = {
+    let (a, b) = (datafusion::DATAFUSION_VERSION.as_bytes(), AUDITED_DATAFUSION_VERSION.as_bytes());
+    assert!(
+        a.len() == b.len(),
+        "DataFusion bumped: re-audit PgCoalesceUdf's ScalarUDFImpl forwarding, then update AUDITED_DATAFUSION_VERSION"
+    );
+    let mut i = 0;
+    while i < a.len() {
+        assert!(
+            a[i] == b[i],
+            "DataFusion bumped: re-audit PgCoalesceUdf's ScalarUDFImpl forwarding, then update AUDITED_DATAFUSION_VERSION"
+        );
+        i += 1;
+    }
+};
 
 impl Default for PgCoalesceUdf {
     fn default() -> Self {

--- a/src/optimizers/pg_array_literal_rewriter.rs
+++ b/src/optimizers/pg_array_literal_rewriter.rs
@@ -58,6 +58,9 @@ pub struct PgCoalesceUdf {
 /// against, compared at compile time to `datafusion::DATAFUSION_VERSION`.
 /// A `cargo update` of datafusion breaks the build here on purpose:
 /// re-audit `ScalarUDFImpl` for new methods, forward them above, then bump.
+/// Maintenance invariant: DATAFUSION_VERSION resolves through the delta-rs
+/// fork's patched graph — the fork must not bump it independently of the
+/// workspace pin, or this check would pass against the wrong version.
 const AUDITED_DATAFUSION_VERSION: &str = "53.1.0";
 const _: () = {
     let (a, b) = (datafusion::DATAFUSION_VERSION.as_bytes(), AUDITED_DATAFUSION_VERSION.as_bytes());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -76,14 +76,18 @@ pub mod test_helpers {
             "walrus_env_guard already held by another test — add #[serial] to the caller"
         );
         let prev = std::env::var_os("WALRUS_DATA_DIR");
-        unsafe { std::env::set_var("WALRUS_DATA_DIR", dir) };
-        scopeguard::guard(prev, |prev| {
+        // Guard constructed BEFORE set_var: if set_var ever panicked, drop
+        // would still clear HELD (and restore prev), instead of poisoning
+        // every later caller with a misleading "already held" assert.
+        let guard = scopeguard::guard(prev, |prev| {
             match prev {
                 Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },
                 None => unsafe { std::env::remove_var("WALRUS_DATA_DIR") },
             }
             HELD.store(false, Ordering::SeqCst);
-        })
+        });
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", dir) };
+        guard
     }
 
     /// Build a BufferedWriteLayer for tests/benches without repeating the registry boilerplate.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -65,13 +65,24 @@ pub mod test_helpers {
     /// Point walrus-rust at the test's data dir, restoring the prior value on
     /// drop — including on panic, so a failed `#[serial]` test can't leak the
     /// var into the next one. SAFETY: `set_var` is racy if another thread
-    /// reads the env concurrently; callers must hold `#[serial]`.
+    /// reads the env concurrently; callers must hold `#[serial]` — enforced
+    /// at runtime by the held-flag assert below, so a forgotten `#[serial]`
+    /// fails loudly instead of racing silently.
     pub fn walrus_env_guard(dir: &std::path::Path) -> impl Drop {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static HELD: AtomicBool = AtomicBool::new(false);
+        assert!(
+            !HELD.swap(true, Ordering::SeqCst),
+            "walrus_env_guard already held by another test — add #[serial] to the caller"
+        );
         let prev = std::env::var_os("WALRUS_DATA_DIR");
         unsafe { std::env::set_var("WALRUS_DATA_DIR", dir) };
-        scopeguard::guard(prev, |prev| match prev {
-            Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },
-            None => unsafe { std::env::remove_var("WALRUS_DATA_DIR") },
+        scopeguard::guard(prev, |prev| {
+            match prev {
+                Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },
+                None => unsafe { std::env::remove_var("WALRUS_DATA_DIR") },
+            }
+            HELD.store(false, Ordering::SeqCst);
         })
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -71,14 +71,15 @@ pub mod test_helpers {
     pub fn walrus_env_guard(dir: &std::path::Path) -> impl Drop {
         use std::sync::atomic::{AtomicBool, Ordering};
         static HELD: AtomicBool = AtomicBool::new(false);
+        // prev read BEFORE taking the flag, and the guard constructed BEFORE
+        // set_var: nothing fallible runs while HELD is set but unguarded, so
+        // no panic path can leave HELD stuck and poison later callers with a
+        // misleading "already held" assert.
+        let prev = std::env::var_os("WALRUS_DATA_DIR");
         assert!(
             !HELD.swap(true, Ordering::Acquire),
             "walrus_env_guard already held by another test — add #[serial] to the caller"
         );
-        let prev = std::env::var_os("WALRUS_DATA_DIR");
-        // Guard constructed BEFORE set_var: if set_var ever panicked, drop
-        // would still clear HELD (and restore prev), instead of poisoning
-        // every later caller with a misleading "already held" assert.
         let guard = scopeguard::guard(prev, |prev| {
             match prev {
                 Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -72,7 +72,7 @@ pub mod test_helpers {
         use std::sync::atomic::{AtomicBool, Ordering};
         static HELD: AtomicBool = AtomicBool::new(false);
         assert!(
-            !HELD.swap(true, Ordering::SeqCst),
+            !HELD.swap(true, Ordering::Acquire),
             "walrus_env_guard already held by another test — add #[serial] to the caller"
         );
         let prev = std::env::var_os("WALRUS_DATA_DIR");
@@ -84,7 +84,7 @@ pub mod test_helpers {
                 Some(v) => unsafe { std::env::set_var("WALRUS_DATA_DIR", v) },
                 None => unsafe { std::env::remove_var("WALRUS_DATA_DIR") },
             }
-            HELD.store(false, Ordering::SeqCst);
+            HELD.store(false, Ordering::Release);
         });
         unsafe { std::env::set_var("WALRUS_DATA_DIR", dir) };
         guard

--- a/tests/slt/json_functions.slt
+++ b/tests/slt/json_functions.slt
@@ -214,11 +214,13 @@ SELECT jsonb_build_array(sub.*) FROM (SELECT id, name, duration FROM otel_logs_a
 ----
 ["00000000-0000-0000-0000-000000000001","test_span",1500]
 
-# Test to_json function
+# Test to_json function. PG parity: to_json(text[]) keeps JSON-looking
+# elements as strings — no sniffing (changed in #53/#54; this expectation
+# was the stale pre-change output and kept master CI red).
 query T
 SELECT to_json(summary) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' ORDER BY timestamp LIMIT 1
 ----
-[{"count":5,"status":"ok"}]
+["{\"status\": \"ok\", \"count\": 5}"]
 
 # Test to_json with different types
 query T
@@ -270,8 +272,8 @@ WHERE project_id='00000000-0000-0000-0000-000000000000'
 ORDER BY timestamp DESC 
 LIMIT 2
 ----
-["00000000-0000-0000-0000-000000000002","2025-08-07T11:00:00.000000Z","trace456","another_span",2500,"test_service2","parent456",1754564400000000000,[{"count":0,"status":"error"}],"span456"]
-["00000000-0000-0000-0000-000000000001","2025-08-07T10:00:00.000000Z","trace123","test_span",1500,"test_service","parent123",1754560800000000000,[{"count":5,"status":"ok"}],"span123"]
+["00000000-0000-0000-0000-000000000002","2025-08-07T11:00:00.000000Z","trace456","another_span",2500,"test_service2","parent456",1754564400000000000,["{\"status\": \"error\", \"count\": 0}"],"span456"]
+["00000000-0000-0000-0000-000000000001","2025-08-07T10:00:00.000000Z","trace123","test_span",1500,"test_service","parent123",1754560800000000000,["{\"status\": \"ok\", \"count\": 5}"],"span123"]
 
 # === Functions that are NOT available ===
 


### PR DESCRIPTION
PR #50 was squash-merged at 11:33 UTC, between two review-fix pushes — the last three commits on its branch (all CI-green there) never reached master. This cherry-picks them:

- **walrus_env_guard runtime serialization assert**: a test that forgets `#[serial]` now fails loudly instead of silently racing `WALRUS_DATA_DIR`
- **build-time DataFusion audit tripwire**: const-asserts `DATAFUSION_VERSION == 53.1.0`; a datafusion bump breaks the build until `PgCoalesceUdf`'s `ScalarUDFImpl` forwarding is re-audited (raised in three successive review passes)
- **warm progress/elapsed logging**: progress every 500 files + elapsed_ms on completion, so a multi-minute 10k-file boot warm is distinguishable from a hang
- **candidate-0 containment-probe test**: pins that files at/under the size hint are served whole from the (0..size) metadata entry, including near-start data reads
- the autofmt bot's `is_multiple_of` lint fix on the progress check

All from the #50 review threads; 160/160 unit tests pass on this branch.

Note for `fix/oom-warm-order-lock-convoy`: the warm-path hunks here touch `warm_cache_for_uris` — the newest-first reordering in that branch will want a trivial rebase over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)