### PR TITLE
perf(write): O(files-added) append-only snapshot advance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc7e18432c1cb40ee023811b1c258433a4c82e27#dc7e18432c1cb40ee023811b1c258433a4c82e27"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc7e18432c1cb40ee023811b1c258433a4c82e27#dc7e18432c1cb40ee023811b1c258433a4c82e27"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc7e18432c1cb40ee023811b1c258433a4c82e27#dc7e18432c1cb40ee023811b1c258433a4c82e27"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc7e18432c1cb40ee023811b1c258433a4c82e27#dc7e18432c1cb40ee023811b1c258433a4c82e27"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "dc7e18432c1cb40ee023811b1c258433a4c82e27", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "3b0468b2ff674f821dfaeaf19a2d47af21ada77c", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,7 @@ const_default!(d_warm_recency_days: u64 = 2);
 // short by a restart every time; 16 finishes it in ~1-3 min. Footer GETs are
 // ~64KB suffix ranges, well within R2/S3 burst limits.
 const_default!(d_warm_concurrency: usize = 16);
+const_default!(d_snapshot_reconcile: u64 = 500);
 const_default!(d_mem_gb: usize = 8);
 const_default!(d_mem_fraction: f64 = 0.9);
 const_default!(d_query_partitions: usize = 0);
@@ -720,6 +721,18 @@ pub struct MaintenanceConfig {
     /// S3) and keeps the cache from filling with dead compaction outputs.
     #[serde(default = "d_true")]
     pub timefusion_evict_after_compaction:        bool,
+    /// Advance the post-commit snapshot by appending only the files the commit
+    /// added, instead of re-materializing the whole active file set (2-8s over
+    /// 26k files every flush in prod). Produces an identical file set — a
+    /// faster, equivalent replay, safe regardless of writer count. Off reverts
+    /// to the full re-materialize per commit.
+    #[serde(default = "d_true")]
+    pub timefusion_incremental_snapshot:          bool,
+    /// Belt-and-suspenders for the above: every Nth commit per table, drop the
+    /// materialized files and re-materialize from S3 truth, bounding any drift
+    /// from an incremental-replay bug. 0 disables reconciliation.
+    #[serde(default = "d_snapshot_reconcile")]
+    pub timefusion_snapshot_reconcile_commits:    u64,
 }
 
 /// Which DataFusion `MemoryPool` to back the runtime with.

--- a/src/database.rs
+++ b/src/database.rs
@@ -2667,7 +2667,10 @@ impl Database {
                     .inspect_err(|e| warn!("Local snapshot catch-up failed for '{storage_uri}': {e}; falling back to full load"))
                     .ok()
                     .map(|()| {
-                        info!("Restored '{storage_uri}' from local snapshot at v{restored_version}, caught up to {:?}", table.version());
+                        info!(
+                            "Restored '{storage_uri}' from local snapshot at v{restored_version}, caught up to {:?}",
+                            table.version()
+                        );
                         table
                     })
             }
@@ -3020,8 +3023,8 @@ impl Database {
     /// (version-guarded), warm the just-written files, invalidate stats, and
     /// return the newly added file URIs.
     async fn record_committed_write(
-        &self, table_ref: &Arc<RwLock<DeltaTable>>, project_id: &str, table_name: &str, mut new_table: DeltaTable, pre_uris: &std::collections::HashSet<String>,
-        warm: bool,
+        &self, table_ref: &Arc<RwLock<DeltaTable>>, project_id: &str, table_name: &str, new_table: DeltaTable,
+        pre_uris: &std::collections::HashSet<String>, warm: bool,
     ) -> Vec<String> {
         let committed_version = new_table.version();
         if let Some(version) = committed_version {
@@ -3070,7 +3073,7 @@ impl Database {
         let reconcile_n = self.config.maintenance.timefusion_snapshot_reconcile_commits;
         if self.config.maintenance.timefusion_incremental_snapshot
             && reconcile_n > 0
-            && committed_version.is_some_and(|v| (v + Self::reconcile_offset(project_id, table_name, reconcile_n)) % reconcile_n == 0)
+            && committed_version.is_some_and(|v| (v + Self::reconcile_offset(project_id, table_name, reconcile_n)).is_multiple_of(reconcile_n))
         {
             let (table_ref, shutdown) = (table_ref.clone(), self.maintenance_shutdown.clone());
             let (project_id, table_name) = (project_id.to_string(), table_name.to_string());

--- a/src/database.rs
+++ b/src/database.rs
@@ -2629,6 +2629,18 @@ impl Database {
         }
     }
 
+    /// Materialize a table snapshot's active file list in memory. `reconcile`
+    /// rebuilds it from object-store truth; otherwise it materializes once if
+    /// not already done. No-op when the table carries no state.
+    async fn materialize_snapshot_files(table: &mut DeltaTable, reconcile: bool) -> Result<()> {
+        let log_store = table.log_store();
+        match table.state.as_mut() {
+            Some(state) if reconcile => state.rematerialize_files(log_store.as_ref()).await.map_err(Into::into),
+            Some(state) => state.ensure_materialized_files(log_store.as_ref()).await.map_err(Into::into),
+            None => Ok(()),
+        }
+    }
+
     /// Creates or loads a DeltaTable with proper configuration. Prefers the
     /// locally persisted snapshot (restore at version V + incremental replay
     /// of commits > V) over a full checkpoint + log-tail rebuild from S3;
@@ -2643,23 +2655,42 @@ impl Database {
                 .with_storage_options(storage_options.clone())
                 .with_allow_http(true))
         };
-        if let Some(state) = crate::snapshot_cache::load(&Self::delta_snapshot_dir(&self.config), storage_uri) {
-            let restored_version = state.version();
-            let mut table = builder()?.build()?;
-            table.state = Some(state);
-            match table.update_state().await {
-                Ok(()) => {
-                    info!(
-                        "Restored '{storage_uri}' from local snapshot at v{restored_version}, caught up to {:?}",
-                        table.version()
-                    );
-                    return Ok(table);
-                }
-                // e.g. the log tail past the snapshot was vacuumed away.
-                Err(e) => warn!("Local snapshot catch-up failed for '{storage_uri}': {e}; falling back to full load"),
+        let restored = match crate::snapshot_cache::load(&Self::delta_snapshot_dir(&self.config), storage_uri) {
+            Some(state) => {
+                let restored_version = state.version();
+                let mut table = builder()?.build()?;
+                table.state = Some(state);
+                // e.g. the log tail past the snapshot was vacuumed away → full load.
+                table
+                    .update_state()
+                    .await
+                    .inspect_err(|e| warn!("Local snapshot catch-up failed for '{storage_uri}': {e}; falling back to full load"))
+                    .ok()
+                    .map(|()| {
+                        info!("Restored '{storage_uri}' from local snapshot at v{restored_version}, caught up to {:?}", table.version());
+                        table
+                    })
             }
+            None => None,
+        };
+        let mut table = match restored {
+            Some(t) => t,
+            None => builder()?.load().await.map_err(|e| anyhow::anyhow!("Failed to load table: {}", e))?,
+        };
+        // Materialize the file list once so every post-commit update stays
+        // incremental. With incremental snapshots on this is a *correctness*
+        // requirement, not just perf: a non-materialized snapshot enumerates an
+        // EMPTY file set, and the fast-advance post-commit hook would build on
+        // it — so fail loud rather than cache a handle that serves empty results
+        // (the caller retries on next access). load()/restore normally arrive
+        // materialized, so this no-ops and can only fail on the rare path that
+        // actually has to materialize.
+        if self.config.maintenance.timefusion_incremental_snapshot {
+            Self::materialize_snapshot_files(&mut table, false)
+                .await
+                .map_err(|e| anyhow::anyhow!("Materializing file list for '{storage_uri}' failed: {e}"))?;
         }
-        builder()?.load().await.map_err(|e| anyhow::anyhow!("Failed to load table: {}", e))
+        Ok(table)
     }
 
     #[instrument(
@@ -2756,6 +2787,20 @@ impl Database {
 
         // Hoist out of the retry loop — the watermark is the same on every attempt.
         let commit_properties = watermark.map(build_watermark_commit_properties);
+        // Let the post-commit hook advance the snapshot by appending the
+        // committed files instead of re-materializing the whole active set.
+        // Applied to both the staged (pure-append) and schema-evolution merge
+        // paths: the hook takes the fast path only when the commit has no Remove
+        // actions, so it can never drop files. A schema-evolution commit
+        // (MetaData + Add, no Remove) is still safe — the hook rebuilds the
+        // kernel snapshot from the log, so the MetaData/schema change IS applied;
+        // only the file-list re-materialization is skipped. Removes (overwrite/
+        // delete) fall back to the full update.
+        let commit_properties = if self.config.maintenance.timefusion_incremental_snapshot {
+            Some(commit_properties.unwrap_or_default().with_fast_append_advance(true))
+        } else {
+            commit_properties
+        };
         let max_retries = 5;
         // Exponential backoff between OCC conflict retries (shared by both paths).
         let retry_backoff = |n: u32| tokio::time::Duration::from_millis(100 * 2_u64.pow(n.min(5)));
@@ -2975,10 +3020,11 @@ impl Database {
     /// (version-guarded), warm the just-written files, invalidate stats, and
     /// return the newly added file URIs.
     async fn record_committed_write(
-        &self, table_ref: &Arc<RwLock<DeltaTable>>, project_id: &str, table_name: &str, new_table: DeltaTable, pre_uris: &std::collections::HashSet<String>,
+        &self, table_ref: &Arc<RwLock<DeltaTable>>, project_id: &str, table_name: &str, mut new_table: DeltaTable, pre_uris: &std::collections::HashSet<String>,
         warm: bool,
     ) -> Vec<String> {
-        if let Some(version) = new_table.version() {
+        let committed_version = new_table.version();
+        if let Some(version) = committed_version {
             self.last_written_versions.write().await.insert((project_id.to_string(), table_name.to_string()), version);
             debug!("Stored last written version for {}/{}: {}", project_id, table_name, version);
         } else {
@@ -3015,7 +3061,55 @@ impl Database {
         }
         self.statistics_extractor.invalidate(project_id, table_name).await;
         debug!("Invalidated statistics cache after write to {}/{}", project_id, table_name);
+        // Periodic reconcile, OFF the flush path: every Nth commit (offset per
+        // table so tables with uniform write rates don't all rebuild at once)
+        // rebuild the file list from S3 truth in the background. This bounds any
+        // incremental-replay drift without blocking the WAL cursor, and runs on
+        // a detached clone so it never touches `added` (tantivy coverage) or the
+        // persisted snapshot — both already captured from the committed state.
+        let reconcile_n = self.config.maintenance.timefusion_snapshot_reconcile_commits;
+        if self.config.maintenance.timefusion_incremental_snapshot
+            && reconcile_n > 0
+            && committed_version.is_some_and(|v| (v + Self::reconcile_offset(project_id, table_name, reconcile_n)) % reconcile_n == 0)
+        {
+            let (table_ref, shutdown) = (table_ref.clone(), self.maintenance_shutdown.clone());
+            let (project_id, table_name) = (project_id.to_string(), table_name.to_string());
+            tokio::spawn(async move {
+                tokio::select! {
+                    _ = shutdown.cancelled() => {}
+                    _ = Self::reconcile_snapshot(&table_ref, &project_id, &table_name) => {}
+                }
+            });
+        }
         added
+    }
+
+    /// Stable per-table offset into the reconcile cycle so tables committing in
+    /// lockstep don't all hit their `% reconcile_n == 0` boundary together.
+    fn reconcile_offset(project_id: &str, table_name: &str, reconcile_n: u64) -> u64 {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        (project_id, table_name).hash(&mut h);
+        h.finish() % reconcile_n
+    }
+
+    /// Rebuild a table's in-memory file list from object-store truth and swap it
+    /// in — but only if no commit advanced the handle while we rebuilt, since a
+    /// rebuild is pinned to its version and a stale swap would drop newer files.
+    /// Runs detached (off the flush path); never persists (the commit path
+    /// already persisted the correct incremental state).
+    async fn reconcile_snapshot(table_ref: &Arc<RwLock<DeltaTable>>, project_id: &str, table_name: &str) {
+        let mut fresh = table_ref.read().await.clone();
+        if let Err(e) = Self::materialize_snapshot_files(&mut fresh, true).await {
+            warn!("Snapshot reconcile failed for {project_id}/{table_name}: {e}");
+            return;
+        }
+        let fresh_version = fresh.version();
+        let mut shared = table_ref.write().await;
+        if fresh_version == shared.version() {
+            *shared = fresh;
+            debug!("Reconciled snapshot for {project_id}/{table_name} at v{fresh_version:?}");
+        }
     }
 
     /// Read the latest commit metadata for each WAL topic and fast-forward the

--- a/src/snapshot_cache.rs
+++ b/src/snapshot_cache.rs
@@ -93,6 +93,59 @@ mod tests {
     use super::*;
     use crate::schema_loader::get_default_schema;
 
+    /// Decisive probe: does a delta-rs commit (the `CommitBuilder` post-commit
+    /// hook that produces `finalized.snapshot()` in TF's flush path) preserve
+    /// the materialized file list? If a commit drops it, every subsequent
+    /// post-commit `snapshot.update()` falls back to a full checkpoint replay —
+    /// the 2-8s/flush prod cost — even though load/update preserve it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_preserves_materialized_files() -> anyhow::Result<()> {
+        let mem = Arc::new(object_store::memory::InMemory::new());
+        let url = Url::parse("memory:///commit_mat")?;
+        let t = DeltaTableBuilder::from_url(url.clone())?.with_storage_backend(mem.clone(), url.clone()).build()?;
+        let mut table = t.create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
+        assert!(table.state.as_ref().unwrap().has_materialized_files(), "freshly created table is materialized");
+
+        // A metadata commit through the high-level ops API exercises the same
+        // CommitBuilder post-commit hook the flush path uses.
+        table = table
+            .set_tbl_properties()
+            .with_properties(std::collections::HashMap::from([("delta.checkpointInterval".to_string(), "50".to_string())]))
+            .await?;
+        assert_eq!(table.version(), Some(1));
+        assert!(
+            table.state.as_ref().unwrap().has_materialized_files(),
+            "post-commit state must stay materialized; if false, every flush full-scans"
+        );
+        Ok(())
+    }
+
+    /// Does a full `.load()` (the path TF takes when there's no usable local
+    /// snapshot — e.g. a legacy on-disk snapshot that misses) come back
+    /// materialized? If not, every post-commit update stays on the full-scan
+    /// branch and never self-heals — the suspected prod cause. Also verifies
+    /// `ensure_materialized_files` (Tier A) repairs it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_load_materialization() -> anyhow::Result<()> {
+        let mem = Arc::new(object_store::memory::InMemory::new());
+        let url = Url::parse("memory:///full_load")?;
+        let t = DeltaTableBuilder::from_url(url.clone())?.with_storage_backend(mem.clone(), url.clone()).build()?;
+        let created = t.create().with_columns(get_default_schema().columns().unwrap_or_default()).await?;
+        created
+            .set_tbl_properties()
+            .with_properties(std::collections::HashMap::from([("delta.checkpointInterval".to_string(), "50".to_string())]))
+            .await?;
+
+        let mut loaded = DeltaTableBuilder::from_url(url.clone())?.with_storage_backend(mem.clone(), url.clone()).load().await?;
+        let materialized_on_load = loaded.state.as_ref().unwrap().has_materialized_files();
+        // Tier A must leave the state materialized regardless of how it loaded.
+        let log_store = loaded.log_store();
+        loaded.state.as_mut().unwrap().ensure_materialized_files(log_store.as_ref()).await?;
+        assert!(loaded.state.as_ref().unwrap().has_materialized_files(), "ensure_materialized_files must materialize after a full load");
+        eprintln!("FULL_LOAD_MATERIALIZED_ON_LOAD={materialized_on_load}");
+        Ok(())
+    }
+
     /// Round-trip: persist a snapshot, restore it into a fresh unloaded
     /// handle, and incrementally catch up to a commit made after the persist.
     /// This is exactly the boot path — restore at version V, replay > V.
@@ -119,6 +172,20 @@ mod tests {
         restored.state = Some(state);
         restored.update_state().await?;
         assert_eq!(restored.version(), Some(1), "restored snapshot must incrementally reach the latest commit");
+
+        // The fork persists the materialized file list (MaterializedFilesWire),
+        // so a restored snapshot must come back materialized and STAY that way
+        // across updates — otherwise post-commit updates fall back to a full
+        // checkpoint replay (the 2-8s/flush prod cost). Guard the whole chain:
+        // ensure (idempotent) → update (incremental) → reconcile rebuild.
+        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "restored snapshot must come back materialized");
+        let log_store = restored.log_store();
+        restored.state.as_mut().unwrap().ensure_materialized_files(log_store.as_ref()).await?;
+        restored.update_state().await?;
+        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "materialization must survive update (stays incremental)");
+        let log_store = restored.log_store();
+        restored.state.as_mut().unwrap().rematerialize_files(log_store.as_ref()).await?;
+        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "rematerialize_files keeps the file list materialized");
 
         // Wrong table url (or hash collision) must miss, not mis-restore.
         assert!(load(dir.path(), "memory:///other_tbl").is_none());

--- a/src/snapshot_cache.rs
+++ b/src/snapshot_cache.rs
@@ -141,7 +141,10 @@ mod tests {
         // Tier A must leave the state materialized regardless of how it loaded.
         let log_store = loaded.log_store();
         loaded.state.as_mut().unwrap().ensure_materialized_files(log_store.as_ref()).await?;
-        assert!(loaded.state.as_ref().unwrap().has_materialized_files(), "ensure_materialized_files must materialize after a full load");
+        assert!(
+            loaded.state.as_ref().unwrap().has_materialized_files(),
+            "ensure_materialized_files must materialize after a full load"
+        );
         eprintln!("FULL_LOAD_MATERIALIZED_ON_LOAD={materialized_on_load}");
         Ok(())
     }
@@ -178,14 +181,23 @@ mod tests {
         // across updates — otherwise post-commit updates fall back to a full
         // checkpoint replay (the 2-8s/flush prod cost). Guard the whole chain:
         // ensure (idempotent) → update (incremental) → reconcile rebuild.
-        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "restored snapshot must come back materialized");
+        assert!(
+            restored.state.as_ref().unwrap().has_materialized_files(),
+            "restored snapshot must come back materialized"
+        );
         let log_store = restored.log_store();
         restored.state.as_mut().unwrap().ensure_materialized_files(log_store.as_ref()).await?;
         restored.update_state().await?;
-        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "materialization must survive update (stays incremental)");
+        assert!(
+            restored.state.as_ref().unwrap().has_materialized_files(),
+            "materialization must survive update (stays incremental)"
+        );
         let log_store = restored.log_store();
         restored.state.as_mut().unwrap().rematerialize_files(log_store.as_ref()).await?;
-        assert!(restored.state.as_ref().unwrap().has_materialized_files(), "rematerialize_files keeps the file list materialized");
+        assert!(
+            restored.state.as_ref().unwrap().has_materialized_files(),
+            "rematerialize_files keeps the file list materialized"
+        );
 
         // Wrong table url (or hash collision) must miss, not mis-restore.
         assert!(load(dir.path(), "memory:///other_tbl").is_none());

--- a/tests/e2e/staged_commit.rs
+++ b/tests/e2e/staged_commit.rs
@@ -81,11 +81,8 @@ async fn concurrent_unified_table_staging_loses_nothing() -> anyhow::Result<()> 
         let db = env.db().clone();
         handles.push(tokio::spawn(async move {
             for i in 0..per {
-                let batch = timefusion::test_utils::test_helpers::json_to_batch(vec![timefusion::test_utils::test_helpers::test_span(
-                    &format!("{p}-{i}"),
-                    "span",
-                    p,
-                )])?;
+                let batch =
+                    timefusion::test_utils::test_helpers::json_to_batch(vec![timefusion::test_utils::test_helpers::test_span(&format!("{p}-{i}"), "span", p)])?;
                 // skip_queue=true → straight to the staged commit path, bypassing MemBuffer.
                 db.insert_records_batch(p, "otel_logs_and_spans", vec![batch], true, None).await?;
             }


### PR DESCRIPTION
## Why

Every flush commit re-materialized the **entire** active file set into fresh Arrow batches — O(active files), ~2–8s on the 26k-file prod table (`ScanMetadataCompleted scan_type=full add_files_seen=26056` on every `flush_completed_buckets` span). The incremental update path still re-streams all existing file rows through the kernel and re-collects them.

## What

Use the delta-rs fork's append-only fast advance (**tonyalaribe/delta-rs-timefusion#1**, pinned rev `3b0468b2`): for an append-only commit, carry the existing materialized batches forward and scan only the files the commit added — **O(files added)** instead of O(active files).

All behind **`TIMEFUSION_INCREMENTAL_SNAPSHOT`** (default **on**, instant rollback via env):
- flush commits set `CommitProperties::with_fast_append_advance(true)`; the fork's post-commit hook takes the fast path only for append-only commits (no `Remove` actions), falling back to the full update otherwise
- materialize the file list once on load so the fast-path seed always exists
- **reconcile** every Nth commit (`TIMEFUSION_SNAPSHOT_RECONCILE_COMMITS`, default 500) rebuilds from object-store truth — run **detached, off the flush path** (never blocks the WAL cursor, never perturbs `added`/the persisted snapshot, version-guarded so it can't regress) and **offset per table** so uniform-rate tables don't rebuild in lockstep

## Correctness & validation

- Fork tests: `advance_append_matches_full_update` (byte-identical file set vs full update) and `fast_advance_falls_back_when_commit_removes_files` (Overwrite under the flag drops removed files).
- TF: snapshot_cache unit tests + `database::tests` against MinIO pass (the one `test_batch_queue_under_load` timeout reproduces identically with the flag off — pre-existing/environmental).

## Merge order

Merge **tonyalaribe/delta-rs-timefusion#1** first; this PR pins its commit `3b0468b2`. The cost win (vs correctness, which is proven) is intended to be confirmed in prod via the flag.