### PR TITLE
feat(telemetry): export logs over OTLP, honor OTEL_TRACES_EXPORTER=none

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4286,7 +4286,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5364,6 +5364,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6029,7 +6041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6183,7 +6195,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6221,7 +6233,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8215,6 +8227,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
@@ -9245,7 +9258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,9 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 tracing = "0.1.44"
 tracing-opentelemetry = "0.32"
 opentelemetry = "0.31"
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "metrics", "logs"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics", "logs"] }
+opentelemetry-appender-tracing = "0.31"
 datafusion-tracing = { git = "https://github.com/datafusion-contrib/datafusion-tracing.git", rev = "8c28322f" }
 instrumented-object-store = { git = "https://github.com/datafusion-contrib/datafusion-tracing.git", rev = "8c28322f" }
 dotenv = "0.15.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,10 @@ COPY --from=builder --chown=nonroot:nonroot /data     /app/data
 
 EXPOSE 80 5432
 
+# Default telemetry destination: the swarm-internal collector. Image ENV
+# loses to service-level env, so operators can still override per deploy.
+# Spans default off (per-query volume); logs + metrics flow.
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://srv-captain--otelcol:4317 \
+    OTEL_TRACES_EXPORTER=none
+
 ENTRYPOINT ["/usr/local/bin/timefusion"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -732,6 +732,9 @@ pub struct TelemetryConfig {
     pub otel_service_version:        String,
     #[serde(default)]
     pub log_format:                  Option<String>,
+    /// Standard OTel var; `none` disables span export (logs/metrics unaffected).
+    #[serde(default)]
+    pub otel_traces_exporter:        Option<String>,
 }
 
 impl TelemetryConfig {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,17 +1,21 @@
-use std::time::Duration;
+use std::{sync::OnceLock, time::Duration};
 
 use opentelemetry::{KeyValue, trace::TracerProvider};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
+    logs::SdkLoggerProvider,
     propagation::TraceContextPropagator,
     trace::{RandomIdGenerator, Sampler},
 };
 use tracing::info;
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::config::TelemetryConfig;
+
+/// Kept for `shutdown_telemetry` to flush buffered log batches at exit.
+static LOGGER_PROVIDER: OnceLock<SdkLoggerProvider> = OnceLock::new();
 
 pub fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<()> {
     // Set global propagator for trace context
@@ -28,37 +32,48 @@ pub fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<()> {
         .with_attributes([KeyValue::new("service.name", service_name.clone()), KeyValue::new("service.version", service_version.clone())])
         .build();
 
-    // Create OTLP span exporter
+    // Span export honors the standard OTEL_TRACES_EXPORTER=none switch —
+    // prod runs with spans off (per-query span volume) but logs/metrics on.
     // Note: In opentelemetry-otlp 0.31, message size limits cannot be directly configured
     // through the public API. The default limit is 4MB for incoming messages.
-    let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+    // Batch configuration is handled automatically (batch size 512, delay 5s,
+    // queue 2048).
+    let telemetry_layer = if config.otel_traces_exporter.as_deref() == Some("none") {
+        None
+    } else {
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(otlp_endpoint)
+            .with_timeout(Duration::from_secs(10))
+            .build()?;
+        let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(RandomIdGenerator::default())
+            .with_resource(resource.clone())
+            .build();
+        opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+        Some(OpenTelemetryLayer::new(tracer_provider.tracer("timefusion")))
+    };
+
+    // OTLP logs: bridge tracing events to the collector so TF shows up as a
+    // service in monoscope (the 2026-06-11 OOM loop was diagnosed entirely
+    // from client-side error strings because TF only logged to stdout).
+    // The bridge must not observe the exporter's own tracing output —
+    // tonic/hyper events inside an export would recurse into another export.
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
         .with_tonic()
         .with_endpoint(otlp_endpoint)
         .with_timeout(Duration::from_secs(10))
         .build()?;
-
-    // Build the tracer provider
-    // Note: In opentelemetry-sdk 0.31, batch configuration is handled automatically
-    // by the batch exporter. The default settings include:
-    // - Max export batch size: 512
-    // - Scheduled delay: 5 seconds
-    // - Max queue size: 2048
-    // These defaults work well for most use cases and help prevent hitting the 4MB limit
-    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_batch_exporter(span_exporter)
-        .with_sampler(Sampler::AlwaysOn)
-        .with_id_generator(RandomIdGenerator::default())
-        .with_resource(resource)
-        .build();
-
-    // Set global tracer provider
-    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
-
-    // Create tracer
-    let tracer = tracer_provider.tracer("timefusion");
-
-    // Create telemetry layer
-    let telemetry_layer = OpenTelemetryLayer::new(tracer);
+    let logger_provider = SdkLoggerProvider::builder().with_batch_exporter(log_exporter).with_resource(resource).build();
+    let log_bridge = opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider).with_filter(
+        tracing_subscriber::filter::filter_fn(|meta| {
+            let t = meta.target();
+            !(t.starts_with("opentelemetry") || t.starts_with("tonic") || t.starts_with("h2") || t.starts_with("hyper"))
+        }),
+    );
+    let _ = LOGGER_PROVIDER.set(logger_provider);
 
     // Get log filter from environment
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
@@ -66,7 +81,7 @@ pub fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<()> {
     // Initialize tracing subscriber with telemetry and formatting layers
     let is_json = config.is_json_logging();
 
-    let subscriber = Registry::default().with(env_filter).with(telemetry_layer);
+    let subscriber = Registry::default().with(env_filter).with(telemetry_layer).with(log_bridge);
 
     if is_json {
         subscriber
@@ -86,6 +101,9 @@ pub fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<()> {
 
 pub fn shutdown_telemetry() {
     info!("Shutting down OpenTelemetry");
-    // Note: In OpenTelemetry 0.31, there's no global shutdown function
-    // The tracer provider will be shut down when dropped
+    // Tracer/meter providers shut down when dropped; flush buffered logs
+    // explicitly so the final shutdown lines reach the collector.
+    if let Some(p) = LOGGER_PROVIDER.get() {
+        let _ = p.shutdown();
+    }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -67,12 +67,11 @@ pub fn init_telemetry(config: &TelemetryConfig) -> anyhow::Result<()> {
         .with_timeout(Duration::from_secs(10))
         .build()?;
     let logger_provider = SdkLoggerProvider::builder().with_batch_exporter(log_exporter).with_resource(resource).build();
-    let log_bridge = opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider).with_filter(
-        tracing_subscriber::filter::filter_fn(|meta| {
+    let log_bridge =
+        opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider).with_filter(tracing_subscriber::filter::filter_fn(|meta| {
             let t = meta.target();
             !(t.starts_with("opentelemetry") || t.starts_with("tonic") || t.starts_with("h2") || t.starts_with("hyper"))
-        }),
-    );
+        }));
     let _ = LOGGER_PROVIDER.set(logger_provider);
 
     // Get log filter from environment


### PR DESCRIPTION
## Problem

TF never appears as a service in monoscope — it exports spans/metrics over OTLP (when configured) but logs only go to stdout. Prod additionally had all `OTEL_*` env vars disabled by `x`-prefixing, so spans pointed at the `localhost:4317` default (the `BatchSpanProcessor.ExportError` noise at boot) and metrics went nowhere. Net effect: today's OOM crash loop had to be diagnosed entirely from the Haskell client's error strings and docker logs over SSH.

## Changes

- **OTLP logs export**: `opentelemetry-appender-tracing` bridges all `tracing` events (same `RUST_LOG` filter as stdout) to the collector, with a filter excluding `opentelemetry`/`tonic`/`h2`/`hyper` targets so the exporter's own events can't recurse into another export.
- **`OTEL_TRACES_EXPORTER=none`** (standard OTel var) now disables span export without taking logs/metrics down with it — that's the prod operator's intent (per-query span volume).
- **Dockerfile ENV defaults**: `OTEL_EXPORTER_OTLP_ENDPOINT=http://srv-captain--otelcol:4317` (same overlay network, verified) and `OTEL_TRACES_EXPORTER=none`. Image ENV loses to service-level env, so per-deploy overrides still work; the `x`-prefixed service vars don't collide.
- `shutdown_telemetry` flushes buffered log batches at exit.

## Verification plan

After deploy: `monoscope facets resource.service.name` should show `timefusion`, and `monoscope logs search '' --service timefusion --since 10m` should return boot/flush lines. This also unblocks the alerting monitors on `timefusion_*` metrics (bucket age, pressure_pct, WAL corruption, flush failures).

`test_batch_queue_under_load` fails on this branch but fails identically on clean master (pre-existing).