### PR TITLE
fix(wal): sweep GC immediately and every 10min, age out at retention+20min

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -61,13 +61,12 @@ pub async fn bootstrap(cfg: Arc<AppConfig>) -> Result<Bootstrapped> {
     db.setup_session_udfs(&mut session_context)?;
     let registry: Arc<crate::functions::FnRegistry> = Arc::new(session_context.state());
 
-    // Pre-init WAL GC: delete files older than 2× retention before walrus
-    // enumerates the dir on construction. Without this, accumulated leaks
-    // from prior process lifetimes dominate startup (see memory
-    // `wal_bloat_startup.md` — prod hit 467 GB / 12-min startup).
+    // Pre-init WAL GC: delete dead files before walrus enumerates the dir on
+    // construction. Without this, accumulated leaks from prior process
+    // lifetimes dominate startup (see memory `wal_bloat_startup.md` — prod
+    // hit 467 GB / 12-min startup).
     let t_gc = std::time::Instant::now();
-    let max_age = std::time::Duration::from_secs(cfg.buffer.retention_mins() * 60 * 2);
-    match crate::wal::gc_wal_files(&cfg.core.wal_dir(), max_age) {
+    match crate::wal::gc_wal_files(&cfg.core.wal_dir(), cfg.buffer.wal_gc_max_age()) {
         Ok((deleted, bytes_freed)) => tracing::info!(
             "bootstrap.phase=wal_gc deleted={deleted} bytes_freed={bytes_freed} elapsed_ms={}",
             t_gc.elapsed().as_millis()

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -717,20 +717,15 @@ impl BufferedWriteLayer {
     }
 
     async fn run_wal_gc_task(&self) {
-        // Run at a small multiple of retention so a single missed sweep
-        // doesn't leave files past their useful life on disk for long.
-        let retention_secs = self.config.buffer.retention_mins() * 60;
-        let interval = Duration::from_secs(retention_secs.max(60));
-        let max_age = Duration::from_secs(retention_secs * 2);
+        // Sweep immediately, then every 10 minutes. The walk touches at most
+        // a few dozen files, and waiting a full retention period before the
+        // first sweep meant a process that restarted faster than that never
+        // reclaimed anything — the 2026-06-11 crash loop (10-min OOM kills)
+        // re-accumulated 30GB this way despite this task existing.
+        const SWEEP_INTERVAL: Duration = Duration::from_secs(600);
+        let max_age = self.config.buffer.wal_gc_max_age();
         let wal_dir = self.wal.data_dir().clone();
         loop {
-            tokio::select! {
-                _ = tokio::time::sleep(interval) => {}
-                _ = self.shutdown.cancelled() => {
-                    info!("WAL GC task shutting down");
-                    break;
-                }
-            }
             let dir = wal_dir.clone();
             // Filesystem walk is sync — push to a blocking thread so we
             // don't stall the runtime if the dir got huge before this fix
@@ -739,10 +734,20 @@ impl BufferedWriteLayer {
             match res {
                 Ok(Ok((deleted, bytes_freed))) if deleted > 0 => {
                     info!("WAL GC: deleted {} stale files, freed {} bytes", deleted, bytes_freed);
+                    if let Some(m) = crate::metrics::registry() {
+                        m.wal_gc_deleted_files.add(deleted, &[]);
+                    }
                 }
                 Ok(Ok(_)) => {}
                 Ok(Err(e)) => warn!("WAL GC error: {}", e),
                 Err(e) => warn!("WAL GC task panicked: {}", e),
+            }
+            tokio::select! {
+                _ = tokio::time::sleep(SWEEP_INTERVAL) => {}
+                _ = self.shutdown.cancelled() => {
+                    info!("WAL GC task shutting down");
+                    break;
+                }
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -451,6 +451,13 @@ impl BufferConfig {
     pub fn retention_mins(&self) -> u64 {
         self.timefusion_buffer_retention_mins.max(1)
     }
+    /// Age past which a WAL file is dead weight: `recover_from_wal` skips
+    /// entries older than `retention_mins`, so anything last written before
+    /// that (plus slack for clock skew / an in-flight flush) can never be
+    /// replayed. Shared by the boot-time and runtime GC passes.
+    pub fn wal_gc_max_age(&self) -> Duration {
+        Duration::from_secs((self.retention_mins() + 20) * 60)
+    }
     pub fn eviction_interval_secs(&self) -> u64 {
         self.timefusion_eviction_interval_secs.max(1)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,14 +113,13 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // optional `TIMEFUSION_TANTIVY_INDEXED_TABLES` override). The query layer
     // accelerates standard SQL predicates (`=`, `LIKE 'prefix%'`) via the
     // TantivyPredicateRewriter — callers don't need to know tantivy exists.
-    // Pre-init WAL GC: delete files past 2× retention before walrus opens
-    // the dir. Walrus' own GC bookkeeping (FileStateTracker) is per-process
-    // and forgets every file written by prior processes — without this
-    // sweep, accumulated leaks dominate startup (prod hit 467 GB / 12-min
-    // startup on 2026-06-09).
+    // Pre-init WAL GC: delete dead files before walrus opens the dir.
+    // Walrus' own GC bookkeeping (FileStateTracker) is per-process and
+    // forgets every file written by prior processes — without this sweep,
+    // accumulated leaks dominate startup (prod hit 467 GB / 12-min startup
+    // on 2026-06-09).
     let t_gc = std::time::Instant::now();
-    let gc_max_age = Duration::from_secs(cfg.buffer.retention_mins() * 60 * 2);
-    match timefusion::wal::gc_wal_files(&cfg.core.wal_dir(), gc_max_age) {
+    match timefusion::wal::gc_wal_files(&cfg.core.wal_dir(), cfg.buffer.wal_gc_max_age()) {
         Ok((deleted, bytes_freed)) => info!(
             "bootstrap.phase=wal_gc deleted={deleted} bytes_freed={bytes_freed} elapsed_ms={}",
             t_gc.elapsed().as_millis()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,6 +62,7 @@ counter_registry! {
     ingest_rows                => "timefusion.ingest.rows": "Rows accepted into MemBuffer",
     ingest_errors              => "timefusion.ingest.errors": "Ingest call failures",
     wal_corruption             => "timefusion.wal.corruption_events": "WAL entries that failed to deserialize or replay",
+    wal_gc_deleted_files       => "timefusion.wal.gc_deleted_files": "Stale WAL files reclaimed by the mtime reaper (walrus leaks files across restarts)",
     flush_completed            => "timefusion.flush.completed": "Flush cycles that committed to Delta",
     flush_failed               => "timefusion.flush.failed": "Flush cycles that errored",
     query_executions           => "timefusion.query.executions": "SQL query plans executed",


### PR DESCRIPTION
## Problem

Walrus's file-deletion bookkeeping (`FileStateTracker`) is per-process, so every restart strands that boot's WAL files — the TF-side mtime reaper is the only thing reclaiming them. But:

1. The runtime reaper's **first sweep fired at t+70min** (one retention period). Any process restarting faster than that never reclaims — the 2026-06-11 OOM crash loop (10-min kills) re-accumulated 30GB this way *despite the reaper existing*.
2. The boot pass couldn't compensate because its age bar was **2× retention (140min)** and the loop's own files were always younger.
3. Steady state held ~140min of dead WAL (~50GB at prod's ~6MB/s) when `recover_from_wal`'s cutoff means only the last 70min is ever replayable.

Verified live today: the first sweep at boot+70min deleted the stale files correctly — the mechanism is sound, only cadence/age were wrong.

## Changes

- Runtime task sweeps **immediately on start, then every 10min** (walk touches ≤ a few dozen files).
- `max_age = retention + 20min` slack (covers clock skew / an in-flight flush), shared by boot and runtime passes via `BufferConfig::wal_gc_max_age()` — replaces two divergent inline computations. Steady state drops ~50GB → ~30GB.
- New `timefusion.wal.gc_deleted_files` counter (the `wal.disk_bytes` / `wal.files` gauges already exist). A monoscope warn monitor on `wal.disk_bytes > 60GB` is live.

Safety argument unchanged from the original reaper: a file whose mtime is older than retention contains only entries `recover_from_wal` would skip, so deleting it can never lose replayable data.

Phase 2 (walrus-native reclamation: rebuild tracker state from the startup scan + persisted cursors so fully-flushed files delete within minutes) tracked separately.

`test_batch_queue_under_load` fails on this branch but fails identically on clean master (pre-existing).