### PR TITLE
fix(wal): privatize IPC-sliced buffers; compact before WAL append

### DIFF
--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -474,6 +474,13 @@ impl BufferedWriteLayer {
 
         let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
 
+        // Compact before reservation AND WAL serialization: scan-backed DML
+        // batches and IPC-decoded inputs otherwise reserve at phantom size
+        // and serialize entire inherited buffers into the WAL (2026-06-11:
+        // fat UPDATE entries re-inflated the buffer to 772GB on every
+        // replay). MemBuffer's insert re-runs this as a cheap no-op.
+        let batches: Vec<RecordBatch> = batches.into_iter().map(crate::mem_buffer::compact_batch).collect();
+
         // Reserve memory atomically before writing - prevents race condition
         let reserved_size = self.try_reserve_memory(&batches).await?;
 

--- a/src/mem_buffer.rs
+++ b/src/mem_buffer.rs
@@ -356,8 +356,37 @@ fn compact_view_arrays(arr: &ArrayRef) -> ArrayRef {
     }
 }
 
-fn compact_view_batch(batch: RecordBatch) -> RecordBatch {
-    let cols: Vec<ArrayRef> = batch.columns().iter().map(compact_view_arrays).collect();
+/// Copy an array into freshly-allocated exact-size buffers when its current
+/// buffers are mostly someone else's bytes. Arrow IPC decode (WAL replay,
+/// gRPC ingest) reads the whole message body into one allocation and hands
+/// every column a slice of it — `Buffer::capacity()` reports the full body,
+/// so a replayed batch is charged ~n_cols × message size (prod 2026-06-11
+/// night: 6,546 replayed entries charged 772.5GB inside a 66.6GiB cgroup).
+/// The cap-vs-len gate sees exactly that: a slice's `len` is its own region,
+/// `capacity` is the underlying allocation. `MutableArrayData` rebases
+/// offsets and copies only the referenced region, recursing into children.
+fn privatize_sliced(arr: &ArrayRef) -> ArrayRef {
+    use arrow::array::{ArrayData, MutableArrayData, make_array};
+    fn waste(data: &ArrayData) -> (usize, usize) {
+        let (cap, len) = data.buffers().iter().fold((0usize, 0usize), |(c, l), b| (c + b.capacity(), l + b.len()));
+        data.child_data().iter().map(waste).fold((cap, len), |(c, l), (cc, cl)| (c + cc, l + cl))
+    }
+    let data = arr.to_data();
+    let (cap, len) = waste(&data);
+    if cap <= len * 2 + 1024 {
+        return arr.clone();
+    }
+    let mut m = MutableArrayData::new(vec![&data], false, data.len());
+    m.extend(0, 0, data.len());
+    make_array(m.freeze())
+}
+
+/// Full charge-honesty pass: view gc first (block slack / scan-block
+/// inheritance), then buffer privatization (IPC message-body slices). Runs
+/// at every bucket insert and before WAL serialization so neither memory
+/// accounting nor WAL entries carry other allocations' bytes.
+pub(crate) fn compact_batch(batch: RecordBatch) -> RecordBatch {
+    let cols: Vec<ArrayRef> = batch.columns().iter().map(|c| privatize_sliced(&compact_view_arrays(c))).collect();
     if cols.iter().zip(batch.columns()).all(|(a, b)| Arc::ptr_eq(a, b)) {
         batch
     } else {
@@ -1740,7 +1769,7 @@ impl TableBuffer {
     /// in the value returned (the caller's MemBuffer-level counter is
     /// approximate by design — converges on drain/evict).
     pub fn insert_batch(&self, batch: RecordBatch, timestamp_micros: i64) -> anyhow::Result<(usize, i64)> {
-        let batch = compact_view_batch(batch);
+        let batch = compact_batch(batch);
         let bucket_id = MemBuffer::compute_bucket_id(timestamp_micros);
         let row_count = batch.num_rows();
         let new_size = estimate_batch_size(&batch);

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1077,7 +1077,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::{
-        array::{Int64Array, StringViewArray},
+        array::{ArrayRef, Int64Array, StringViewArray},
         datatypes::{DataType, Field, Schema},
     };
 
@@ -1102,6 +1102,49 @@ mod tests {
         let deserialized = deserialize_record_batch(&serialized).unwrap();
         assert_eq!(batch.num_rows(), deserialized.num_rows());
         assert_eq!(batch.num_columns(), deserialized.num_columns());
+    }
+
+    // Prod 2026-06-11 night: WAL replay of 6,546 entries charged 772.5GB
+    // (~118MB each ≈ 89 cols × ~1.3MB message). Arrow IPC decode reads the
+    // whole message body into one allocation and hands every column a slice
+    // of it, so each column's `Buffer::capacity()` reports the full body —
+    // a replayed batch is charged ~n_cols × message size unless the buffers
+    // are privatized before entering a bucket.
+    #[test]
+    fn replayed_batch_charged_logical_not_message_body() {
+        let n_cols = 30;
+        let n_rows = 50;
+        let payload: Vec<String> = (0..n_rows).map(|i| format!("{i:0>100}")).collect();
+        let mut fields =
+            vec![Field::new("ts", DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into())), false)];
+        fields.extend(
+            (0..n_cols).map(|i| Field::new(format!("c{i}"), if i % 2 == 0 { DataType::Utf8View } else { DataType::Utf8 }, true)),
+        );
+        let ts = chrono::Utc::now().timestamp_micros();
+        let mut cols: Vec<ArrayRef> =
+            vec![Arc::new(arrow::array::TimestampMicrosecondArray::from(vec![ts; n_rows]).with_timezone("UTC"))];
+        let strs: Vec<&str> = payload.iter().map(|s| s.as_str()).collect();
+        cols.extend((0..n_cols).map(|i| -> ArrayRef {
+            if i % 2 == 0 {
+                Arc::new(StringViewArray::from(strs.clone()))
+            } else {
+                Arc::new(arrow::array::StringArray::from(strs.clone()))
+            }
+        }));
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), cols).unwrap();
+
+        let bytes = serialize_record_batch(&batch).unwrap();
+        let replayed = deserialize_record_batch(&bytes).unwrap();
+
+        let buffer = crate::mem_buffer::MemBuffer::new();
+        buffer.insert("p1", "t1", replayed, ts).unwrap();
+        let charged = buffer.estimated_memory_bytes();
+        // logical ≈ 30 cols × 50 rows × 100B ≈ 150KB; without privatization
+        // each column charges the ~190KB message body (~5.7MB total).
+        assert!(
+            charged < 1024 * 1024,
+            "replayed ~150KB-logical batch charged {charged} bytes — IPC message-body slices are leaking into accounting"
+        );
     }
 
     #[test]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1115,14 +1115,10 @@ mod tests {
         let n_cols = 30;
         let n_rows = 50;
         let payload: Vec<String> = (0..n_rows).map(|i| format!("{i:0>100}")).collect();
-        let mut fields =
-            vec![Field::new("ts", DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into())), false)];
-        fields.extend(
-            (0..n_cols).map(|i| Field::new(format!("c{i}"), if i % 2 == 0 { DataType::Utf8View } else { DataType::Utf8 }, true)),
-        );
+        let mut fields = vec![Field::new("ts", DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into())), false)];
+        fields.extend((0..n_cols).map(|i| Field::new(format!("c{i}"), if i % 2 == 0 { DataType::Utf8View } else { DataType::Utf8 }, true)));
         let ts = chrono::Utc::now().timestamp_micros();
-        let mut cols: Vec<ArrayRef> =
-            vec![Arc::new(arrow::array::TimestampMicrosecondArray::from(vec![ts; n_rows]).with_timezone("UTC"))];
+        let mut cols: Vec<ArrayRef> = vec![Arc::new(arrow::array::TimestampMicrosecondArray::from(vec![ts; n_rows]).with_timezone("UTC"))];
         let strs: Vec<&str> = payload.iter().map(|s| s.as_str()).collect();
         cols.extend((0..n_cols).map(|i| -> ArrayRef {
             if i % 2 == 0 {


### PR DESCRIPTION
## Problem

After #63 deployed, the very next boot rejected all inserts again: WAL replay of **6,546 entries charged 772.5GB** (RSS 13.9GiB — phantom multi-counting). Mechanism, confirmed by failing-first test:

1. Arrow IPC decode (WAL replay, and gRPC ingest) reads the whole message body into **one allocation** and hands every column a slice of it. `Buffer::capacity()` reports the full allocation, so a replayed batch is charged ~`n_cols × message_size` — 89 columns × ~1.3MB average entry = ~118MB each. The #63 view gc can't help: these are offset-based (`Utf8`/`Binary`) buffers.
2. The fat entries themselves are yesterday's scan-backed UPDATE batches: **WAL append runs before MemBuffer's compaction** (durability first), so the un-compacted inherited buffers were serialized at full size — which is also why the WAL ballooned to 30GB/day and why every restart re-poisons the buffer from disk.

## Fix

- **`privatize_sliced`** — recursive cap-vs-len gate over the `ArrayData` tree (a slice's `len` is its region; `capacity` is the whole allocation — exactly the IPC sharing signature) + `MutableArrayData` copy, which rebases offsets and copies only referenced bytes. Composed after the view gc in the new `compact_batch`, still applied at every bucket insert (covers replay and gRPC).
- **Compact before WAL append** in `BufferedWriteLayer::insert` — reservations become honest and WAL entries stop carrying inherited buffers, eliminating the fat-WAL source rather than just absorbing it at replay.

## Test

`replayed_batch_charged_logical_not_message_body` — a ~150KB-logical batch round-tripped through the WAL IPC serde and inserted into MemBuffer: charged **5,377,008 bytes** before the fix, **<1MB** after. Full mem_buffer + wal suites pass.

Prod was mitigated meanwhile by wiping the poisoned WAL (third wipe today — this PR removes the re-poisoning source).

`test_batch_queue_under_load` fails on this branch but fails identically on clean master (pre-existing).