### PR TITLE
test(dedup): make concurrent-append race deterministic

### DIFF
--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -80,6 +80,7 @@ async fn dedup_compaction_collapses_cross_flush_duplicates() -> Result<()> {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
+    use std::sync::atomic::Ordering::{Acquire, Release};
     let cfg = TestConfigBuilder::new("dedup_occ_race").with_buffer_mode(BufferMode::Enabled).build();
     let _env = walrus_env_guard(&cfg.core.timefusion_data_dir);
     let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
@@ -94,7 +95,6 @@ async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
 
     // Append fire: fresh-timestamp rows (same partition date space, distinct
     // ids) committing continuously while dedup rewrites the sealed chunk.
-    use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let committed = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let appender = {
@@ -122,7 +122,7 @@ async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
     let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
     let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
     let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
-    stop.store(true, Relaxed);
+    stop.store(true, Release);
     let appended = appender.await?;
     assert!(appended > 0, "appender must have raced at least one commit");
     assert_eq!(dropped, 1, "dedup must collapse the duplicate despite concurrent appends");

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -94,32 +94,42 @@ async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
 
     // Append fire: fresh-timestamp rows (same partition date space, distinct
     // ids) committing continuously while dedup rewrites the sealed chunk.
+    use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let committed = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let appender = {
-        let (db, project_id, stop) = (Arc::clone(&db), project_id.clone(), Arc::clone(&stop));
+        let (db, project_id, stop, committed) = (Arc::clone(&db), project_id.clone(), Arc::clone(&stop), Arc::clone(&committed));
         tokio::spawn(async move {
             let mut i = 0u64;
-            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+            while !stop.load(Acquire) {
                 let now = chrono::Utc::now().timestamp_micros();
                 let batch = json_to_batch(vec![test_span_ts(&format!("live_{i}"), "live", &project_id, now)]).unwrap();
                 db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![batch], true, None).await.unwrap();
                 i += 1;
+                committed.store(i, Release);
             }
             i
         })
     };
 
+    // Gate dedup on the appender's first committed row so the race is guaranteed,
+    // not a scheduling artifact: on a loaded CI runner dedup could otherwise finish
+    // before the spawned task is scheduled, failing the `appended > 0` assertion.
+    while committed.load(Acquire) == 0 {
+        tokio::task::yield_now().await;
+    }
+
     let table_ref = db.unified_tables().read().await.get("otel_logs_and_spans").expect("table created").clone();
     let date = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts).unwrap().date_naive();
     let dropped = db.dedup_partition(&table_ref, "otel_logs_and_spans", &project_id, date).await?;
-    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    stop.store(true, Relaxed);
     let appended = appender.await?;
     assert!(appended > 0, "appender must have raced at least one commit");
     assert_eq!(dropped, 1, "dedup must collapse the duplicate despite concurrent appends");
 
     let count_sql = format!("SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id);
     let post = db.query_delta_only(&count_sql).await?;
-    assert_eq!(post[0].column(0).as_primitive::<Int64Type>().value(0), 1);
+    assert_eq!(post[0].column(0).as_primitive::<Int64Type>().value(0), 1, "post-dedup: dup_id row should be collapsed to 1");
     Ok(())
 }
 

--- a/tests/dedup_compaction_test.rs
+++ b/tests/dedup_compaction_test.rs
@@ -129,7 +129,11 @@ async fn dedup_commits_despite_concurrent_appends() -> Result<()> {
 
     let count_sql = format!("SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id = '{}' AND id = 'dup_id'", project_id);
     let post = db.query_delta_only(&count_sql).await?;
-    assert_eq!(post[0].column(0).as_primitive::<Int64Type>().value(0), 1, "post-dedup: dup_id row should be collapsed to 1");
+    assert_eq!(
+        post[0].column(0).as_primitive::<Int64Type>().value(0),
+        1,
+        "post-dedup: dup_id row should be collapsed to 1"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Context

Follow-up to the closed #68. The `delta_commit_lock` fix and its `dedup_commits_despite_concurrent_appends` regression test both landed on master via #69 (`c28f2bf`) — #68 was a parallel duplicate and is closed. This PR applies the still-actionable review feedback from #68's Claude review to the test as it now lives in master.

## Changes

- **Deterministic race (was 🟡 flaky on CI):** gate `dedup_partition` on the appender's *first committed row* before starting. Previously `assert!(appended > 0)` could fail as a scheduling artifact if dedup finished before the spawned appender task was scheduled on a loaded 4-thread runner — a failure for the wrong reason.
- **Atomic ordering:** stop/commit flags use `Release`/`Acquire` instead of `Relaxed` (idiomatic stop-flag intent).
- **Assertion message:** added the missing failure message on the post-dedup count assertion.

Not addressed (intentional): the per-`Database` lock granularity flagged in review is a deliberate design choice — commits are sub-second vs the 10-min flush cadence, so global serialization is acceptable and simpler than per-table locks.

## Test

`cargo test --test dedup_compaction_test dedup_commits_despite_concurrent_appends` passes (1.8s). Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)