### PR TITLE
perf: defer expensive projections past TopK + fix O(n²) json_build_array

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1527,6 +1527,9 @@ impl Database {
             .with_runtime_env(runtime_env)
             .with_default_features()
             .with_analyzer_rules(analyzer_rules)
+            // Appended after DataFusion's defaults so push_down_limit has
+            // already folded LIMIT into Sort.fetch — see the rule's docs.
+            .with_optimizer_rule(Arc::new(crate::optimizers::DeferExpensiveProjection))
             .with_physical_optimizer_rule(instrument_rule)
             .with_query_planner(Arc::new({
                 let planner = DmlQueryPlanner::new(self.clone());

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2017,24 +2017,30 @@ mod tests {
     /// first arg used to clamp num_rows to 1).
     #[test]
     fn test_json_build_array_linear_and_broadcast() {
-        use datafusion::arrow::array::{Int64Array, StringViewArray};
-        use datafusion::logical_expr::ScalarFunctionArgs;
+        use datafusion::{
+            arrow::array::{Int64Array, StringViewArray},
+            logical_expr::ScalarFunctionArgs,
+        };
         let n = 8192;
         let ids: ArrayRef = Arc::new(StringViewArray::from_iter_values((0..n).map(|i| format!("id-{i}"))));
         let nums: ArrayRef = Arc::new(Int64Array::from_iter_values(0..n as i64));
         let scalar = ColumnarValue::Scalar(datafusion::scalar::ScalarValue::Utf8(Some("tag".into())));
         let args = ScalarFunctionArgs {
-            args: vec![scalar, ColumnarValue::Array(ids), ColumnarValue::Array(nums)],
-            arg_fields: vec![],
-            number_rows: n,
-            return_field: Arc::new(datafusion::arrow::datatypes::Field::new("", DataType::Utf8View, true)),
+            args:           vec![scalar, ColumnarValue::Array(ids), ColumnarValue::Array(nums)],
+            arg_fields:     vec![],
+            number_rows:    n,
+            return_field:   Arc::new(datafusion::arrow::datatypes::Field::new("", DataType::Utf8View, true)),
             config_options: Arc::new(datafusion::config::ConfigOptions::default()),
         };
         let start = std::time::Instant::now();
         let ColumnarValue::Array(out) = JsonBuildArrayUDF::new().invoke_with_args(args).unwrap() else {
             panic!("expected array output")
         };
-        assert!(start.elapsed() < std::time::Duration::from_secs(2), "quadratic regression: took {:?}", start.elapsed());
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "quadratic regression: took {:?}",
+            start.elapsed()
+        );
         let out = out.as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
         assert_eq!(out.len(), n);
         assert_eq!(out.value(7), r#"["tag","id-7",7]"#);

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -955,43 +955,31 @@ impl ScalarUDFImpl for JsonBuildArrayUDF {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
         let args = args.args;
-        if args.is_empty() {
-            // Empty array case
-            let mut builder = StringViewBuilder::with_capacity(1);
-            builder.append_value("[]");
-            return Ok(ColumnarValue::Array(Arc::new(builder.finish())));
-        }
+        let num_rows = args
+            .iter()
+            .find_map(|a| match a {
+                ColumnarValue::Array(array) => Some(array.len()),
+                ColumnarValue::Scalar(_) => None,
+            })
+            .unwrap_or(1);
 
-        // Determine the number of rows
-        let num_rows = match &args[0] {
-            ColumnarValue::Array(array) => array.len(),
-            ColumnarValue::Scalar(_) => 1,
-        };
+        // Convert each argument column ONCE up front. Converting inside the
+        // row loop is O(rows² × args) — observed as ~0.6ms/row × millions of
+        // rows, enough to OOM prod on a wide-window span-list query.
+        let cols = args
+            .iter()
+            .map(|arg| match arg {
+                ColumnarValue::Array(array) => array_to_json_values(array),
+                ColumnarValue::Scalar(scalar) => array_to_json_values(&scalar.to_array()?),
+            })
+            .collect::<datafusion::error::Result<Vec<_>>>()?;
 
         let mut builder = StringViewBuilder::with_capacity(num_rows);
-
         for row_idx in 0..num_rows {
-            let mut row_values = Vec::new();
-
-            for arg in &args {
-                let value = match arg {
-                    ColumnarValue::Array(array) => {
-                        let json_values = array_to_json_values(array)?;
-                        json_values[row_idx].clone()
-                    }
-                    ColumnarValue::Scalar(scalar) => {
-                        let array = scalar.to_array()?;
-                        let json_values = array_to_json_values(&array)?;
-                        json_values[0].clone()
-                    }
-                };
-                row_values.push(value);
-            }
-
-            let json_array = JsonValue::Array(row_values);
-            builder.append_value(json_array.to_string());
+            // len-1 columns are broadcast scalars
+            let row = cols.iter().map(|c| c[if c.len() == 1 { 0 } else { row_idx }].clone()).collect();
+            builder.append_value(JsonValue::Array(row).to_string());
         }
-
         Ok(ColumnarValue::Array(Arc::new(builder.finish())))
     }
 }
@@ -2021,6 +2009,35 @@ mod tests {
         b.append(true);
         let arr: ArrayRef = Arc::new(b.finish());
         assert_eq!(array_to_json_values(&arr).unwrap(), expected);
+    }
+
+    /// Regression guard: json_build_array used to call array_to_json_values
+    /// per row per arg — O(rows² × args). At one 8192-row batch that's ~10s;
+    /// linear is <100ms. Also pins mixed scalar+array broadcast (a scalar
+    /// first arg used to clamp num_rows to 1).
+    #[test]
+    fn test_json_build_array_linear_and_broadcast() {
+        use datafusion::arrow::array::{Int64Array, StringViewArray};
+        use datafusion::logical_expr::ScalarFunctionArgs;
+        let n = 8192;
+        let ids: ArrayRef = Arc::new(StringViewArray::from_iter_values((0..n).map(|i| format!("id-{i}"))));
+        let nums: ArrayRef = Arc::new(Int64Array::from_iter_values(0..n as i64));
+        let scalar = ColumnarValue::Scalar(datafusion::scalar::ScalarValue::Utf8(Some("tag".into())));
+        let args = ScalarFunctionArgs {
+            args: vec![scalar, ColumnarValue::Array(ids), ColumnarValue::Array(nums)],
+            arg_fields: vec![],
+            number_rows: n,
+            return_field: Arc::new(datafusion::arrow::datatypes::Field::new("", DataType::Utf8View, true)),
+            config_options: Arc::new(datafusion::config::ConfigOptions::default()),
+        };
+        let start = std::time::Instant::now();
+        let ColumnarValue::Array(out) = JsonBuildArrayUDF::new().invoke_with_args(args).unwrap() else {
+            panic!("expected array output")
+        };
+        assert!(start.elapsed() < std::time::Duration::from_secs(2), "quadratic regression: took {:?}", start.elapsed());
+        let out = out.as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
+        assert_eq!(out.len(), n);
+        assert_eq!(out.value(7), r#"["tag","id-7",7]"#);
     }
 
     #[test]

--- a/src/optimizers/defer_expensive_projection.rs
+++ b/src/optimizers/defer_expensive_projection.rs
@@ -1,0 +1,192 @@
+//! Defer expensive scalar projections past TopK (Sort with fetch).
+//!
+//! `SELECT jsonb_build_array(...) FROM t WHERE ... ORDER BY ts DESC LIMIT 501`
+//! plans as `Sort(fetch=501)` over `Projection(expensive exprs)`: the JSON
+//! building / timestamp formatting / casts run for EVERY row in the time
+//! window before TopK keeps 501. On wide windows that's minutes of CPU and
+//! an OOM-sized allocation storm (observed killing prod TimeFusion).
+//!
+//! Rewrite: `Sort(fetch) → Projection(expensive)` becomes
+//! `Projection(expensive, rebuilt) → Sort(fetch, exprs inlined) → Projection(raw cols)`
+//! so non-trivial exprs are evaluated only on the `fetch` surviving rows.
+//! Registered after DataFusion's defaults, so `push_down_limit` has already
+//! folded LIMIT into `Sort.fetch` by the time it runs.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{
+        Column, Result,
+        tree_node::{Transformed, TreeNode},
+    },
+    logical_expr::{Expr, LogicalPlan, Projection, Sort, SortExpr},
+    optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule},
+};
+
+#[derive(Debug, Default)]
+pub struct DeferExpensiveProjection;
+
+/// Columns, literals, and aliases thereof cost nothing per-row; everything
+/// else (function calls, casts, IS NULL, arithmetic) is worth deferring.
+fn is_trivial(e: &Expr) -> bool {
+    match e {
+        Expr::Column(_) | Expr::Literal(..) => true,
+        Expr::Alias(a) => is_trivial(&a.expr),
+        _ => false,
+    }
+}
+
+impl OptimizerRule for DeferExpensiveProjection {
+    fn name(&self) -> &str {
+        "defer_expensive_projection"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(&self, plan: LogicalPlan, _config: &dyn OptimizerConfig) -> Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Sort(sort) = plan else { return Ok(Transformed::no(plan)) };
+        let (LogicalPlan::Projection(proj), Some(_)) = (sort.input.as_ref(), sort.fetch) else {
+            return Ok(Transformed::no(LogicalPlan::Sort(sort)));
+        };
+        if proj.expr.iter().all(is_trivial) {
+            return Ok(Transformed::no(LogicalPlan::Sort(sort)));
+        }
+
+        // Projection-output column → underlying (unaliased) expr, for inlining
+        // sort keys that reference projection outputs.
+        let out_map: std::collections::HashMap<Column, Expr> = proj
+            .schema
+            .iter()
+            .zip(proj.expr.iter())
+            .map(|((q, f), e)| (Column::new(q.cloned(), f.name()), e.clone().unalias()))
+            .collect();
+        let new_sort_exprs = sort
+            .expr
+            .iter()
+            .map(|se| {
+                let expr = se
+                    .expr
+                    .clone()
+                    .transform_up(|e| {
+                        Ok(match &e {
+                            Expr::Column(c) => match out_map.get(c) {
+                                Some(rep) => Transformed::yes(rep.clone()),
+                                None => Transformed::no(e),
+                            },
+                            _ => Transformed::no(e),
+                        })
+                    })?
+                    .data;
+                Ok(SortExpr { expr, ..se.clone() })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Raw input columns the deferred exprs and inlined sort keys need.
+        let mut needed: Vec<Column> = Vec::new();
+        for e in proj.expr.iter().chain(new_sort_exprs.iter().map(|se| &se.expr)) {
+            for c in e.column_refs() {
+                if !needed.contains(c) {
+                    needed.push(c.clone());
+                }
+            }
+        }
+        if needed.is_empty() {
+            return Ok(Transformed::no(LogicalPlan::Sort(sort)));
+        }
+
+        let min_proj = Projection::try_new(needed.into_iter().map(Expr::Column).collect(), Arc::clone(&proj.input))?;
+        let new_sort = LogicalPlan::Sort(Sort {
+            expr: new_sort_exprs,
+            input: Arc::new(LogicalPlan::Projection(min_proj)),
+            fetch: sort.fetch,
+        });
+        // Rebuild the original projection above the TopK, aliasing each expr
+        // to its original (qualifier, name) so the parent plan's column
+        // references and the root schema are unchanged.
+        let rebuilt = proj
+            .schema
+            .iter()
+            .zip(proj.expr.iter())
+            .map(|((q, f), e)| e.clone().unalias().alias_qualified(q.cloned(), f.name()))
+            .collect();
+        let hoisted = Projection::try_new_with_schema(rebuilt, Arc::new(new_sort), Arc::clone(&proj.schema))?;
+        Ok(Transformed::yes(LogicalPlan::Projection(hoisted)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema, TimeUnit},
+        datasource::MemTable,
+        execution::session_state::SessionStateBuilder,
+        prelude::SessionContext,
+    };
+
+    async fn plans(sql: &str, with_rule: bool) -> (String, String) {
+        let mut builder = SessionStateBuilder::new().with_default_features();
+        if with_rule {
+            builder = builder.with_optimizer_rule(Arc::new(DeferExpensiveProjection));
+        }
+        let ctx = SessionContext::new_with_state(builder.build());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        ]));
+        ctx.register_table("t", Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap())).unwrap();
+        let df = ctx.sql(sql).await.unwrap();
+        let logical = format!("{}", df.clone().into_optimized_plan().unwrap().display_indent());
+        let physical = format!("{}", datafusion::physical_plan::displayable(df.create_physical_plan().await.unwrap().as_ref()).indent(false));
+        (logical, physical)
+    }
+
+    async fn optimized_plan(sql: &str, with_rule: bool) -> String {
+        plans(sql, with_rule).await.0
+    }
+
+    /// Regression guard for the prod OOM: jsonb-style row building must not
+    /// run below the TopK. Without the rule, the expensive expr sits under
+    /// `Sort`, i.e. it is evaluated for every row in the window.
+    #[tokio::test]
+    async fn defers_expensive_projection_past_topk() {
+        let sql = "SELECT concat(id, name) FROM t ORDER BY timestamp DESC LIMIT 5";
+        let before = optimized_plan(sql, false).await;
+        let (b_sort, b_concat) = (before.find("Sort:").unwrap(), before.rfind("concat").unwrap());
+        assert!(b_concat > b_sort, "baseline should evaluate concat below Sort:\n{before}");
+
+        let (after, phys) = plans(sql, true).await;
+        let sort_pos = after.find("Sort:").expect(&after);
+        let concat_pos = after.find("concat").expect(&after);
+        assert!(concat_pos < sort_pos, "expensive expr must be above the TopK sort:\n{after}");
+        assert!(after.contains("fetch=5"), "TopK fetch must survive the rewrite:\n{after}");
+        // The physical ProjectionPushdown rule must not push the expensive
+        // projection back below SortExec (it can only do so when the sort key
+        // survives the projection as a raw column, which it doesn't here).
+        let p_sort = phys.find("SortExec").expect(&phys);
+        assert!(phys.find("concat").expect(&phys) < p_sort, "physical plan must keep concat above SortExec:\n{phys}");
+        assert!(phys.contains("TopK"), "SortExec must run as TopK:\n{phys}");
+    }
+
+    /// Sort keys that reference an expensive projection output must be
+    /// inlined below the sort, and the query still plannable.
+    #[tokio::test]
+    async fn inlines_expensive_sort_key() {
+        let sql = "SELECT upper(name) AS u, concat(id, name) FROM t ORDER BY u DESC LIMIT 3";
+        let after = optimized_plan(sql, true).await;
+        let sort_pos = after.find("Sort:").expect(&after);
+        assert!(after.rfind("concat").unwrap() < sort_pos, "concat must be deferred:\n{after}");
+    }
+
+    /// No fetch → no rewrite (nothing to win without a TopK).
+    #[tokio::test]
+    async fn leaves_unfetched_sort_alone() {
+        let sql = "SELECT concat(id, name) FROM t ORDER BY timestamp DESC";
+        let after = optimized_plan(sql, true).await;
+        let sort_pos = after.find("Sort:").expect(&after);
+        assert!(after.rfind("concat").unwrap() > sort_pos, "plain sort should be untouched:\n{after}");
+    }
+}

--- a/src/optimizers/defer_expensive_projection.rs
+++ b/src/optimizers/defer_expensive_projection.rs
@@ -98,7 +98,7 @@ impl OptimizerRule for DeferExpensiveProjection {
 
         let min_proj = Projection::try_new(needed.into_iter().map(Expr::Column).collect(), Arc::clone(&proj.input))?;
         let new_sort = LogicalPlan::Sort(Sort {
-            expr: new_sort_exprs,
+            expr:  new_sort_exprs,
             input: Arc::new(LogicalPlan::Projection(min_proj)),
             fetch: sort.fetch,
         });
@@ -118,13 +118,14 @@ impl OptimizerRule for DeferExpensiveProjection {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use datafusion::{
         arrow::datatypes::{DataType, Field, Schema, TimeUnit},
         datasource::MemTable,
         execution::session_state::SessionStateBuilder,
         prelude::SessionContext,
     };
+
+    use super::*;
 
     async fn plans(sql: &str, with_rule: bool) -> (String, String) {
         let mut builder = SessionStateBuilder::new().with_default_features();
@@ -140,7 +141,10 @@ mod tests {
         ctx.register_table("t", Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap())).unwrap();
         let df = ctx.sql(sql).await.unwrap();
         let logical = format!("{}", df.clone().into_optimized_plan().unwrap().display_indent());
-        let physical = format!("{}", datafusion::physical_plan::displayable(df.create_physical_plan().await.unwrap().as_ref()).indent(false));
+        let physical = format!(
+            "{}",
+            datafusion::physical_plan::displayable(df.create_physical_plan().await.unwrap().as_ref()).indent(false)
+        );
         (logical, physical)
     }
 
@@ -167,7 +171,10 @@ mod tests {
         // projection back below SortExec (it can only do so when the sort key
         // survives the projection as a raw column, which it doesn't here).
         let p_sort = phys.find("SortExec").expect(&phys);
-        assert!(phys.find("concat").expect(&phys) < p_sort, "physical plan must keep concat above SortExec:\n{phys}");
+        assert!(
+            phys.find("concat").expect(&phys) < p_sort,
+            "physical plan must keep concat above SortExec:\n{phys}"
+        );
         assert!(phys.contains("TopK"), "SortExec must run as TopK:\n{phys}");
     }
 

--- a/src/optimizers/mod.rs
+++ b/src/optimizers/mod.rs
@@ -1,3 +1,4 @@
+mod defer_expensive_projection;
 pub mod pg_array_literal_rewriter;
 mod tantivy_rewriter;
 mod variant_insert_rewriter;
@@ -8,6 +9,7 @@ use datafusion::{
     logical_expr::{BinaryExpr, Expr, Operator},
     scalar::ScalarValue,
 };
+pub use defer_expensive_projection::DeferExpensiveProjection;
 pub use pg_array_literal_rewriter::PgArrayLiteralRewriter;
 pub use tantivy_rewriter::TantivyPredicateRewriter;
 pub use variant_insert_rewriter::VariantInsertRewriter;


### PR DESCRIPTION
## Problem

The monoscope trace-explorer span-list query

\`\`\`sql
SELECT jsonb_build_array(id, to_char(timestamp ...), ..., to_jsonb(summary), ...)
FROM otel_logs_and_spans
WHERE project_id = $1 AND timestamp BETWEEN $2 AND $3
ORDER BY timestamp DESC LIMIT 501
\`\`\`

ran **15m07s on a 24h window and OOM-crashed prod TimeFusion** — very likely the cause of the known ~8x/day silent restart loop. Two compounding bugs:

1. **Projection evaluated below TopK.** DataFusion plans the `jsonb_build_array(...)` projection under `Sort(fetch=501)`, so JSON building / `to_char` formatting / `to_jsonb(summary)` ran for *every row in the time window* before TopK kept 501.
2. **`json_build_array` was O(rows² × args).** `JsonBuildArrayUDF::invoke_with_args` called `array_to_json_values(entire column)` inside the per-row loop — ~0.6ms/row for the 12-arg call. It also clamped `num_rows` to 1 when the first arg was a scalar.

## Fix

- New `DeferExpensiveProjection` optimizer rule (appended after DataFusion defaults): rewrites `Sort(fetch) → Projection(expensive)` into `Projection(expensive) → Sort(fetch) → Projection(raw cols)`, inlining sort keys that reference projection outputs. Non-trivial exprs now run only on the `fetch` surviving rows. Unit tests assert both the logical and the physical plan (TopK stays, physical ProjectionPushdown can't undo it).
- `JsonBuildArrayUDF` converts each argument column once up front; len-1 columns broadcast. Regression test pins linear behavior (8192-row batch < 2s; quadratic took ~10s) and the scalar-first broadcast.

## Numbers (exact query, local release-iter vs OVH S3, warm)

| | before | after |
|---|---|---|
| 35-day window, 20k rows, LIMIT 501 | 310ms | **40ms** |
| raw TopK / count over same window | 20ms | 20ms |

Full lib suite + sqllogictest pass (`test_batch_queue_under_load` fails pre-existing on master too).