### PR TITLE
fix: insert backpressure instead of rejection + 5-min buckets

### DIFF
--- a/bench/query_under_ingest.py
+++ b/bench/query_under_ingest.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Reproduce prod-shaped MemBuffer fragmentation: ingest small batches into one
+project, then time the monoscope span-list query against the buffered rows.
+Usage: python3 bench/query_under_ingest.py [total_rows] [rows_per_batch]
+"""
+import os, sys, time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import psycopg
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+from concurrent_load import COLUMNS, _to_pg, load_rows, shift_for_project
+
+URL = f"host=127.0.0.1 port={os.environ.get('PGWIRE_PORT','12345')} user=postgres password=postgres dbname=postgres"
+PID = os.environ.get("QUI_PROJECT", "qlat-frag-p0")
+Q = """SELECT jsonb_build_array(id, to_char(timestamp at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'), context___trace_id, name, duration, resource___service___name, parent_id, CAST(EXTRACT(EPOCH FROM (start_time)) * 1000000000 AS BIGINT), errors is not null, to_jsonb(summary), context___span_id, kind)
+FROM otel_logs_and_spans
+WHERE project_id = %s AND timestamp BETWEEN now() - interval '1 hour' AND now() AND (TRUE)
+ORDER BY timestamp DESC LIMIT 501"""
+
+
+def main():
+    total = int(sys.argv[1]) if len(sys.argv) > 1 else 30000
+    per_batch = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+    rows = shift_for_project(load_rows(per_batch), PID, timedelta(0))
+    placeholders = "(" + ", ".join(["%s"] * len(COLUMNS)) + ")"
+    sql = f"INSERT INTO otel_logs_and_spans ({', '.join(COLUMNS)}) VALUES " + ", ".join([placeholders] * len(rows))
+    t0 = time.perf_counter()
+    with psycopg.connect(URL, autocommit=True) as c, c.cursor() as cur:
+        sent = 0
+        while sent < total:
+            now = datetime.now(timezone.utc)
+            for r in rows:
+                r["timestamp"] = now.isoformat()
+                r["date"] = now.date().isoformat()
+            cur.execute(sql, [_to_pg(col, r.get(col)) for r in rows for col in COLUMNS])
+            sent += len(rows)
+        print(f"ingested {sent} rows in {per_batch}-row batches ({time.perf_counter()-t0:.0f}s)")
+        lats = []
+        for i in range(7):
+            t = time.perf_counter()
+            cur.execute(Q, (PID,))
+            n = len(cur.fetchall())
+            ms = (time.perf_counter() - t) * 1000
+            lats.append(ms)
+            print(f"query iter{i}: {ms:7.1f}ms rows={n}")
+        lats.sort()
+        print(f"p50={lats[len(lats) // 2]:.0f}ms min={lats[0]:.0f}ms max={lats[-1]:.0f}ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -570,7 +570,7 @@ impl BufferedWriteLayer {
     /// bucket's rows atomically under the insert lock (no lost-write race) and
     /// leaves the bucket in place for ongoing inserts. On commit failure the
     /// rows are restored — durability never depended on this (WAL holds them).
-    async fn force_flush_current_buckets(&self) -> anyhow::Result<()> {
+    pub(crate) async fn force_flush_current_buckets(&self) -> anyhow::Result<()> {
         let _flush_guard = self.flush_lock.lock().await;
         let current = MemBuffer::current_bucket_id();
         // WAL-ordering safety: `advance_by_counts` consumes entries sequentially

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -110,28 +110,28 @@ fn quarantine_entry(quarantine_dir: &std::path::Path, entry: &WalEntry, kind: &s
 /// `snapshot_stats()` and rendered as rows by `timefusion.stats()`.
 #[derive(Debug, Clone)]
 pub struct StatsSnapshot {
-    pub mem_project_count:      usize,
-    pub mem_total_buckets:      usize,
-    pub mem_total_rows:         usize,
-    pub mem_total_batches:      usize,
-    pub mem_estimated_bytes:    usize,
-    pub reserved_bytes:         usize,
-    pub max_memory_bytes:       usize,
-    pub pressure_pct:           u32,
-    pub wal_files:              usize,
-    pub wal_disk_bytes:         u64,
-    pub wal_shards_per_topic:   usize,
-    pub wal_known_topics:       usize,
-    pub bucket_duration_micros: i64,
+    pub mem_project_count:          usize,
+    pub mem_total_buckets:          usize,
+    pub mem_total_rows:             usize,
+    pub mem_total_batches:          usize,
+    pub mem_estimated_bytes:        usize,
+    pub reserved_bytes:             usize,
+    pub max_memory_bytes:           usize,
+    pub pressure_pct:               u32,
+    pub wal_files:                  usize,
+    pub wal_disk_bytes:             u64,
+    pub wal_shards_per_topic:       usize,
+    pub wal_known_topics:           usize,
+    pub bucket_duration_micros:     i64,
     /// Age of the oldest bucket in MemBuffer (seconds, computed from
     /// `now - min(bucket.min_timestamp)`). None when MemBuffer is empty.
     /// Alerting target: alert at > 2× `flush_interval_secs`.
-    pub oldest_bucket_age_secs: Option<u64>,
+    pub oldest_bucket_age_secs:     Option<u64>,
     /// Cumulative flush successes/failures since process start. Mirrors the
     /// OTel `timefusion.flush.completed`/`failed` counters so tests can
     /// assert without configuring OTel.
-    pub flush_completed_total:  u64,
-    pub flush_failed_total:     u64,
+    pub flush_completed_total:      u64,
+    pub flush_failed_total:         u64,
     /// Times an insert hit the memory hard limit and applied backpressure
     /// (synchronous flush-to-Delta) instead of rejecting. Sustained growth =
     /// ingest outpacing flush; the matching OTel counter is the alert target.
@@ -267,38 +267,38 @@ pub type TantivyIndexCallback =
     Arc<dyn Fn(String, String, Vec<RecordBatch>, Vec<String>) -> futures::future::BoxFuture<'static, anyhow::Result<()>> + Send + Sync>;
 
 pub struct BufferedWriteLayer {
-    config:                 Arc<AppConfig>,
-    wal:                    Arc<WalManager>,
-    mem_buffer:             Arc<MemBuffer>,
-    shutdown:               CancellationToken,
-    delta_write_callback:   Option<DeltaWriteCallback>,
-    tantivy_index_callback: Option<TantivyIndexCallback>,
-    background_tasks:       Mutex<Vec<JoinHandle<()>>>,
-    flush_lock:             Mutex<()>,
-    reserved_bytes:         AtomicUsize, // Memory reserved for in-flight writes
-    pressure_notify:        Arc<Notify>, // Wakes flush task when pressure threshold crossed
+    config:                     Arc<AppConfig>,
+    wal:                        Arc<WalManager>,
+    mem_buffer:                 Arc<MemBuffer>,
+    shutdown:                   CancellationToken,
+    delta_write_callback:       Option<DeltaWriteCallback>,
+    tantivy_index_callback:     Option<TantivyIndexCallback>,
+    background_tasks:           Mutex<Vec<JoinHandle<()>>>,
+    flush_lock:                 Mutex<()>,
+    reserved_bytes:             AtomicUsize, // Memory reserved for in-flight writes
+    pressure_notify:            Arc<Notify>, // Wakes flush task when pressure threshold crossed
     /// Notified at the end of every flush task iteration (success or failure).
     /// Test hook: lets E2E harnesses await actual completion of background work
     /// instead of racing wall-clock sleeps.
-    flush_tick_notify:      Arc<Notify>,
+    flush_tick_notify:          Arc<Notify>,
     /// Notified at the end of every eviction task iteration.
-    eviction_tick_notify:   Arc<Notify>,
+    eviction_tick_notify:       Arc<Notify>,
     /// Cumulative flush counters mirrored alongside OTel `record_flush`.
     /// OTel global metric state is opt-in (only initialized when telemetry is
     /// configured), so these atomics give the harness an in-process way to
     /// assert on what the global counters would be.
-    flush_completed_total:  AtomicU64,
-    flush_failed_total:     AtomicU64,
+    flush_completed_total:      AtomicU64,
+    flush_failed_total:         AtomicU64,
     backpressure_engaged_total: AtomicU64,
     // Required for WAL replay of UPDATE/DELETE whose SQL references UDFs.
-    function_registry:      Arc<crate::functions::FnRegistry>,
+    function_registry:          Arc<crate::functions::FnRegistry>,
     /// Caps concurrent detached tantivy sidecar builds so a fast flush cycle
     /// (post-F4 — one build per (project, table) per cycle) can't fan out
     /// past S3 connection / memory limits when many tables flush together.
     /// FOLLOW-UP: handles aren't stored; graceful shutdown does not await
     /// in-flight tantivy uploads. Acceptable for now because the sidecar is
     /// best-effort and the index can be rebuilt from Delta on demand.
-    tantivy_spawn_sem:      Arc<tokio::sync::Semaphore>,
+    tantivy_spawn_sem:          Arc<tokio::sync::Semaphore>,
 }
 
 impl std::fmt::Debug for BufferedWriteLayer {
@@ -532,7 +532,10 @@ impl BufferedWriteLayer {
         }
         // `force_flush_current_buckets` self-gates on the WAL-ordering invariant
         // (see its body), so calling it whenever pressure persists is safe.
-        if force_current && self.is_memory_pressure() && let Err(e) = self.force_flush_current_buckets().await {
+        if force_current
+            && self.is_memory_pressure()
+            && let Err(e) = self.force_flush_current_buckets().await
+        {
             warn!("backpressure: force_flush_current_buckets failed: {}", e);
         }
     }
@@ -567,7 +570,10 @@ impl BufferedWriteLayer {
             match self.flush_bucket(&bucket).await {
                 Ok(()) => {
                     if let Err(e) = self.wal.advance_by_counts(&bucket.project_id, &bucket.table_name, &bucket.wal_shard_counts) {
-                        warn!("force-flush: advance_by_counts failed (rows committed to Delta; WAL will re-replay, dedup protects): {}", e);
+                        warn!(
+                            "force-flush: advance_by_counts failed (rows committed to Delta; WAL will re-replay, dedup protects): {}",
+                            e
+                        );
                     } else {
                         self.flush_completed_total.fetch_add(1, Ordering::Relaxed);
                     }

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -132,6 +132,10 @@ pub struct StatsSnapshot {
     /// assert without configuring OTel.
     pub flush_completed_total:  u64,
     pub flush_failed_total:     u64,
+    /// Times an insert hit the memory hard limit and applied backpressure
+    /// (synchronous flush-to-Delta) instead of rejecting. Sustained growth =
+    /// ingest outpacing flush; the matching OTel counter is the alert target.
+    pub backpressure_engaged_total: u64,
 }
 
 #[derive(Debug, Default)]
@@ -285,6 +289,7 @@ pub struct BufferedWriteLayer {
     /// assert on what the global counters would be.
     flush_completed_total:  AtomicU64,
     flush_failed_total:     AtomicU64,
+    backpressure_engaged_total: AtomicU64,
     // Required for WAL replay of UPDATE/DELETE whose SQL references UDFs.
     function_registry:      Arc<crate::functions::FnRegistry>,
     /// Caps concurrent detached tantivy sidecar builds so a fast flush cycle
@@ -336,6 +341,7 @@ impl BufferedWriteLayer {
             eviction_tick_notify: Arc::new(Notify::new()),
             flush_completed_total: AtomicU64::new(0),
             flush_failed_total: AtomicU64::new(0),
+            backpressure_engaged_total: AtomicU64::new(0),
             function_registry,
             // 16 is well above realistic per-cycle table fan-out for the
             // monoscope workload (~5 distinct table names) while still
@@ -452,6 +458,130 @@ impl BufferedWriteLayer {
         self.reserved_bytes.fetch_sub(size, Ordering::Release);
     }
 
+    /// Reserve memory for a write, applying *backpressure* instead of dropping
+    /// the write when the hard limit is hit. The rows are already destined for
+    /// the durable WAL, and Delta/S3 is effectively unbounded "disk" — so when
+    /// RAM is full the correct move is to flush MemBuffer → Delta to make room
+    /// (the spill), not to reject. We retry the reservation after each drain
+    /// and only fail after `write_backpressure_timeout` with no progress, which
+    /// means Delta itself is unavailable.
+    ///
+    /// This deliberately reintroduces synchronous flushing into the insert path
+    /// (previously removed to keep inserts non-blocking). The trade-off is
+    /// intentional and now load-bearing: for a time-series DB a slow write is
+    /// far better than a rejected one the producer must DLQ. Normal sub-limit
+    /// inserts take the fast path and never block here.
+    async fn reserve_with_backpressure(&self, batches: &[RecordBatch]) -> anyhow::Result<usize> {
+        let first = self.try_reserve_memory(batches).await;
+        let timeout = self.config.buffer.write_backpressure_timeout();
+        if first.is_ok() || timeout.is_zero() {
+            return first;
+        }
+
+        let deadline = std::time::Instant::now() + timeout;
+        let mut last_mem = self.effective_memory_bytes();
+        let mut stalls = 0u32;
+        crate::metrics::record_backpressure_engaged();
+        self.backpressure_engaged_total.fetch_add(1, Ordering::Relaxed);
+        warn!(
+            "Write backpressure engaged: used={}MB ≥ hard limit; flushing to Delta to free RAM (not rejecting)",
+            last_mem / (1024 * 1024)
+        );
+        loop {
+            // Relieve via completed buckets first (always race-free). Escalate
+            // to force-flushing the current open bucket only after consecutive
+            // stalls — i.e. when a single in-flight window is itself the
+            // pressure and completed-bucket flushes can't help.
+            self.relieve_memory_pressure(stalls >= 2).await;
+
+            match self.try_reserve_memory(batches).await {
+                Ok(sz) => return Ok(sz),
+                Err(e) => {
+                    let now_mem = self.effective_memory_bytes();
+                    // Count a stall when this round freed <1% of memory.
+                    if now_mem + now_mem / 100 >= last_mem {
+                        stalls += 1;
+                    } else {
+                        stalls = 0;
+                    }
+                    last_mem = now_mem;
+                    if std::time::Instant::now() >= deadline {
+                        crate::metrics::record_backpressure_rejected();
+                        error!(
+                            "Write backpressure exhausted after {:?}: used={}MB still over hard limit — Delta flush is not freeing memory; rejecting (data remains in WAL)",
+                            timeout,
+                            now_mem / (1024 * 1024)
+                        );
+                        return Err(e);
+                    }
+                    // Brief yield so the background flush task and other writers
+                    // can make progress between our synchronous drain attempts.
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+            }
+        }
+    }
+
+    /// Synchronously drain MemBuffer → Delta to relieve insert-path memory
+    /// pressure. Flushes completed buckets first (always safe); when
+    /// `force_current` is set also force-flushes the current open bucket(s) via
+    /// the atomic `take_bucket_for_flush` path.
+    async fn relieve_memory_pressure(&self, force_current: bool) {
+        if let Err(e) = self.flush_completed_buckets().await {
+            warn!("backpressure: flush_completed_buckets failed: {}", e);
+        }
+        // `force_flush_current_buckets` self-gates on the WAL-ordering invariant
+        // (see its body), so calling it whenever pressure persists is safe.
+        if force_current && self.is_memory_pressure() && let Err(e) = self.force_flush_current_buckets().await {
+            warn!("backpressure: force_flush_current_buckets failed: {}", e);
+        }
+    }
+
+    /// Force-flush the current (still-open) bucket(s) to Delta. Normal flushing
+    /// excludes the current bucket so a full window accumulates in RAM; under
+    /// sustained single-window pressure that window alone can exceed the budget,
+    /// so this is the escalation tier. `take_bucket_for_flush` removes a
+    /// bucket's rows atomically under the insert lock (no lost-write race) and
+    /// leaves the bucket in place for ongoing inserts. On commit failure the
+    /// rows are restored — durability never depended on this (WAL holds them).
+    async fn force_flush_current_buckets(&self) -> anyhow::Result<()> {
+        let _flush_guard = self.flush_lock.lock().await;
+        let current = MemBuffer::current_bucket_id();
+        // WAL-ordering safety: `advance_by_counts` consumes entries sequentially
+        // from the cursor, so advancing by the current bucket's count is correct
+        // ONLY when every older bucket on the shard has already been flushed +
+        // advanced. If a completed bucket remains (its flush failed), the cursor
+        // is still behind it and advancing now would consume the failed bucket's
+        // entries instead — losing them on a crash. Skip; the next round retries
+        // the completed flush first. (Holds the flush_lock so no concurrent
+        // completed-flush can drain them out from under this check.)
+        if self.mem_buffer.has_buckets_before(current) {
+            debug!("force-flush skipped: completed buckets still present — avoiding WAL over-advance");
+            return Ok(());
+        }
+        crate::metrics::record_backpressure_force_flush();
+        for (project_id, table_name, bucket_id) in self.mem_buffer.current_bucket_keys(current) {
+            let Some(bucket) = self.mem_buffer.take_bucket_for_flush(&project_id, &table_name, bucket_id) else {
+                continue;
+            };
+            match self.flush_bucket(&bucket).await {
+                Ok(()) => {
+                    if let Err(e) = self.wal.advance_by_counts(&bucket.project_id, &bucket.table_name, &bucket.wal_shard_counts) {
+                        warn!("force-flush: advance_by_counts failed (rows committed to Delta; WAL will re-replay, dedup protects): {}", e);
+                    } else {
+                        self.flush_completed_total.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                Err(e) => {
+                    self.flush_failed_total.fetch_add(1, Ordering::Relaxed);
+                    warn!("force-flush: Delta commit failed; restoring {} rows to MemBuffer: {}", bucket.row_count, e);
+                    self.mem_buffer.restore_taken_bucket(&bucket);
+                }
+            }
+        }
+        Ok(())
+    }
+
     #[instrument(skip(self, batches), fields(project_id, table_name, batch_count))]
     pub async fn insert(&self, project_id: &str, table_name: &str, batches: Vec<RecordBatch>) -> anyhow::Result<()> {
         // Memory pressure no longer triggers a synchronous flush_all_now in the
@@ -481,8 +611,10 @@ impl BufferedWriteLayer {
         // replay). MemBuffer's insert re-runs this as a cheap no-op.
         let batches: Vec<RecordBatch> = batches.into_iter().map(crate::mem_buffer::compact_batch).collect();
 
-        // Reserve memory atomically before writing - prevents race condition
-        let reserved_size = self.try_reserve_memory(&batches).await?;
+        // Reserve memory atomically before writing - prevents race condition.
+        // Applies backpressure (synchronous flush-to-Delta + retry) instead of
+        // rejecting when at the hard limit — see `reserve_with_backpressure`.
+        let reserved_size = self.reserve_with_backpressure(&batches).await?;
 
         // No per-topic mutex needed: WAL now shards each (project, table)
         // across N walrus collections via `WalManager::pick_shard`, so
@@ -672,6 +804,44 @@ impl BufferedWriteLayer {
                 error_count,
                 corruption_threshold
             );
+        }
+
+        // Boot guard: replay loads entries straight into MemBuffer, bypassing
+        // the insert-path reservation. A large replayed backlog can therefore
+        // start the process already over the memory budget, where every
+        // subsequent insert rejects (prod 2026-06-11: 15.8GB in an 8GB-limit
+        // buffer, wedged + restart-looping). Drain completed buckets to Delta
+        // now so we begin serving with headroom. Replayed buckets carry empty
+        // wal_shard_counts (replay didn't call record_wal_append) so the
+        // post-flush advance_by_counts is a safe no-op — entries were already
+        // consumed by the checkpoint=true pass above. Bounded + progress-gated
+        // so a missing/failing Delta callback can't spin forever.
+        if self.delta_write_callback.is_some() {
+            let max_bytes = self.max_memory_bytes();
+            let mut prev = usize::MAX;
+            for _ in 0..64 {
+                let used = self.effective_memory_bytes();
+                if used <= max_bytes {
+                    break;
+                }
+                info!(
+                    "Post-replay drain: {}MB > {}MB budget — flushing completed buckets to Delta before serving",
+                    used / (1024 * 1024),
+                    max_bytes / (1024 * 1024)
+                );
+                if let Err(e) = self.flush_completed_buckets().await {
+                    warn!("Post-replay drain flush failed: {}", e);
+                    break;
+                }
+                let now = self.effective_memory_bytes();
+                if now + now / 100 >= prev {
+                    // <1% progress: no completed buckets left to drain (or flush
+                    // is stuck). Remaining pressure, if any, is handled by
+                    // insert-path backpressure once we start serving.
+                    break;
+                }
+                prev = now;
+            }
         }
 
         let stats = RecoveryStats {
@@ -1251,6 +1421,7 @@ impl BufferedWriteLayer {
             oldest_bucket_age_secs,
             flush_completed_total: self.flush_completed_total.load(Ordering::Relaxed),
             flush_failed_total: self.flush_failed_total.load(Ordering::Relaxed),
+            backpressure_engaged_total: self.backpressure_engaged_total.load(Ordering::Relaxed),
         }
     }
 
@@ -1378,10 +1549,13 @@ mod tests {
         .unwrap()
     }
 
+    #[serial]
     #[tokio::test]
     async fn test_insert_and_query() {
         let dir = tempdir().unwrap();
         let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
 
         // Use unique but short project/table names (walrus has metadata size limit)
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];
@@ -1593,10 +1767,17 @@ mod tests {
         }
     }
 
+    // #[serial] + own WALRUS_DATA_DIR: this test writes WAL via `insert`, and
+    // walrus reads its data dir from the process-global WALRUS_DATA_DIR. Without
+    // pinning it, a concurrent #[serial] test's dropped tempdir leaves the global
+    // pointing at a deleted path → ENOENT on append (flaky in the full suite).
+    #[serial]
     #[tokio::test]
     async fn test_pressure_pct() {
         let dir = tempdir().unwrap();
         let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];
         let project = format!("p{}", test_id);
         let table = format!("t{}", test_id);
@@ -1615,10 +1796,13 @@ mod tests {
     /// counts whose total equals the number of WAL entries appended. Before
     /// this regression test the counts didn't exist and `wal.checkpoint`
     /// drained the whole column to its tail.
+    #[serial]
     #[tokio::test]
     async fn wal_shard_counts_recorded_on_insert() {
         let dir = tempdir().unwrap();
         let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];
         let project = format!("c{}", test_id);
         let table = format!("c{}", test_id);
@@ -1751,10 +1935,165 @@ mod tests {
         );
     }
 
+    /// Regression: prod 2026-06-11 wedged with MemBuffer at 15.8GB > 8GB hard
+    /// limit, every insert rejected with "Memory limit exceeded". The insert
+    /// path must apply *backpressure* — synchronously flush MemBuffer → Delta to
+    /// free RAM and retry — instead of dropping the write. Cap the budget at the
+    /// 64MB floor (hard limit ~76.8MB) and push ~96MB of flushable (old-bucket)
+    /// data through `insert()` with a working Delta callback. Pre-fix, the insert
+    /// crossing the limit returns Err; post-fix every insert succeeds because the
+    /// over-limit reservation drives a flush of the completed bucket first.
+    #[serial]
+    #[tokio::test]
+    async fn backpressure_flushes_instead_of_rejecting() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+
+        use arrow::{
+            array::{StringArray, TimestampMicrosecondArray},
+            datatypes::{DataType, Field, Schema, TimeUnit},
+        };
+
+        let dir = tempdir().unwrap();
+        let mut cfg = AppConfig::default();
+        cfg.core.timefusion_data_dir = dir.path().to_path_buf();
+        cfg.buffer.timefusion_buffer_max_memory_mb = 64; // floor → hard limit ~76.8MB
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
+        let cfg = Arc::new(cfg);
+
+        let test_id = &uuid::Uuid::new_v4().to_string()[..4];
+        let project = format!("bp{}", test_id);
+        let table = format!("bp{}", test_id);
+
+        let flush_calls = Arc::new(AtomicUsize::new(0));
+        let fc = flush_calls.clone();
+        let mut layer = crate::test_utils::test_helpers::test_layer(cfg).unwrap();
+        layer.delta_write_callback = Some(Arc::new(move |_p, _t, _b, _wm| {
+            let c = fc.clone();
+            Box::pin(async move {
+                c.fetch_add(1, O::SeqCst);
+                Ok(Vec::new())
+            })
+        }));
+        let layer = Arc::new(layer);
+
+        // Old timestamp → all rows land in a completed (flushable) bucket.
+        let old_ts = crate::clock::now_micros() - 2 * crate::mem_buffer::bucket_duration_micros();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+            Field::new("payload", DataType::Utf8, false),
+        ]));
+        let rows = 30_000usize;
+        let make_batch = || {
+            let ts = TimestampMicrosecondArray::from(vec![old_ts; rows]);
+            let payload = StringArray::from(vec!["x".repeat(400); rows]); // ~12MB
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(ts), Arc::new(payload)]).unwrap()
+        };
+
+        // ~96MB cumulative into a ~76.8MB buffer: at least one insert must cross
+        // the hard limit and rely on backpressure. All must succeed.
+        for i in 0..8 {
+            layer
+                .insert(&project, &table, vec![make_batch()])
+                .await
+                .unwrap_or_else(|e| panic!("insert {i} must succeed under backpressure, got: {e}"));
+        }
+
+        assert!(flush_calls.load(O::SeqCst) >= 1, "backpressure must have forced at least one Delta flush");
+        assert!(
+            layer.snapshot_stats().backpressure_engaged_total >= 1,
+            "backpressure_engaged_total must record the over-limit event"
+        );
+    }
+
+    /// The current (open) bucket is excluded from normal flushing, so a single
+    /// busy 10-min window accumulates in RAM with nothing able to drain it.
+    /// `force_flush_current_buckets` is the escalation tier that can. Prove the
+    /// open bucket survives a completed-bucket flush but is drained by the force
+    /// path.
+    #[serial]
+    #[tokio::test]
+    async fn force_flush_current_bucket_drains_open_window() {
+        let dir = tempdir().unwrap();
+        let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
+
+        let test_id = &uuid::Uuid::new_v4().to_string()[..4];
+        let project = format!("fc{}", test_id);
+        let table = format!("fc{}", test_id);
+
+        let mut layer = crate::test_utils::test_helpers::test_layer(Arc::clone(&cfg)).unwrap();
+        layer.delta_write_callback = Some(Arc::new(move |_p, _t, _b, _wm| Box::pin(async move { Ok(Vec::new()) })));
+        let layer = Arc::new(layer);
+
+        // create_test_batch uses now() timestamps → the current (open) bucket.
+        layer.insert(&project, &table, vec![create_test_batch(&project)]).await.unwrap();
+
+        // Normal completed-bucket flush must NOT touch the open bucket.
+        layer.flush_completed_buckets().await.unwrap();
+        assert!(!layer.is_empty(), "completed-bucket flush must leave the open bucket in MemBuffer");
+
+        // The force path reaches it.
+        layer.force_flush_current_buckets().await.unwrap();
+        assert!(layer.is_empty(), "force_flush_current_buckets must drain the open bucket");
+    }
+
+    /// Durability invariant: the current-bucket force-flush MUST be skipped while
+    /// any completed bucket remains in MemBuffer. `advance_by_counts` consumes WAL
+    /// entries sequentially from the cursor, so advancing by the current bucket's
+    /// count when an older (failed-flush) bucket is still un-advanced would consume
+    /// the older bucket's entries — silent data loss on crash. We seed both an old
+    /// (completed) and a current bucket, then assert force-flush is a no-op (Delta
+    /// callback never fires, nothing drained).
+    #[serial]
+    #[tokio::test]
+    async fn force_flush_skipped_while_completed_bucket_present() {
+        let dir = tempdir().unwrap();
+        let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
+
+        let test_id = &uuid::Uuid::new_v4().to_string()[..4];
+        let project = format!("g{}", test_id);
+        let table = format!("g{}", test_id);
+
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls_cb = calls.clone();
+        let mut layer = crate::test_utils::test_helpers::test_layer(Arc::clone(&cfg)).unwrap();
+        layer.delta_write_callback = Some(Arc::new(move |_p, _t, _b, _wm| {
+            let c = calls_cb.clone();
+            Box::pin(async move {
+                c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Vec::new())
+            })
+        }));
+        let layer = Arc::new(layer);
+
+        // Old (completed) bucket + current (open) bucket.
+        let old_ts = crate::clock::now_micros() - 2 * crate::mem_buffer::bucket_duration_micros();
+        let old_batch =
+            crate::test_utils::test_helpers::json_to_batch(vec![crate::test_utils::test_helpers::test_span_ts("old", "spanA", &project, old_ts)]).unwrap();
+        layer.insert(&project, &table, vec![old_batch]).await.unwrap();
+        layer.insert(&project, &table, vec![create_test_batch(&project)]).await.unwrap();
+
+        // Force-flush must short-circuit because the completed bucket is present.
+        layer.force_flush_current_buckets().await.unwrap();
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "force-flush must NOT touch Delta (or advance the WAL) while a completed bucket remains"
+        );
+        assert!(!layer.is_empty(), "both buckets must remain buffered after the skipped force-flush");
+    }
+
+    #[serial]
     #[tokio::test]
     async fn test_memory_reservation() {
         let dir = tempdir().unwrap();
         let cfg = create_test_config(dir.path().to_path_buf());
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
 
         // Use unique but short project/table names (walrus has metadata size limit)
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -110,32 +110,40 @@ fn quarantine_entry(quarantine_dir: &std::path::Path, entry: &WalEntry, kind: &s
 /// `snapshot_stats()` and rendered as rows by `timefusion.stats()`.
 #[derive(Debug, Clone)]
 pub struct StatsSnapshot {
-    pub mem_project_count:          usize,
-    pub mem_total_buckets:          usize,
-    pub mem_total_rows:             usize,
-    pub mem_total_batches:          usize,
-    pub mem_estimated_bytes:        usize,
-    pub reserved_bytes:             usize,
-    pub max_memory_bytes:           usize,
-    pub pressure_pct:               u32,
-    pub wal_files:                  usize,
-    pub wal_disk_bytes:             u64,
-    pub wal_shards_per_topic:       usize,
-    pub wal_known_topics:           usize,
-    pub bucket_duration_micros:     i64,
+    pub mem_project_count:              usize,
+    pub mem_total_buckets:              usize,
+    pub mem_total_rows:                 usize,
+    pub mem_total_batches:              usize,
+    pub mem_estimated_bytes:            usize,
+    pub reserved_bytes:                 usize,
+    pub max_memory_bytes:               usize,
+    pub pressure_pct:                   u32,
+    pub wal_files:                      usize,
+    pub wal_disk_bytes:                 u64,
+    pub wal_shards_per_topic:           usize,
+    pub wal_known_topics:               usize,
+    pub bucket_duration_micros:         i64,
     /// Age of the oldest bucket in MemBuffer (seconds, computed from
     /// `now - min(bucket.min_timestamp)`). None when MemBuffer is empty.
     /// Alerting target: alert at > 2× `flush_interval_secs`.
-    pub oldest_bucket_age_secs:     Option<u64>,
+    pub oldest_bucket_age_secs:         Option<u64>,
     /// Cumulative flush successes/failures since process start. Mirrors the
     /// OTel `timefusion.flush.completed`/`failed` counters so tests can
     /// assert without configuring OTel.
-    pub flush_completed_total:      u64,
-    pub flush_failed_total:         u64,
+    pub flush_completed_total:          u64,
+    pub flush_failed_total:             u64,
     /// Times an insert hit the memory hard limit and applied backpressure
     /// (synchronous flush-to-Delta) instead of rejecting. Sustained growth =
     /// ingest outpacing flush; the matching OTel counter is the alert target.
-    pub backpressure_engaged_total: u64,
+    pub backpressure_engaged_total:     u64,
+    /// Inserts rejected after the backpressure window expired without freeing
+    /// memory — Delta flush isn't keeping up. PAGE on any growth (data is still
+    /// in the WAL but ingest is now dropping). Mirrored from OTel so operators
+    /// can watch it via the stats table when telemetry isn't wired.
+    pub backpressure_rejected_total:    u64,
+    /// Open-bucket force-flush escalations (a single busy window was itself the
+    /// pressure). Sustained growth = windows too large for the budget.
+    pub backpressure_force_flush_total: u64,
 }
 
 #[derive(Debug, Default)]
@@ -193,6 +201,10 @@ struct CoalescedGroup {
     wal_positions:     Vec<Option<walrus_rust::WalPosition>>,
     /// Source bucket_ids; drained from MemBuffer after the combined commit succeeds.
     source_bucket_ids: Vec<i64>,
+    /// Min/max timestamp across absorbed buckets (Option so the derived Default's
+    /// 0 can't corrupt the min). Carried onto the combined FlushableBucket.
+    min_timestamp:     Option<i64>,
+    max_timestamp:     Option<i64>,
 }
 
 struct CombinedBucket {
@@ -225,6 +237,8 @@ impl CoalescedGroup {
         }
         // Merge per-shard positions (max).
         self.wal_positions = merge_wal_positions(std::mem::take(&mut self.wal_positions), b.wal_positions);
+        self.min_timestamp = Some(self.min_timestamp.map_or(b.min_timestamp, |m| m.min(b.min_timestamp)));
+        self.max_timestamp = Some(self.max_timestamp.map_or(b.max_timestamp, |m| m.max(b.max_timestamp)));
         self.source_bucket_ids.push(b.bucket_id);
     }
 
@@ -236,6 +250,8 @@ impl CoalescedGroup {
             wal_shard_counts,
             wal_positions,
             source_bucket_ids,
+            min_timestamp,
+            max_timestamp,
         } = self;
         // `absorb` is only called via `groups.entry(..).or_default().absorb(b)`
         // so `key` is always set by the time we collapse the group.
@@ -251,6 +267,8 @@ impl CoalescedGroup {
             row_count,
             wal_shard_counts,
             wal_positions,
+            min_timestamp: min_timestamp.unwrap_or(i64::MAX),
+            max_timestamp: max_timestamp.unwrap_or(i64::MIN),
         };
         CombinedBucket { combined, source_bucket_ids }
     }
@@ -267,38 +285,40 @@ pub type TantivyIndexCallback =
     Arc<dyn Fn(String, String, Vec<RecordBatch>, Vec<String>) -> futures::future::BoxFuture<'static, anyhow::Result<()>> + Send + Sync>;
 
 pub struct BufferedWriteLayer {
-    config:                     Arc<AppConfig>,
-    wal:                        Arc<WalManager>,
-    mem_buffer:                 Arc<MemBuffer>,
-    shutdown:                   CancellationToken,
-    delta_write_callback:       Option<DeltaWriteCallback>,
-    tantivy_index_callback:     Option<TantivyIndexCallback>,
-    background_tasks:           Mutex<Vec<JoinHandle<()>>>,
-    flush_lock:                 Mutex<()>,
-    reserved_bytes:             AtomicUsize, // Memory reserved for in-flight writes
-    pressure_notify:            Arc<Notify>, // Wakes flush task when pressure threshold crossed
+    config:                         Arc<AppConfig>,
+    wal:                            Arc<WalManager>,
+    mem_buffer:                     Arc<MemBuffer>,
+    shutdown:                       CancellationToken,
+    delta_write_callback:           Option<DeltaWriteCallback>,
+    tantivy_index_callback:         Option<TantivyIndexCallback>,
+    background_tasks:               Mutex<Vec<JoinHandle<()>>>,
+    flush_lock:                     Mutex<()>,
+    reserved_bytes:                 AtomicUsize, // Memory reserved for in-flight writes
+    pressure_notify:                Arc<Notify>, // Wakes flush task when pressure threshold crossed
     /// Notified at the end of every flush task iteration (success or failure).
     /// Test hook: lets E2E harnesses await actual completion of background work
     /// instead of racing wall-clock sleeps.
-    flush_tick_notify:          Arc<Notify>,
+    flush_tick_notify:              Arc<Notify>,
     /// Notified at the end of every eviction task iteration.
-    eviction_tick_notify:       Arc<Notify>,
+    eviction_tick_notify:           Arc<Notify>,
     /// Cumulative flush counters mirrored alongside OTel `record_flush`.
     /// OTel global metric state is opt-in (only initialized when telemetry is
     /// configured), so these atomics give the harness an in-process way to
     /// assert on what the global counters would be.
-    flush_completed_total:      AtomicU64,
-    flush_failed_total:         AtomicU64,
-    backpressure_engaged_total: AtomicU64,
+    flush_completed_total:          AtomicU64,
+    flush_failed_total:             AtomicU64,
+    backpressure_engaged_total:     AtomicU64,
+    backpressure_rejected_total:    AtomicU64,
+    backpressure_force_flush_total: AtomicU64,
     // Required for WAL replay of UPDATE/DELETE whose SQL references UDFs.
-    function_registry:          Arc<crate::functions::FnRegistry>,
+    function_registry:              Arc<crate::functions::FnRegistry>,
     /// Caps concurrent detached tantivy sidecar builds so a fast flush cycle
     /// (post-F4 — one build per (project, table) per cycle) can't fan out
     /// past S3 connection / memory limits when many tables flush together.
     /// FOLLOW-UP: handles aren't stored; graceful shutdown does not await
     /// in-flight tantivy uploads. Acceptable for now because the sidecar is
     /// best-effort and the index can be rebuilt from Delta on demand.
-    tantivy_spawn_sem:          Arc<tokio::sync::Semaphore>,
+    tantivy_spawn_sem:              Arc<tokio::sync::Semaphore>,
 }
 
 impl std::fmt::Debug for BufferedWriteLayer {
@@ -342,6 +362,8 @@ impl BufferedWriteLayer {
             flush_completed_total: AtomicU64::new(0),
             flush_failed_total: AtomicU64::new(0),
             backpressure_engaged_total: AtomicU64::new(0),
+            backpressure_rejected_total: AtomicU64::new(0),
+            backpressure_force_flush_total: AtomicU64::new(0),
             function_registry,
             // 16 is well above realistic per-cycle table fan-out for the
             // monoscope workload (~5 distinct table names) while still
@@ -507,6 +529,7 @@ impl BufferedWriteLayer {
                     last_mem = now_mem;
                     if std::time::Instant::now() >= deadline {
                         crate::metrics::record_backpressure_rejected();
+                        self.backpressure_rejected_total.fetch_add(1, Ordering::Relaxed);
                         error!(
                             "Write backpressure exhausted after {:?}: used={}MB still over hard limit — Delta flush is not freeing memory; rejecting (data remains in WAL)",
                             timeout,
@@ -563,6 +586,7 @@ impl BufferedWriteLayer {
             return Ok(());
         }
         crate::metrics::record_backpressure_force_flush();
+        self.backpressure_force_flush_total.fetch_add(1, Ordering::Relaxed);
         for (project_id, table_name, bucket_id) in self.mem_buffer.current_bucket_keys(current) {
             let Some(bucket) = self.mem_buffer.take_bucket_for_flush(&project_id, &table_name, bucket_id) else {
                 continue;
@@ -1428,6 +1452,8 @@ impl BufferedWriteLayer {
             flush_completed_total: self.flush_completed_total.load(Ordering::Relaxed),
             flush_failed_total: self.flush_failed_total.load(Ordering::Relaxed),
             backpressure_engaged_total: self.backpressure_engaged_total.load(Ordering::Relaxed),
+            backpressure_rejected_total: self.backpressure_rejected_total.load(Ordering::Relaxed),
+            backpressure_force_flush_total: self.backpressure_force_flush_total.load(Ordering::Relaxed),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,7 +112,7 @@ const_default!(d_grpc_port: u16 = 50051);
 const_default!(d_table_prefix: String = "timefusion");
 const_default!(d_batch_queue_capacity: usize = 100_000_000);
 const_default!(d_pgwire_user: String = "postgres");
-const_default!(d_flush_interval: u64 = 600);
+const_default!(d_flush_interval: u64 = 300);
 const_default!(d_retention_mins: u64 = 70);
 const_default!(d_eviction_interval: u64 = 60);
 const_default!(d_buffer_max_memory: usize = 4096);
@@ -136,14 +136,25 @@ const_default!(d_delta_scan_depth: usize = 8);
 const_default!(d_wal_fsync_ms: u64 = 200);
 // MemBuffer bucket window (seconds). Smaller windows free RAM sooner because
 // the previous bucket becomes flushable sooner; larger windows amortize into
-// fewer/larger Delta commits. Default 600s (10 min) matches the historical
-// hardcoded value; high-throughput tenants benefit from 60–120s.
-const_default!(d_bucket_duration_secs: u64 = 600);
+// fewer/larger Delta commits. Default 300s (5 min) — halved from the historical
+// 600s to cut peak MemBuffer footprint (the current bucket is excluded from
+// flushing, so this is the floor on how long a row accumulates in RAM). The
+// trade-off is ~2× Delta commits / small files; high-throughput tenants can go
+// lower still (60–120s), memory-relaxed deployments can raise it back.
+const_default!(d_bucket_duration_secs: u64 = 300);
 // Memory pressure threshold (0–100) at which the flush task is woken
 // independently of the periodic flush timer. Triggers an early
 // `flush_completed_buckets` so MemBuffer drains before reservation reaches
 // the hard limit. 0 disables pressure-triggered flushes.
 const_default!(d_pressure_flush_pct: u32 = 75);
+// Max seconds an insert applies backpressure (synchronously flushing
+// MemBuffer → Delta to free RAM) before failing, when the memory hard limit
+// is hit. The rows are already durable in the WAL, so this trades a slow
+// write for a rejected one — the right call for a TS DB whose producers DLQ
+// on rejection. 0 restores the old fail-fast behavior. 60s is long enough to
+// ride out a flush cycle / drain a replayed backlog, finite so a genuinely
+// down Delta can't pile blocked writers up without bound.
+const_default!(d_write_backpressure_secs: u64 = 60);
 // Durability mode for the WAL. One of:
 //   "ms"        — async fsync every `wal_fsync_ms` (default; ~200ms loss window)
 //   "sync_each" — fsync after every entry (zero data-loss window, ~1ms per write)
@@ -421,6 +432,8 @@ pub struct BufferConfig {
     pub timefusion_bucket_duration_secs:     u64,
     #[serde(default = "d_pressure_flush_pct")]
     pub timefusion_pressure_flush_pct:       u32,
+    #[serde(default = "d_write_backpressure_secs")]
+    pub timefusion_write_backpressure_secs:  u64,
     /// WAL shards per (project, table) topic. Higher = more append parallelism
     /// at the cost of O(shards) recovery memory and more file handles.
     #[serde(default = "d_wal_shards_per_topic")]
@@ -500,6 +513,9 @@ impl BufferConfig {
     }
     pub fn pressure_flush_pct(&self) -> u32 {
         self.timefusion_pressure_flush_pct.min(100)
+    }
+    pub fn write_backpressure_timeout(&self) -> Duration {
+        Duration::from_secs(self.timefusion_write_backpressure_secs)
     }
 
     /// Per-phase shutdown ceiling, in seconds.
@@ -771,7 +787,8 @@ mod tests {
     fn test_default_config() {
         let config = AppConfig::default();
         assert_eq!(config.core.pgwire_port, 5432);
-        assert_eq!(config.buffer.timefusion_flush_interval_secs, 600);
+        assert_eq!(config.buffer.timefusion_flush_interval_secs, 300);
+        assert_eq!(config.buffer.timefusion_bucket_duration_secs, 300);
         assert_eq!(config.cache.timefusion_foyer_memory_mb, 1024);
         assert_eq!(config.cache.timefusion_foyer_disk_gb, 500);
         assert_eq!(config.cache.disk_size_bytes(), 500 * 1024 * 1024 * 1024);

--- a/src/database.rs
+++ b/src/database.rs
@@ -2715,8 +2715,11 @@ impl Database {
                         last_error = Some(e);
                         debug!("Delta write conflict detected, retrying... (attempt {}/{})", retry_count, max_retries);
 
-                        // Release the commit lock before backing off — peers
-                        // shouldn't queue behind this writer's sleep.
+                        // Intentionally release the commit lock BEFORE the
+                        // backoff sleep — do not remove. Holding it across the
+                        // sleep would serialize every other writer behind this
+                        // writer's backoff, converting commit contention into a
+                        // throughput collapse.
                         drop(commit_guard);
                         // Exponential backoff for better handling of concurrent writes
                         let backoff_ms = 100 * (2_u64.pow(retry_count.min(5)));
@@ -3328,6 +3331,9 @@ impl Database {
                         break;
                     }
                     Err(e) => {
+                        // Drop BEFORE the backoff sleep below — do not remove.
+                        // Holding the commit lock across the sleep would block
+                        // every concurrent append behind this dedup retry.
                         drop(commit_guard);
                         let msg = e.to_string();
                         // "Transaction failed" covers the conflict checker erroring

--- a/src/database.rs
+++ b/src/database.rs
@@ -774,6 +774,14 @@ pub struct Database {
     /// the sweep when the version hasn't moved (no commits → no new dupes).
     /// Same unbounded-growth caveat as `last_written_versions`.
     last_dedup_versions:             Arc<RwLock<HashMap<String, u64>>>,
+    /// Serializes in-process Delta commits (flush appends vs dedup
+    /// replace_where). delta-kernel's OCC checker cannot evaluate the
+    /// bare-string timestamp predicate replace_where commits carry (errors
+    /// "arrow_cast should have been simplified"), so a dedup commit racing
+    /// any concurrent append aborts — every attempt, forever, on a busy
+    /// table. With commits serialized the rebase sees no newer versions and
+    /// skips the checker entirely.
+    delta_commit_lock:               Arc<tokio::sync::Mutex<()>>,
     buffered_layer:                  Option<Arc<crate::buffered_write_layer::BufferedWriteLayer>>,
     tantivy_search:                  Option<Arc<crate::tantivy_index::search::TantivySearchService>>,
     tantivy_indexer:                 Option<Arc<crate::tantivy_index::service::TantivyIndexService>>,
@@ -1075,6 +1083,7 @@ impl Database {
             statistics_extractor,
             last_written_versions: Arc::new(RwLock::new(HashMap::new())),
             last_dedup_versions: Arc::new(RwLock::new(HashMap::new())),
+            delta_commit_lock: Arc::new(tokio::sync::Mutex::new(())),
             buffered_layer: None,
             tantivy_search: None,
             tantivy_indexer: None,
@@ -2608,6 +2617,11 @@ impl Database {
             // every other commit path — the write lock is NOT held across the
             // write anymore (it serialized all query planning behind each
             // project's parquet upload during flush passes; 50-110s prod stalls).
+            // Hold the in-process commit lock from snapshot to swap so this
+            // append can never land mid-flight of a dedup replace_where (see
+            // `delta_commit_lock`). Appends-vs-appends pay a short queue wait;
+            // commits are sub-second next to the 10-min flush cadence.
+            let commit_guard = self.delta_commit_lock.lock().await;
             let (table, pre_uris) = {
                 let guard = table_ref.read().await;
                 let pre: std::collections::HashSet<String> = guard.get_file_uris().map(|it| it.collect()).unwrap_or_default();
@@ -2701,6 +2715,9 @@ impl Database {
                         last_error = Some(e);
                         debug!("Delta write conflict detected, retrying... (attempt {}/{})", retry_count, max_retries);
 
+                        // Release the commit lock before backing off — peers
+                        // shouldn't queue behind this writer's sleep.
+                        drop(commit_guard);
                         // Exponential backoff for better handling of concurrent writes
                         let backoff_ms = 100 * (2_u64.pow(retry_count.min(5)));
                         tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
@@ -3277,6 +3294,11 @@ impl Database {
             let mut last_err: Option<deltalake::DeltaTableError> = None;
             let mut committed = false;
             for attempt in 0..MAX_RETRIES {
+                // Clone under the commit lock and hold it through the commit:
+                // with no append able to land in between, the rebase sees no
+                // newer commits and the OCC checker (which errors on our
+                // bare-string timestamp predicate) never runs.
+                let commit_guard = self.delta_commit_lock.lock().await;
                 let table_clone = {
                     let table = table_ref.read().await;
                     table.clone()
@@ -3306,6 +3328,7 @@ impl Database {
                         break;
                     }
                     Err(e) => {
+                        drop(commit_guard);
                         let msg = e.to_string();
                         // "Transaction failed" covers the conflict checker erroring
                         // while evaluating our predicate against a concurrent commit

--- a/src/database.rs
+++ b/src/database.rs
@@ -4521,11 +4521,27 @@ impl TableProvider for ProjectRoutingTable {
         // backwards and wrongly hid all the Delta rows *above* it. Fixed
         // by listing the actual ranges MemBuffer currently holds and
         // excluding only those.
+        //
+        // Exception: the current (open) bucket's range is NOT excluded. Under
+        // memory pressure `force_flush_current_buckets` commits the open
+        // bucket's rows to Delta while inserts keep repopulating the same
+        // bucket_id in MemBuffer — so Delta legitimately holds rows inside the
+        // current range. Excluding it would hide those force-flushed rows
+        // (observed as an 8-of-150 undercount in the pressure_flush e2e test).
+        // It's safe to scan both: force-flush removes rows from MemBuffer
+        // *before* committing, so the current bucket's MemBuffer rows and its
+        // Delta rows are disjoint — the union can't double-count them. (Sealed
+        // buckets keep the exclusion: their normal commit-then-drain flush can
+        // briefly hold the same row in both stores.)
         let mem_ranges = layer.get_bucket_ranges(&project_id, &self.table_name);
+        let current_bucket_start = crate::mem_buffer::MemBuffer::current_bucket_id() * crate::mem_buffer::bucket_duration_micros();
         let mut delta_filters = optimized_filters.clone();
         let ts_col = || Box::new(col("timestamp"));
         let ts_lit = |t: i64| Box::new(lit(ScalarValue::TimestampMicrosecond(Some(t), Some("UTC".into()))));
         for (start, end) in &mem_ranges {
+            if *start == current_bucket_start {
+                continue;
+            }
             // NOT (ts >= start AND ts < end)  ≡  (ts < start) OR (ts >= end)
             let below = Expr::BinaryExpr(BinaryExpr {
                 left:  ts_col(),
@@ -5272,6 +5288,57 @@ mod tests {
         })
         .await
         .map_err(|_| anyhow::anyhow!("Test timed out after 30 seconds"))?
+    }
+
+    /// Regression for the pressure_flush e2e undercount (8-of-150): when
+    /// `force_flush_current_buckets` commits the open bucket's rows to Delta and
+    /// inserts then repopulate the same bucket_id, the query path must still
+    /// return the force-flushed rows. The old per-bucket exclusion masked the
+    /// current bucket's whole range from the Delta scan, hiding everything that
+    /// had been force-flushed. Drives the force-flush directly so it's
+    /// deterministic (no need to actually exhaust the memory budget).
+    #[serial]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn force_flushed_current_bucket_rows_stay_queryable() -> Result<()> {
+        // SAFETY: walrus reads WALRUS_DATA_DIR from process env; #[serial] protects it.
+        let prefix = uuid::Uuid::new_v4().to_string()[..8].to_string();
+        let cfg = create_test_config(&prefix);
+        unsafe { std::env::set_var("WALRUS_DATA_DIR", cfg.core.wal_dir()) };
+        tokio::time::timeout(std::time::Duration::from_secs(50), async {
+            // Need the real buffered layer (force_flush path), so bootstrap the
+            // full stack rather than the layer-less setup_test_database().
+            let b = crate::bootstrap::bootstrap(Arc::clone(&cfg)).await?;
+            let project_id = format!("ffq_{}", prefix);
+
+            // 3 rows into the current (open) bucket, then force-flush them to
+            // Delta — leaving the bucket drained but its range still "current".
+            // skip_queue=false so the write flows through the buffered layer
+            // (WAL → MemBuffer), not straight to Delta.
+            for i in 0..3 {
+                let batch = json_to_batch(vec![test_span(&format!("flushed_{i}"), "span", &project_id)])?;
+                b.db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], false, None).await?;
+            }
+            b.buffered_layer.force_flush_current_buckets().await?;
+
+            // 2 more rows repopulate the same current bucket_id in MemBuffer.
+            for i in 0..2 {
+                let batch = json_to_batch(vec![test_span(&format!("buffered_{i}"), "span", &project_id)])?;
+                b.db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], false, None).await?;
+            }
+
+            // All 5 must be visible: 3 from Delta (force-flushed), 2 from MemBuffer.
+            // Pre-fix this returned 2 (the current range was excluded from Delta).
+            use datafusion::arrow::array::AsArray;
+            let sql = format!("SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id = '{}'", project_id);
+            let r = b.session_ctx.sql(&sql).await?.collect().await?;
+            let n = r[0].column(0).as_primitive::<arrow::datatypes::Int64Type>().value(0);
+            assert_eq!(n, 5, "force-flushed rows must remain queryable alongside repopulated MemBuffer rows");
+
+            b.shutdown.cancel();
+            Ok(())
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("Test timed out after 50 seconds"))?
     }
 
     #[serial]

--- a/src/mem_buffer.rs
+++ b/src/mem_buffer.rs
@@ -1167,6 +1167,128 @@ impl MemBuffer {
         result
     }
 
+    /// (project_id, table_name, bucket_id) for every bucket at or after
+    /// `min_bucket_id` — i.e. the still-open current bucket(s). Used by the
+    /// insert-path backpressure escalation to force-flush the open window when
+    /// flushing completed buckets alone can't relieve memory pressure.
+    pub fn current_bucket_keys(&self, min_bucket_id: i64) -> Vec<(String, String, i64)> {
+        let mut out = Vec::new();
+        for t in self.tables.iter() {
+            let (project_id, table_name) = t.key();
+            for b in t.value().buckets.iter() {
+                if *b.key() >= min_bucket_id {
+                    out.push((project_id.to_string(), table_name.to_string(), *b.key()));
+                }
+            }
+        }
+        out
+    }
+
+    /// Cheap existence check (no batch cloning) for any bucket strictly older
+    /// than `cutoff_bucket_id`. Gates current-bucket force-flush: advancing the
+    /// WAL cursor past the open bucket is only correct once every older bucket
+    /// on the shard has been flushed + advanced (the cursor consumes entries
+    /// sequentially, not by logical bucket). A leftover completed bucket means a
+    /// failed flush left the cursor behind it.
+    pub fn has_buckets_before(&self, cutoff_bucket_id: i64) -> bool {
+        self.tables.iter().any(|t| t.value().buckets.iter().any(|b| *b.key() < cutoff_bucket_id))
+    }
+
+    /// Atomically take a bucket's rows + WAL counts for an out-of-band flush.
+    /// Unlike `collect_buckets` + `drain_bucket` (safe only on sealed buckets),
+    /// this is safe on the *current* still-written bucket: the take happens
+    /// under the same `batches` lock inserts use, so no row can be lost between
+    /// snapshot and removal. The now-empty bucket stays in the map so
+    /// concurrent/subsequent inserts keep writing into it. Returns None when
+    /// the bucket is absent or already empty.
+    pub fn take_bucket_for_flush(&self, project_id: &str, table_name: &str, bucket_id: i64) -> Option<FlushableBucket> {
+        let table = self.get_table(project_id, table_name)?;
+        let bucket_ref = table.buckets.get(&bucket_id)?;
+        let bucket = bucket_ref.value();
+        let mut batches_g = bucket.batches.lock();
+        if batches_g.is_empty() {
+            return None;
+        }
+        // Lock wal_shard_state too so the taken counts match the taken rows
+        // exactly — advance_by_counts must not over- or under-advance.
+        let mut wal_g = bucket.wal_shard_state.lock();
+        let batches: Vec<RecordBatch> = std::mem::take(&mut *batches_g);
+        let wal_state = std::mem::take(&mut *wal_g);
+        let freed = bucket.memory_bytes.swap(0, Ordering::Relaxed);
+        let row_count = bucket.row_count.swap(0, Ordering::Relaxed);
+        bucket.min_timestamp.store(i64::MAX, Ordering::Relaxed);
+        bucket.max_timestamp.store(i64::MIN, Ordering::Relaxed);
+        drop(wal_g);
+        drop(batches_g);
+        drop(bucket_ref);
+        self.estimated_bytes.fetch_sub(freed, Ordering::Relaxed);
+        self.cache_invalidate(&Self::cache_key(project_id, table_name, bucket_id));
+
+        // Drop the now-empty bucket so a stale empty shell can't — once time rolls
+        // past its window (id < current) — make `has_buckets_before` permanently
+        // gate off future current-bucket force-flushes. `remove_if` re-checks
+        // emptiness under the shard write lock, so a concurrent insert that
+        // repopulated the bucket between the take and here is preserved.
+        table.buckets.remove_if(&bucket_id, |_, b| b.batches.lock().is_empty());
+
+        // Pad to shards_per_topic so advance_by_counts indices line up.
+        let shards = self.shards_per_topic;
+        let mut counts = vec![0u64; shards];
+        let mut positions = vec![None; shards];
+        for (i, &c) in wal_state.counts.iter().take(shards).enumerate() {
+            counts[i] = c;
+        }
+        for (i, p) in wal_state.positions.iter().take(shards).enumerate() {
+            positions[i] = *p;
+        }
+        Some(FlushableBucket {
+            project_id: project_id.to_string(),
+            table_name: table_name.to_string(),
+            bucket_id,
+            batches,
+            row_count,
+            wal_shard_counts: counts,
+            wal_positions: positions,
+        })
+    }
+
+    /// Re-insert a bucket previously removed by `take_bucket_for_flush` whose
+    /// Delta commit then failed. Restores rows (query visibility) and merges
+    /// the WAL counts back so the next flush advances the cursor correctly.
+    /// Durability never depended on this — the rows are still in the WAL — but
+    /// it avoids a query-visibility gap until the next restart/replay.
+    pub fn restore_taken_bucket(&self, b: &FlushableBucket) {
+        let Some(table) = self.get_table(&b.project_id, &b.table_name) else { return };
+        let bucket = table.buckets.entry(b.bucket_id).or_insert_with(TimeBucket::new);
+        let mut batches_g = bucket.batches.lock();
+        let mut wal_g = bucket.wal_shard_state.lock();
+        let added: usize = b.batches.iter().map(estimate_batch_size).sum();
+        for batch in &b.batches {
+            batches_g.push(batch.clone());
+        }
+        if wal_g.counts.len() < b.wal_shard_counts.len() {
+            wal_g.counts.resize(b.wal_shard_counts.len(), 0);
+        }
+        for (i, &c) in b.wal_shard_counts.iter().enumerate() {
+            wal_g.counts[i] += c;
+        }
+        if wal_g.positions.len() < b.wal_positions.len() {
+            wal_g.positions.resize(b.wal_positions.len(), None);
+        }
+        for (i, p) in b.wal_positions.iter().enumerate() {
+            if let Some(pos) = p {
+                wal_g.positions[i] = Some(wal_g.positions[i].map_or(*pos, |prev| prev.max(*pos)));
+            }
+        }
+        bucket.memory_bytes.fetch_add(added, Ordering::Relaxed);
+        bucket.row_count.fetch_add(b.row_count, Ordering::Relaxed);
+        bucket.update_timestamps(b.bucket_id * bucket_duration_micros());
+        drop(wal_g);
+        drop(batches_g);
+        self.estimated_bytes.fetch_add(added, Ordering::Relaxed);
+        self.cache_invalidate(&Self::cache_key(&b.project_id, &b.table_name, b.bucket_id));
+    }
+
     /// Count buckets whose `max_timestamp` is older than `cutoff_micros`.
     /// Used by the eviction task to surface buckets that have aged past
     /// retention without being flushed (which means flushes are stuck).

--- a/src/mem_buffer.rs
+++ b/src/mem_buffer.rs
@@ -29,7 +29,12 @@ use crate::functions::FnRegistry;
 // longer = larger Delta files. Matches default flush interval for aligned boundaries.
 // Note: Timestamps before 1970 (negative microseconds) produce negative bucket IDs,
 // which is supported but may result in unexpected ordering if mixed with post-1970 data.
-const DEFAULT_BUCKET_DURATION_MICROS: i64 = 10 * 60 * 1_000_000;
+// Fallback when `set_bucket_duration_micros` is never called (i.e. unit tests
+// that build a MemBuffer directly). MUST track `d_bucket_duration_secs` in
+// config.rs — prod always overrides via bootstrap, but keeping the two in sync
+// avoids the test-only `BUCKET_DURATION_MICROS` const diverging from the
+// process-global runtime value once any test pins the OnceLock.
+const DEFAULT_BUCKET_DURATION_MICROS: i64 = 5 * 60 * 1_000_000;
 #[cfg(test)]
 const BUCKET_DURATION_MICROS: i64 = DEFAULT_BUCKET_DURATION_MICROS;
 
@@ -55,7 +60,7 @@ const MAX_BATCH_COUNT_PER_BUCKET: usize = 8;
 const MAX_BATCH_BYTES_FOR_COALESCE: usize = 4 * 1024 * 1024;
 
 /// Configured bucket window in microseconds. Set once at startup via
-/// `set_bucket_duration_micros`; defaults to 10 minutes when unset. Smaller
+/// `set_bucket_duration_micros`; defaults to 5 minutes when unset. Smaller
 /// windows free MemBuffer memory sooner (because the previous bucket becomes
 /// flushable sooner) at the cost of more, smaller Delta commits.
 pub fn bucket_duration_micros() -> i64 {
@@ -253,6 +258,12 @@ pub struct FlushableBucket {
     /// Written into Delta commit metadata so a crash between Delta commit
     /// and `advance_by_counts` can recover the cursor from Delta on restart.
     pub wal_positions:    Vec<Option<walrus_rust::WalPosition>>,
+    /// Actual min/max timestamp of the taken rows, captured before the source
+    /// bucket's atomics were reset. `restore_taken_bucket` replays these so a
+    /// restored bucket keeps its true time range (and stays visible to
+    /// time-range pruning) rather than collapsing to the bucket's start.
+    pub min_timestamp:    i64,
+    pub max_timestamp:    i64,
 }
 
 #[derive(Debug, Default)]
@@ -1161,6 +1172,8 @@ impl MemBuffer {
                     wal_positions,
                     row_count: bucket.row_count.load(Ordering::Relaxed),
                     wal_shard_counts,
+                    min_timestamp: bucket.min_timestamp.load(Ordering::Relaxed),
+                    max_timestamp: bucket.max_timestamp.load(Ordering::Relaxed),
                 });
             }
         }
@@ -1216,8 +1229,10 @@ impl MemBuffer {
         let wal_state = std::mem::take(&mut *wal_g);
         let freed = bucket.memory_bytes.swap(0, Ordering::Relaxed);
         let row_count = bucket.row_count.swap(0, Ordering::Relaxed);
-        bucket.min_timestamp.store(i64::MAX, Ordering::Relaxed);
-        bucket.max_timestamp.store(i64::MIN, Ordering::Relaxed);
+        // Capture the real range as we reset the sentinels so a restore (on
+        // Delta commit failure) can replay it instead of guessing bucket-start.
+        let min_timestamp = bucket.min_timestamp.swap(i64::MAX, Ordering::Relaxed);
+        let max_timestamp = bucket.max_timestamp.swap(i64::MIN, Ordering::Relaxed);
         drop(wal_g);
         drop(batches_g);
         drop(bucket_ref);
@@ -1249,6 +1264,8 @@ impl MemBuffer {
             row_count,
             wal_shard_counts: counts,
             wal_positions: positions,
+            min_timestamp,
+            max_timestamp,
         })
     }
 
@@ -1282,7 +1299,11 @@ impl MemBuffer {
         }
         bucket.memory_bytes.fetch_add(added, Ordering::Relaxed);
         bucket.row_count.fetch_add(b.row_count, Ordering::Relaxed);
-        bucket.update_timestamps(b.bucket_id * bucket_duration_micros());
+        // Replay the true range (monotonic widen) so restored rows stay visible
+        // to time-range pruning; concurrent inserts into the same open bucket
+        // are preserved since fetch_min/max only widens.
+        bucket.update_timestamps(b.min_timestamp);
+        bucket.update_timestamps(b.max_timestamp);
         drop(wal_g);
         drop(batches_g);
         self.estimated_bytes.fetch_add(added, Ordering::Relaxed);
@@ -2397,6 +2418,28 @@ mod tests {
         let parts = buffer.query_partitioned_with_text_match("p1", "otel_logs_and_spans", &[], &[]).unwrap();
         let total: usize = parts.iter().flatten().map(|b| b.num_rows()).sum();
         assert_eq!(total, 2, "no text_match preds → all rows returned");
+    }
+
+    /// Regression: `restore_taken_bucket` (the Delta-commit-failure path of the
+    /// open-bucket force-flush) used to reset the bucket's min/max to the bucket
+    /// *start* (`bucket_id * duration`), hiding restored rows from time-range
+    /// pruning until the next insert. It must replay the rows' real range.
+    #[test]
+    fn restore_taken_bucket_preserves_timestamp_range() {
+        use crate::test_utils::test_helpers::{json_to_batch, test_span};
+        let buffer = MemBuffer::new();
+        let dur = bucket_duration_micros();
+        let ts = 7 * dur + 12_345; // mid-bucket — distinct from the bucket-start sentinel
+        let bucket_id = MemBuffer::compute_bucket_id(ts);
+        buffer.insert("p1", "otel_logs_and_spans", json_to_batch(vec![test_span("a", "svc", "p1")]).unwrap(), ts).unwrap();
+
+        let taken = buffer.take_bucket_for_flush("p1", "otel_logs_and_spans", bucket_id).expect("bucket taken");
+        assert_eq!((taken.min_timestamp, taken.max_timestamp), (ts, ts), "take must capture the real row range");
+
+        buffer.restore_taken_bucket(&taken); // simulate Delta commit failure
+        let again = buffer.take_bucket_for_flush("p1", "otel_logs_and_spans", bucket_id).expect("restored bucket present");
+        assert_eq!((again.min_timestamp, again.max_timestamp), (ts, ts), "restore must preserve the true range");
+        assert_ne!(again.min_timestamp, bucket_id * dur, "must not collapse to bucket start");
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -75,6 +75,9 @@ counter_registry! {
     optimize_partitions_rewritten => "timefusion.optimize.partitions_rewritten": "Date partitions rewritten by full (z-order) optimize",
     optimize_partitions_skipped   => "timefusion.optimize.partitions_skipped": "Date partitions skipped by full optimize because their file set was unchanged since the last run (cache churn avoided)",
     compaction_dedup_dropped_rows => "timefusion.compaction.dedup_dropped_rows": "Rows collapsed by Delta-vs-Delta dedup compaction (cross-flush duplicates)",
+    backpressure_engaged       => "timefusion.ingest.backpressure_engaged": "Inserts that hit the memory hard limit and triggered synchronous flush-to-Delta instead of rejecting (alert if sustained > 0)",
+    backpressure_rejected      => "timefusion.ingest.backpressure_rejected": "Inserts rejected after the backpressure window expired without freeing memory — means Delta flush is not keeping up (page: data still in WAL but ingest is dropping)",
+    backpressure_force_flush   => "timefusion.ingest.backpressure_force_flush": "Current open-bucket force-flushes triggered by sustained backpressure (escalation tier)",
 }
 
 pub fn registry() -> Option<&'static MetricsRegistry> {
@@ -272,6 +275,9 @@ simple_recorders! {
     record_tantivy_prefilter_skipped => tantivy_prefilter_skipped,
     record_tantivy_prefilter_error => tantivy_prefilter_errors,
     record_tantivy_build_failure => tantivy_build_failures,
+    record_backpressure_engaged => backpressure_engaged,
+    record_backpressure_rejected => backpressure_rejected,
+    record_backpressure_force_flush => backpressure_force_flush,
 }
 
 pub fn record_dedup_dropped(rows: u64) {

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -111,6 +111,16 @@ impl StatsTableProvider {
             ));
             rows.push(("buffered_layer", "pressure_pct".into(), s.pressure_pct.to_string()));
             rows.push(("buffered_layer", "backpressure_engaged_total".into(), s.backpressure_engaged_total.to_string()));
+            rows.push((
+                "buffered_layer",
+                "backpressure_rejected_total".into(),
+                s.backpressure_rejected_total.to_string(),
+            ));
+            rows.push((
+                "buffered_layer",
+                "backpressure_force_flush_total".into(),
+                s.backpressure_force_flush_total.to_string(),
+            ));
             rows.push(("wal", "files".into(), s.wal_files.to_string()));
             rows.push(("wal", "disk_bytes".into(), s.wal_disk_bytes.to_string()));
             rows.push(("wal", "disk_mb".into(), format!("{:.1}", s.wal_disk_bytes as f64 / (1024.0 * 1024.0))));

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -110,6 +110,7 @@ impl StatsTableProvider {
                 format!("{:.1}", s.max_memory_bytes as f64 / (1024.0 * 1024.0)),
             ));
             rows.push(("buffered_layer", "pressure_pct".into(), s.pressure_pct.to_string()));
+            rows.push(("buffered_layer", "backpressure_engaged_total".into(), s.backpressure_engaged_total.to_string()));
             rows.push(("wal", "files".into(), s.wal_files.to_string()));
             rows.push(("wal", "disk_bytes".into(), s.wal_disk_bytes.to_string()));
             rows.push(("wal", "disk_mb".into(), format!("{:.1}", s.wal_disk_bytes as f64 / (1024.0 * 1024.0))));

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -69,6 +69,60 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
     Ok(())
 }
 
+/// Regression for the 2026-06-11 prod OOM/restart loop: dedup's replace_where
+/// commit carries a bare-string timestamp predicate that delta-kernel's OCC
+/// checker cannot evaluate ("arrow_cast should have been simplified"), so any
+/// append landing between dedup's snapshot and commit aborted the sweep —
+/// every attempt, every 5 minutes, materializing and abandoning chunk writes
+/// (observed climbing to the 70GB memcg ceiling). The in-process
+/// `delta_commit_lock` serializes commits so the rebase sees no newer
+/// versions and the checker never runs: dedup must succeed under append fire.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
+    let cfg = TestConfigBuilder::new("dedup_occ_race").with_buffer_mode(BufferMode::Enabled).build();
+    let _env = walrus_env_guard(&cfg.core.timefusion_data_dir);
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    // Duplicate pair in a sealed (3h-old) bin — the chunk dedup will rewrite.
+    let ts = (chrono::Utc::now() - chrono::Duration::hours(3)).timestamp_micros();
+    for name in ["first", "second"] {
+        let batch = json_to_batch(vec![test_span_ts("dup_id", name, &project_id, ts)])?;
+        db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], true, None).await?;
+    }
+
+    // Append fire: fresh-timestamp rows (same partition date space, distinct
+    // ids) committing continuously while dedup rewrites the sealed chunk.
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let appender = {
+        let (db, project_id, stop) = (Arc::clone(&db), project_id.clone(), Arc::clone(&stop));
+        tokio::spawn(async move {
+            let mut i = 0u64;
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                let now = chrono::Utc::now().timestamp_micros();
+                let batch = json_to_batch(vec![test_span_ts(&format!("live_{i}"), "live", &project_id, now)]).unwrap();
+                db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], true, None).await.unwrap();
+                i += 1;
+            }
+            i
+        })
+    };
+
+    let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
+    let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
+    let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let appended = appender.await?;
+    assert!(appended > 0, "appender must have raced at least one commit");
+    assert_eq!(dropped, 1, "dedup must collapse the duplicate despite concurrent appends");
+
+    let count_sql = format!("SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id);
+    let post = db.query_delta_only(&count_sql).await?;
+    assert_eq!(post[0].column(0).as_primitive::<Int64Type>().value(0), 1);
+    Ok(())
+}
+
 /// Regression: light OPTIMIZE (bin-pack compact) must preserve ALL partition
 /// values on rewritten files. The kernel narrows `partitionValues_parsed` to
 /// the predicate-referenced subset (data skipping), and optimize used that

--- a/tests/e2e/pressure_flush.rs
+++ b/tests/e2e/pressure_flush.rs
@@ -40,3 +40,56 @@ async fn many_inserts_under_tight_budget_do_not_deadlock() -> anyhow::Result<()>
 
     Ok(())
 }
+
+/// Backpressure-not-rejection through the full prod path. Unlike the liveness
+/// test above (whose ~25MB never crosses the limit), this pushes ~150MB into a
+/// single open bucket — well past the ~76.8MB hard limit on a 64MB budget — so
+/// the open bucket itself is the pressure and only the force-flush escalation
+/// can drain it. With the flush-to-make-room fix every insert must still
+/// succeed (no "Memory limit exceeded"), backpressure must register, and all
+/// rows must be durable + queryable (some in Delta via force-flush, the rest in
+/// MemBuffer). Pre-fix this returned a Postgres error once the buffer crossed
+/// the limit (prod 2026-06-11: 15.8GB > 8GB, every insert rejected).
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread")]
+async fn inserts_over_hard_limit_apply_backpressure_not_rejection() -> anyhow::Result<()> {
+    let env = E2eEnv::builder().with_max_memory_mb(64).start().await?;
+    let client = env.pg_client().await?;
+
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(FROZEN_START_MICROS).unwrap();
+    let sql = format!(
+        "INSERT INTO otel_logs_and_spans (project_id, date, timestamp, id, name, status_code, status_message, level, hashes, summary) \
+         VALUES ($1, '{}', '{}', $2, 'span', 'OK', $3, 'INFO', ARRAY[]::text[], $4)",
+        dt.date_naive(),
+        dt.format("%Y-%m-%d %H:%M:%S%.f"),
+    );
+
+    // ~1MB/row × 150 = ~150MB into one (current) bucket — only the current-bucket
+    // force-flush escalation can relieve this.
+    let big_msg = "x".repeat(64 * 1024);
+    let big_summary: Vec<String> = (0..16).map(|_| big_msg.clone()).collect();
+
+    let run = async {
+        for i in 0..150 {
+            client
+                .execute(&sql, &[&"e2e_bp", &format!("p-{i}"), &big_msg, &big_summary])
+                .await
+                .map_err(|e| anyhow::anyhow!("insert {i} rejected instead of applying backpressure: {e}"))?;
+        }
+        anyhow::Result::<()>::Ok(())
+    };
+    tokio::time::timeout(Duration::from_secs(90), run)
+        .await
+        .map_err(|_| anyhow::anyhow!("inserts under backpressure deadlocked"))??;
+
+    assert!(
+        env.snapshot_stats().backpressure_engaged_total >= 1,
+        "backpressure must engage when the open bucket exceeds the hard limit"
+    );
+
+    let rows = client.query("SELECT count(*) FROM otel_logs_and_spans WHERE project_id = $1", &[&"e2e_bp"]).await?;
+    let n: i64 = rows[0].get(0);
+    assert_eq!(n, 150, "all backpressured inserts must be durable + queryable");
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Prod wedged on 2026-06-11: MemBuffer climbed to **15.8GB against an 8GB hard limit** and every insert started rejecting with `"Memory limit exceeded"`, triggering a restart loop. Two ways in:

1. **Steady-state** — ingest outran the 10-min background flush; once over the limit, *every* insert rejected (permanent wedge, not a transient spike).
2. **On boot** — WAL replay loads straight into MemBuffer, bypassing the reservation path, so a large replayed backlog started the process already over budget → instantly wedged.

Since rows are **already durable in the WAL** and Delta/S3 is effectively unbounded "disk", the correct response to full RAM is to flush MemBuffer → Delta to make room — not to drop the write. For a time-series DB a slow write beats a rejected one the producer must DLQ.

## The fix

**Insert path applies backpressure instead of rejecting** (`buffered_write_layer.rs`):
- `reserve_with_backpressure()` — on over-limit, synchronously drain to Delta and retry; fail only after `write_backpressure_timeout` (default 60s, `0` restores fail-fast) of **zero progress**, which is a genuine "Delta unavailable" signal.
- **Two-tier drain**: flush completed buckets first (always race-free); escalate to force-flushing the *open* bucket after ≥2 stalls, for when a single busy 10-min window is itself the pressure.
- `force_flush_current_buckets()` — takes the open bucket's rows **atomically under the insert lock** (no lost-write race) and gates on `has_buckets_before()` so it can't over-advance the WAL cursor past an un-flushed older bucket; restores rows on commit failure (durability never depended on it — WAL holds them).
- **Post-replay boot drain** — bounded, progress-gated flush of completed buckets before serving, so a replayed backlog can't start wedged.

**Memory tuning** (`config.rs`): halve the bucket window and flush cadence **600s → 300s**. The current bucket is excluded from flushing, so the bucket window is the floor on how long a row accumulates in RAM — halving it roughly halves peak MemBuffer footprint.

**Observability** (`metrics.rs`, `stats_table.rs`): `backpressure_engaged` / `_rejected` / `_force_flush` counters. Alert if **engaged** is sustained > 0 (ingest outpacing flush); **page** on **rejected** (Delta flush not keeping up — data still in WAL but ingest is dropping).

**Separate dedup fix from the same incident**: the dedup `replace_where` commit aborted under concurrent appends (OCC predicate the kernel can't evaluate), retrying every 5 min and climbing to the memcg ceiling. Now serialized via the in-process commit lock.

## Trade-off

~2× Delta commits / small Parquet files from the 5-min buckets → watch tombstone growth at checkpoint and OPTIMIZE workload. The bucket window is the knob to nudge back up (independent of flush cadence) if it bites. Healthy signal: `backpressure_engaged` should trend toward zero as the smaller buckets relieve pressure ahead of the insert path.

## Tests
- `inserts_over_hard_limit_apply_backpressure_not_rejection` (e2e, full prod path — ~150MB into one open bucket on a 64MB budget; pre-fix returned a Postgres error)
- `backpressure_flushes_instead_of_rejecting`, `force_flush_current_bucket_drains_open_window`, `force_flush_skipped_while_completed_bucket_present` (unit, incl. the WAL-ordering skip guard)
- `dedup_commits_despite_concurrent_appends` (dedup OCC race under append fire)