### PR TITLE
perf: fix insert-path backpressure thundering herd (p99 19.5s -> 546ms)

### DIFF
--- a/bench/concurrent_load.py
+++ b/bench/concurrent_load.py
@@ -134,6 +134,7 @@ class Stats:
         self.batches = 0
         self.errors: list[str] = []
         self.lat: dict[str, list[float]] = defaultdict(list)
+        self.wlat: list[float] = []  # per-INSERT latency (ms) — the dual-write ack metric
         self.query_errors: list[str] = []
 
 
@@ -156,10 +157,13 @@ def writer(stop: threading.Event, pid: str, rows: list[dict], batch_size: int, s
                 for c in COLUMNS:
                     flat.append(_to_pg(c, r.get(c)))
             try:
+                t = time.perf_counter()
                 cur.execute(base_sql + ", ".join([placeholders]*len(batch)), flat)
+                ins_ms = (time.perf_counter() - t) * 1000
                 with stats.lock:
                     stats.inserted += len(batch)
                     stats.batches += 1
+                    stats.wlat.append(ins_ms)
             except Exception as e:
                 with stats.lock:
                     stats.errors.append(repr(e)[:200])
@@ -283,6 +287,10 @@ def main():
     print(f"  insert errors  : {len(stats.errors)}")
     if stats.errors[:3]:
         for e in stats.errors[:3]: print(f"    - {e}")
+    if stats.wlat:
+        w = stats.wlat
+        print(f"  INSERT ack lat : n={len(w):,}  p50={pct(w,50):6.1f}ms  p90={pct(w,90):7.1f}ms  "
+              f"p99={pct(w,99):7.1f}ms  p99.9={pct(w,99.9):8.1f}ms  max={max(w):8.1f}ms")
 
     print("\n# reads (budget {:.0f} ms)".format(args.budget_ms))
     overall_pass = len(stats.errors) == 0

--- a/bench/insert_tail.sh
+++ b/bench/insert_tail.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Insert-ack tail-latency bench: reproduce the dual-write gating symptom.
+# Starts TF (release-iter) against local MinIO with a small buffer + many
+# projects so the serial Delta flush can't keep up → backpressure → tail.
+#
+# Usage: ./bench/insert_tail.sh <label> [writers] [duration] [mem_mb] [flush_secs]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+label="${1:-base}"
+writers="${2:-24}"
+duration="${3:-90}"
+mem_mb="${4:-512}"
+flush_secs="${5:-30}"
+data_dir="./data/itail-${label}"
+log="/tmp/tf-itail-${label}.log"
+bin="${TF_BIN:-./target/release-iter/timefusion}"
+
+pkill -f 'target/(debug|release|release-iter)/timefusion' 2>/dev/null || true
+sleep 1
+rm -rf "$data_dir"; mkdir -p "$data_dir"
+# WIPE=1 wipes the Delta table for a cold baseline; default reuses the existing
+# table (realistic — prod tables always exist; avoids the cold-create race).
+if [ "${WIPE:-0}" = "1" ]; then
+  AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+    aws --endpoint-url http://127.0.0.1:9000 s3 rm s3://timefusion-bench --recursive >/dev/null 2>&1 || true
+fi
+
+set -a; source .env; set +a
+export AWS_S3_BUCKET=timefusion-bench
+export TIMEFUSION_DATA_DIR="$data_dir"
+export TIMEFUSION_TABLE_PREFIX=bench
+export RUST_LOG="${RUST_LOG_OVERRIDE:-warn,timefusion=info}"
+export TIMEFUSION_BUFFER_FLUSH_INTERVAL_SECS="$flush_secs"
+export TIMEFUSION_BUFFER_MAX_MEMORY_MB="$mem_mb"
+# Keep cache reservations small so max_memory_mb ≈ effective MemBuffer budget
+# (the test .env shrinks foyer memory to 64MB but leaves the 512MB metadata-cache
+# reservation, which otherwise eats most of the budget and distorts the bench).
+export TIMEFUSION_FOYER_METADATA_MEMORY_MB="${FOYER_META_MB:-64}"
+export TIMEFUSION_ALLOW_INSECURE_AUTH=true
+export MAX_PG_CONNECTIONS=128
+export TIMEFUSION_BATCH_QUEUE_CAPACITY=10000
+unset OTEL_EXPORTER_OTLP_ENDPOINT
+export OTEL_SDK_DISABLED=true
+
+nohup "$bin" >"$log" 2>&1 &
+echo $! > /tmp/tf-itail.pid
+for i in $(seq 1 60); do
+  nc -z 127.0.0.1 12345 2>/dev/null && { echo "TF[$label] up after ${i}s (pid=$(cat /tmp/tf-itail.pid))"; break; }
+  sleep 1
+done
+nc -z 127.0.0.1 12345 2>/dev/null || { echo "TF[$label] failed to start"; tail -30 "$log"; exit 1; }
+
+echo "=== running concurrent_load: writers=$writers duration=${duration}s mem=${mem_mb}MB flush=${flush_secs}s ==="
+python3 bench/concurrent_load.py --writers "$writers" --readers 2 --duration "$duration" --batch 30 --row-limit "${ROW_LIMIT:-6000}" || true
+echo "=== TF flush/pressure log tail ==="
+grep -iE 'flush|pressure|backpressure|reject|memory limit' "$log" | tail -25 || true

--- a/bench/insert_tail.sh
+++ b/bench/insert_tail.sh
@@ -26,7 +26,9 @@ if [ "${WIPE:-0}" = "1" ]; then
     aws --endpoint-url http://127.0.0.1:9000 s3 rm s3://timefusion-bench --recursive >/dev/null 2>&1 || true
 fi
 
-set -a; source .env; set +a
+# Source .env if present (S3 creds etc); under `set -e` a missing file would
+# otherwise abort the script with a cryptic error.
+[ -f .env ] && { set -a; source .env; set +a; } || echo "note: no .env found; using ambient environment"
 export AWS_S3_BUCKET=timefusion-bench
 export TIMEFUSION_DATA_DIR="$data_dir"
 export TIMEFUSION_TABLE_PREFIX=bench

--- a/bench/run_insert_bench.sh
+++ b/bench/run_insert_bench.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 label="${1:-m}"; writers="${2:-24}"; dur="${3:-60}"; mem="${4:-256}"; flush="${5:-15}"
+mkdir -p bench/data
 report="bench/data/${label}.report"
 ROW_LIMIT="${ROW_LIMIT:-6000}" ./bench/insert_tail.sh "$label" "$writers" "$dur" "$mem" "$flush" > "$report" 2>&1 || true
 echo "########## CONFIG: $label  writers=$writers mem=${mem}MB flush=${flush}s ##########"

--- a/bench/run_insert_bench.sh
+++ b/bench/run_insert_bench.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Clean insert-ack measurement: runs insert_tail.sh for one config, saves the
+# full concurrent_load report (never truncated) to bench/data/<label>.report,
+# and prints just the ingest/latency summary + flush health.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+label="${1:-m}"; writers="${2:-24}"; dur="${3:-60}"; mem="${4:-256}"; flush="${5:-15}"
+report="bench/data/${label}.report"
+ROW_LIMIT="${ROW_LIMIT:-6000}" ./bench/insert_tail.sh "$label" "$writers" "$dur" "$mem" "$flush" > "$report" 2>&1 || true
+echo "########## CONFIG: $label  writers=$writers mem=${mem}MB flush=${flush}s ##########"
+grep -E 'INSERT ack lat|rows inserted|batches sent|throughput|insert errors|press=' "$report" || true
+log="/tmp/tf-itail-${label}.log"
+echo "-- flush health --"
+echo "force-flush failures: $(grep -c 'force-flush: Delta commit failed' "$log" 2>/dev/null || echo 0)"
+echo "backpressure engaged:  $(grep -c 'backpressure engaged' "$log" 2>/dev/null || echo 0)"
+echo "backpressure rejects:  $(grep -c 'backpressure exhausted' "$log" 2>/dev/null || echo 0)"
+echo "force-flush invocations: $(grep -c 'force-flush' "$log" 2>/dev/null || echo 0)"

--- a/bench/run_select_bench.sh
+++ b/bench/run_select_bench.sh
@@ -16,7 +16,7 @@ rm -rf "$data_dir"; mkdir -p "$data_dir"
 AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
   aws --endpoint-url http://127.0.0.1:9000 s3 rm s3://timefusion-bench --recursive >/dev/null 2>&1 || true
 
-set -a; source .env; set +a
+[ -f .env ] && { set -a; source .env; set +a; } || echo "note: no .env found; using ambient environment"
 export AWS_S3_BUCKET=timefusion-bench
 export TIMEFUSION_DATA_DIR="$data_dir"
 export TIMEFUSION_TABLE_PREFIX=bench

--- a/bench/run_select_bench.sh
+++ b/bench/run_select_bench.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Clean SELECT-latency bench: fresh TF on a wiped bucket (no cold-create race),
+# seed a prod-shaped dataset, then measure the popular log-explorer queries with
+# plan-only vs exec breakdown (query_latency.py run + run_ages).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+label="${1:-sel}"
+projects="${QLAT_PROJECTS:-1}"; days="${QLAT_DAYS:-3}"; rpd="${QLAT_ROWS_PER_DAY:-20000}"
+data_dir="./data/sel-${label}"
+log="/tmp/tf-sel-${label}.log"
+bin="${TF_BIN:-./target/release-iter/timefusion}"
+
+pkill -f 'target/(debug|release|release-iter)/timefusion' 2>/dev/null || true
+sleep 1
+rm -rf "$data_dir"; mkdir -p "$data_dir"
+AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+  aws --endpoint-url http://127.0.0.1:9000 s3 rm s3://timefusion-bench --recursive >/dev/null 2>&1 || true
+
+set -a; source .env; set +a
+export AWS_S3_BUCKET=timefusion-bench
+export TIMEFUSION_DATA_DIR="$data_dir"
+export TIMEFUSION_TABLE_PREFIX=bench
+export RUST_LOG="${RUST_LOG_OVERRIDE:-warn,timefusion=info}"
+export TIMEFUSION_BUFFER_FLUSH_INTERVAL_SECS=15
+export TIMEFUSION_BUFFER_MAX_MEMORY_MB="${MEM_MB:-2048}"
+export TIMEFUSION_FOYER_METADATA_MEMORY_MB="${FOYER_META_MB:-64}"
+export TIMEFUSION_ALLOW_INSECURE_AUTH=true
+export MAX_PG_CONNECTIONS=128
+unset OTEL_EXPORTER_OTLP_ENDPOINT
+export OTEL_SDK_DISABLED=true
+
+nohup "$bin" >"$log" 2>&1 &
+for i in $(seq 1 60); do nc -z 127.0.0.1 12345 2>/dev/null && break; sleep 1; done
+nc -z 127.0.0.1 12345 2>/dev/null || { echo "TF failed to start"; tail -20 "$log"; exit 1; }
+echo "TF[sel-$label] up"
+
+echo "=== seeding ${projects}p x ${days}d x ${rpd}/day ==="
+QLAT_PROJECTS=$projects QLAT_DAYS=$days QLAT_ROWS_PER_DAY=$rpd python3 bench/query_latency.py seed_scale 2>&1 | tail -2
+# Force a flush so older data is in Delta (queries exercise MemBuffer+Delta union).
+sleep 18
+echo "=== query_latency run ==="
+python3 bench/query_latency.py run 2>&1 | tail -22
+echo "=== run_ages (cold/warm partition probe) ==="
+python3 bench/query_latency.py run_ages 2>&1 | tail -12 || true

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -557,9 +557,14 @@ impl BufferedWriteLayer {
                         );
                         return Err(e);
                     }
-                    // Brief yield so the background flush task can free RAM
-                    // before we retry the reservation.
-                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    // Wait for a flush to free RAM, then retry. Woken early by
+                    // `flush_tick_notify` (the relief winner / background task
+                    // signals it on every flush), capped at 25ms so a missed
+                    // wakeup can't stall the retry.
+                    tokio::select! {
+                        _ = self.flush_tick_notify.notified() => {}
+                        _ = tokio::time::sleep(Duration::from_millis(25)) => {}
+                    }
                 }
             }
         }
@@ -581,6 +586,10 @@ impl BufferedWriteLayer {
         {
             warn!("pressure: force_flush_current_buckets failed: {}", e);
         }
+        // Memory may now be below the limit — wake any backpressured writers
+        // parked on `flush_tick_notify` so they retry their reservation
+        // immediately instead of waiting out their 25ms poll.
+        self.flush_tick_notify.notify_waiters();
     }
 
     /// Force-flush the current (still-open) bucket(s) to Delta. Normal flushing
@@ -1081,7 +1090,14 @@ impl BufferedWriteLayer {
                 self.relieve_memory_pressure().await;
                 let now = self.effective_memory_bytes();
                 if now + now / 100 >= last {
-                    break; // no progress this round
+                    // Gave up still over the limit: Delta isn't freeing RAM, so
+                    // inserts are about to hit their own backpressure/reject path.
+                    // Surface it at error level — per-flush failures are already
+                    // metered in flush_completed/force_flush; this flags the
+                    // relief loop itself stalling. (`record_flush(false)` would
+                    // be wrong here — no commit was attempted this round.)
+                    error!("Pressure relief made no progress: used={}MB still over the limit — Delta flush is not freeing memory", now / (1024 * 1024));
+                    break;
                 }
                 last = now;
             }

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -291,6 +291,12 @@ pub struct BufferedWriteLayer {
     tantivy_index_callback:         Option<TantivyIndexCallback>,
     background_tasks:               Mutex<Vec<JoinHandle<()>>>,
     flush_lock:                     Mutex<()>,
+    // Single-flights insert-path backpressure relief: only the writer that wins
+    // this try_lock drives a relief flush; the rest wait for it to free RAM.
+    // Without it, every blocked writer ran its own flush cycle (the ~20s p99
+    // herd). Distinct from `flush_lock` so relief never blocks behind a routine
+    // background flush already holding `flush_lock`.
+    relief_lock:                    Mutex<()>,
     reserved_bytes:                 AtomicUsize, // Memory reserved for in-flight writes
     pressure_notify:                Arc<Notify>, // Wakes flush task when pressure threshold crossed
     /// Notified at the end of every flush task iteration (success or failure).
@@ -369,6 +375,7 @@ impl BufferedWriteLayer {
             tantivy_index_callback: None,
             background_tasks: Mutex::new(Vec::new()),
             flush_lock: Mutex::new(()),
+            relief_lock: Mutex::new(()),
             reserved_bytes: AtomicUsize::new(0),
             pressure_notify: Arc::new(Notify::new()),
             flush_tick_notify: Arc::new(Notify::new()),
@@ -517,65 +524,62 @@ impl BufferedWriteLayer {
         }
 
         let deadline = std::time::Instant::now() + timeout;
-        let mut last_mem = self.effective_memory_bytes();
-        let mut stalls = 0u32;
         crate::metrics::record_backpressure_engaged();
         self.backpressure_engaged_total.fetch_add(1, Ordering::Relaxed);
         warn!(
-            "Write backpressure engaged: used={}MB ≥ hard limit; flushing to Delta to free RAM (not rejecting)",
-            last_mem / (1024 * 1024)
+            "Write backpressure engaged: used={}MB ≥ hard limit; waking background flush to free RAM (not rejecting, not flushing on insert thread)",
+            self.effective_memory_bytes() / (1024 * 1024)
         );
         loop {
-            // Relieve via completed buckets first (always race-free). Escalate
-            // to force-flushing the current open bucket only after consecutive
-            // stalls — i.e. when a single in-flight window is itself the
-            // pressure and completed-bucket flushes can't help.
-            self.relieve_memory_pressure(stalls >= 2).await;
+            // Single-flight relief: only the writer that wins `relief_lock`
+            // drives the synchronous flush; everyone else just nudges the
+            // background flusher and waits. Previously every blocked writer ran
+            // its own `flush_completed_buckets` + force-flush cycle, all queued
+            // on `flush_lock` — with N writers the one at the back of the herd
+            // waited O(N × commit), the source of the ~20s p99 tail. Now one
+            // writer flushes (O(commit)) while the rest sleep below.
+            if let Ok(_relief) = self.relief_lock.try_lock() {
+                self.relieve_memory_pressure().await;
+            } else {
+                self.pressure_notify.notify_one();
+            }
 
             match self.try_reserve_memory(batches).await {
                 Ok(sz) => return Ok(sz),
                 Err(e) => {
-                    let now_mem = self.effective_memory_bytes();
-                    // Count a stall when this round freed <1% of memory.
-                    if now_mem + now_mem / 100 >= last_mem {
-                        stalls += 1;
-                    } else {
-                        stalls = 0;
-                    }
-                    last_mem = now_mem;
                     if std::time::Instant::now() >= deadline {
                         crate::metrics::record_backpressure_rejected();
                         self.backpressure_rejected_total.fetch_add(1, Ordering::Relaxed);
                         error!(
                             "Write backpressure exhausted after {:?}: used={}MB still over hard limit — Delta flush is not freeing memory; rejecting (data remains in WAL)",
                             timeout,
-                            now_mem / (1024 * 1024)
+                            self.effective_memory_bytes() / (1024 * 1024)
                         );
                         return Err(e);
                     }
-                    // Brief yield so the background flush task and other writers
-                    // can make progress between our synchronous drain attempts.
+                    // Brief yield so the background flush task can free RAM
+                    // before we retry the reservation.
                     tokio::time::sleep(Duration::from_millis(25)).await;
                 }
             }
         }
     }
 
-    /// Synchronously drain MemBuffer → Delta to relieve insert-path memory
-    /// pressure. Flushes completed buckets first (always safe); when
-    /// `force_current` is set also force-flushes the current open bucket(s) via
-    /// the atomic `take_bucket_for_flush` path.
-    async fn relieve_memory_pressure(&self, force_current: bool) {
+    /// One pass of pressure relief: drain completed buckets, then — if still
+    /// over the limit — force-flush the current open bucket(s). Order matters:
+    /// `force_flush_current_buckets` self-gates while completed buckets remain
+    /// (WAL-ordering invariant), so completed buckets must drain first. Shared
+    /// by the insert backpressure path (single-flighted via `relief_lock`) and
+    /// the background flush task; both warn-and-continue on flush errors so the
+    /// caller's retry/no-progress logic decides when to give up.
+    async fn relieve_memory_pressure(&self) {
         if let Err(e) = self.flush_completed_buckets().await {
-            warn!("backpressure: flush_completed_buckets failed: {}", e);
+            warn!("pressure: flush_completed_buckets failed: {}", e);
         }
-        // `force_flush_current_buckets` self-gates on the WAL-ordering invariant
-        // (see its body), so calling it whenever pressure persists is safe.
-        if force_current
-            && self.is_memory_pressure()
+        if self.is_memory_pressure()
             && let Err(e) = self.force_flush_current_buckets().await
         {
-            warn!("backpressure: force_flush_current_buckets failed: {}", e);
+            warn!("pressure: force_flush_current_buckets failed: {}", e);
         }
     }
 
@@ -1064,6 +1068,22 @@ impl BufferedWriteLayer {
                 crate::metrics::record_flush(false);
                 self.flush_failed_total.fetch_add(1, Ordering::Relaxed);
                 error!("Flush task error: {}", e);
+            }
+
+            // Pressure escalation off the insert path: a single still-open
+            // window can be the whole budget, which completed-bucket flushing
+            // can't relieve. Drive `relieve_memory_pressure` until we drop below
+            // the limit or a round frees nothing (avoids a busy spin when Delta
+            // is the bottleneck). Inserts proactively served here usually never
+            // touch their own backpressure path.
+            let mut last = self.effective_memory_bytes();
+            while self.is_memory_pressure() {
+                self.relieve_memory_pressure().await;
+                let now = self.effective_memory_bytes();
+                if now + now / 100 >= last {
+                    break; // no progress this round
+                }
+                last = now;
             }
             // WAL monitoring: check file accumulation
             let (file_count, total_bytes) = self.wal.wal_stats();

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -1096,7 +1096,10 @@ impl BufferedWriteLayer {
                     // metered in flush_completed/force_flush; this flags the
                     // relief loop itself stalling. (`record_flush(false)` would
                     // be wrong here — no commit was attempted this round.)
-                    error!("Pressure relief made no progress: used={}MB still over the limit — Delta flush is not freeing memory", now / (1024 * 1024));
+                    error!(
+                        "Pressure relief made no progress: used={}MB still over the limit — Delta flush is not freeing memory",
+                        now / (1024 * 1024)
+                    );
                     break;
                 }
                 last = now;

--- a/src/database.rs
+++ b/src/database.rs
@@ -879,6 +879,7 @@ impl Database {
     /// - Per-field `dictionary: false` opt-out for high-entropy free-text.
     /// - Per-field `bloom_filter: true` opt-in for point-lookup columns
     ///   (ids/trace_ids/span_ids); NDV scaled to row-group size.
+    ///
     /// `declare_sorted`: pass `true` only from paths that sort rows by the
     /// schema sort keys before writing (flush, dedup). Optimize/compact pass
     /// `false`. See `build_writer_properties`.

--- a/tests/e2e/pressure_flush.rs
+++ b/tests/e2e/pressure_flush.rs
@@ -82,9 +82,14 @@ async fn inserts_over_hard_limit_apply_backpressure_not_rejection() -> anyhow::R
         .await
         .map_err(|_| anyhow::anyhow!("inserts under backpressure deadlocked"))??;
 
+    // The ~150MB lands in one open bucket, so only the current-bucket
+    // force-flush escalation can drain it — assert that ran. (We no longer
+    // require `backpressure_engaged_total >= 1`: the background flusher now
+    // escalates proactively at the pressure threshold, often draining the
+    // bucket before any insert reaches the hard-limit backpressure path.)
     assert!(
-        env.snapshot_stats().backpressure_engaged_total >= 1,
-        "backpressure must engage when the open bucket exceeds the hard limit"
+        env.snapshot_stats().backpressure_force_flush_total >= 1,
+        "force-flush must drain the over-budget open bucket"
     );
 
     let rows = client.query("SELECT count(*) FROM otel_logs_and_spans WHERE project_id = $1", &[&"e2e_bp"]).await?;


### PR DESCRIPTION
Under memory pressure every blocked writer ran its own flush cycle, serialized on the global flush_lock + delta_commit_lock. With N writers the one at the back of the herd waited O(N x commit) -- the source of the 16-25s insert p99 tail in the monoscope dual-write (and the 25s = retry ceiling once flushes errored).

Single-flight the relief: only the writer that wins a new relief_lock (try_lock) drives the synchronous flush; the rest wake the background flusher and wait. The background flush task now also escalates to force-flushing the open bucket under pressure, so writers usually never block at all. A shared relieve_memory_pressure() drains completed buckets then force-flushes the current one (order required by the WAL self-gate).

Result (MinIO, 24 writers, realistic budget): insert-ack p99 19,570ms -> 546ms; TF now beats Postgres on p50/p90/p99/max. e2e pressure_flush asserts force-flush drains the over-budget bucket (proactive drain often avoids the reactive backpressure path).

bench: concurrent_load.py reports INSERT-ack percentiles; add insert_tail/run_insert_bench/run_select_bench harness.

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
