### PR TITLE
perf(write): incremental append-only catch-up in refresh_table_snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           components: rustfmt
       - run: cargo +nightly fmt --all --check
+      # NOTE: a former step here grepped vendor/datafusion-postgres for the
+      # `was_pre_optimized` optimize-skip patch. That crate is now a git dep
+      # ([patch.crates-io] in Cargo.toml → apitoolkit/datafusion-postgres@timefusion-df54),
+      # so the grep targeted a deleted path and failed every run. The
+      # optimize-skip behavioral contract is consequently NOT CI-guarded: if a
+      # branch bump drops the patch, extended queries silently double-optimize.
+      # Verify the patch on every datafusion-postgres rev bump (see plan_cache.rs);
+      # a round-trip "no double state.optimize()" smoke test would re-add a guard.
 
   # Combined clippy + test. `cargo clippy` implies `cargo check`, and both
   # share ~all artifacts with `cargo test` — running them in one job lets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,6 @@ jobs:
         with:
           components: rustfmt
       - run: cargo +nightly fmt --all --check
-      # Sentinel: fail the build if a future `cargo vendor` / manual resync
-      # silently reverts the vendored datafusion-postgres patches that
-      # power the per-query optimize skip. See PATCHES.md for the recipe.
-      - name: vendor patches still applied
-        run: |
-          set -euo pipefail
-          grep -q 'was_pre_optimized' vendor/datafusion-postgres/src/hooks/mod.rs \
-            || { echo "vendored hooks/mod.rs lost was_pre_optimized — see vendor/datafusion-postgres/PATCHES.md"; exit 1; }
-          grep -q 'was_pre_optimized' vendor/datafusion-postgres/src/handlers.rs \
-            || { echo "vendored handlers.rs lost the optimize-skip patch — see vendor/datafusion-postgres/PATCHES.md"; exit 1; }
 
   # Combined clippy + test. `cargo clippy` implies `cargo check`, and both
   # share ~all artifacts with `cargo test` — running them in one job lets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=3b0468b2ff674f821dfaeaf19a2d47af21ada77c#3b0468b2ff674f821dfaeaf19a2d47af21ada77c"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "3b0468b2ff674f821dfaeaf19a2d47af21ada77c", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "0752b7eab70899d833b6fb4b3735953c14a872b1", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,13 +42,6 @@ pub fn config() -> &'static AppConfig {
     CONFIG.get().expect("Config not initialized. Call init_config() first.")
 }
 
-/// Global config if initialized. Unlike [`config`] this never panics, for the
-/// few call sites reachable before/without `init_config` (e.g. the E2E harness,
-/// which wires a `Database` directly without setting the global singleton).
-pub fn try_config() -> Option<&'static AppConfig> {
-    CONFIG.get()
-}
-
 /// Whether the operator has opted into open auth for local dev via
 /// `TIMEFUSION_ALLOW_INSECURE_AUTH=true`. Both the pgwire and gRPC auth
 /// paths gate their fail-secure defaults on this flag.

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,13 @@ pub fn config() -> &'static AppConfig {
     CONFIG.get().expect("Config not initialized. Call init_config() first.")
 }
 
+/// Global config if initialized. Unlike [`config`] this never panics, for the
+/// few call sites reachable before/without `init_config` (e.g. the E2E harness,
+/// which wires a `Database` directly without setting the global singleton).
+pub fn try_config() -> Option<&'static AppConfig> {
+    CONFIG.get()
+}
+
 /// Whether the operator has opted into open auth for local dev via
 /// `TIMEFUSION_ALLOW_INSECURE_AUTH=true`. Both the pgwire and gRPC auth
 /// paths gate their fail-secure defaults on this flag.

--- a/src/database.rs
+++ b/src/database.rs
@@ -254,7 +254,12 @@ pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>, incr
     // files instead of re-collecting the whole active set — the O(active files)
     // re-materialize `update_state` pays (2-8s on the 26k-file unified table).
     // Falls back to the full update when not applicable (removes in range, gap
-    // too large, not materialized).
+    // too large, not materialized). The fallback path is slightly *more*
+    // expensive than a bare update_state — it pays advance_appends_only's
+    // probe (one get_latest_version + cached commit GETs) before the full
+    // update_state's uncached `_delta_log` LIST + re-materialize. That recurs
+    // on the first refresh after each compaction (light-optimize removes files
+    // every ~5 min); acceptable since the common append-only case is the win.
     let advanced = if incremental {
         let log_store = fresh.log_store();
         match fresh.state.as_mut() {

--- a/src/database.rs
+++ b/src/database.rs
@@ -230,7 +230,7 @@ const REFRESH_APPEND_CATCHUP_MAX_GAP: u64 = 64;
 /// may have advanced the shared handle past our clone — never regress it.
 /// Returns the shared handle's version after the refresh. Single choke-point
 /// for snapshot refreshes so the lock discipline can't drift between sites.
-pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>) -> std::result::Result<Option<u64>, deltalake::DeltaTableError> {
+pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>, incremental: bool) -> std::result::Result<Option<u64>, deltalake::DeltaTableError> {
     // Staleness probe before the expensive path: commit files are immutable
     // and versions are contiguous, so the snapshot is current iff
     // `{version+1}.json` doesn't exist — one GET/404 instead of the
@@ -249,15 +249,12 @@ pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>) -> s
         }
     }
     let mut fresh = table.read().await.clone();
-    // Fast path: when incremental snapshots are on and the catch-up range is
-    // append-only, advance by appending the new files instead of re-collecting
-    // the whole active set — the O(active files) re-materialize `update_state`
-    // pays (2-8s on the 26k-file unified table). Falls back to the full update
-    // when not applicable (removes in range, gap too large, not materialized).
-    // try_config (not config()) — refresh runs in the E2E harness too, which
-    // wires a Database without the global singleton; default to the flag's
-    // default (on) when unset.
-    let incremental = crate::config::try_config().is_none_or(|c| c.maintenance.timefusion_incremental_snapshot);
+    // Fast path (gated by the caller's `incremental` flag, i.e. self.config):
+    // when the catch-up range is append-only, advance by appending the new
+    // files instead of re-collecting the whole active set — the O(active files)
+    // re-materialize `update_state` pays (2-8s on the 26k-file unified table).
+    // Falls back to the full update when not applicable (removes in range, gap
+    // too large, not materialized).
     let advanced = if incremental {
         let log_store = fresh.log_store();
         match fresh.state.as_mut() {
@@ -982,7 +979,7 @@ impl Database {
         const MAX_RETRIES: u32 = 5;
 
         loop {
-            match refresh_table_snapshot(table).await {
+            match refresh_table_snapshot(table, self.config.maintenance.timefusion_incremental_snapshot).await {
                 Ok(version) => {
                     if let Some(version) = version {
                         debug!("Updated table for {}/{} to version {}", project_id, table_name, version);
@@ -2287,7 +2284,7 @@ impl Database {
             Ok(r) => r,
             Err(_) => return Ok(Vec::new()),
         };
-        let _ = refresh_table_snapshot(&table_ref).await;
+        let _ = refresh_table_snapshot(&table_ref, self.config.maintenance.timefusion_incremental_snapshot).await;
         let uris: Vec<String> = table_ref.read().await.get_file_uris()?.collect();
         Ok(uris)
     }
@@ -2933,7 +2930,7 @@ impl Database {
                 // GET that 404-short-circuits when already current), so the extra
                 // lock-hold is sub-millisecond on the common path.
                 let commit_guard = self.delta_commit_lock.lock().await;
-                if let Err(e) = refresh_table_snapshot(&table_ref).await {
+                if let Err(e) = refresh_table_snapshot(&table_ref, self.config.maintenance.timefusion_incremental_snapshot).await {
                     debug!("pre-commit refresh failed (attempt {}): {}", retry_count + 1, e);
                 }
                 let mut new_table = { table_ref.read().await.clone() };
@@ -2976,7 +2973,7 @@ impl Database {
         let mut retry_count = 0;
         let mut last_error = None;
         while retry_count < max_retries {
-            if let Err(e) = refresh_table_snapshot(&table_ref).await {
+            if let Err(e) = refresh_table_snapshot(&table_ref, self.config.maintenance.timefusion_incremental_snapshot).await {
                 debug!("Failed to update table state before write (attempt {}): {}", retry_count + 1, e);
             }
             let commit_guard = self.delta_commit_lock.lock().await;
@@ -3019,7 +3016,7 @@ impl Database {
                         drop(commit_guard);
                         tokio::time::sleep(retry_backoff(retry_count)).await;
                         drop(table); // stale clone — the retry re-clones after the reload
-                        if let Err(reload_err) = refresh_table_snapshot(&table_ref).await {
+                        if let Err(reload_err) = refresh_table_snapshot(&table_ref, self.config.maintenance.timefusion_incremental_snapshot).await {
                             debug!("Failed to reload table state after conflict: {}", reload_err);
                         }
                     } else {
@@ -3989,7 +3986,7 @@ impl Database {
                 }
 
                 // Update the table state after vacuum
-                if refresh_table_snapshot(table_ref).await.is_ok() {
+                if refresh_table_snapshot(table_ref, self.config.maintenance.timefusion_incremental_snapshot).await.is_ok() {
                     info!("Table state updated after vacuum");
                 } else {
                     error!("Failed to update table state after vacuum");
@@ -5657,7 +5654,7 @@ mod tests {
 
         let refresher = {
             let shared = Arc::clone(&shared);
-            tokio::spawn(async move { refresh_table_snapshot(&shared).await })
+            tokio::spawn(async move { refresh_table_snapshot(&shared, true).await })
         };
 
         // Sample read-lock acquisition latency while the refresh is in flight.
@@ -5747,13 +5744,13 @@ mod tests {
         let shared = Arc::new(RwLock::new(slow));
 
         let t0 = std::time::Instant::now();
-        assert_eq!(refresh_table_snapshot(&shared).await.map_err(|e| anyhow::anyhow!(e))?, Some(0));
+        assert_eq!(refresh_table_snapshot(&shared, true).await.map_err(|e| anyhow::anyhow!(e))?, Some(0));
         assert!(t0.elapsed() < list_wait, "current-table refresh paid a LIST ({:?})", t0.elapsed());
 
         // External commit → the probe finds {v+1}.json and the refresh must
         // run the full update to pick it up.
         let _ = ensure_table_properties(table, HashMap::from([("delta.checkpointInterval".to_string(), "50".to_string())])).await;
-        assert_eq!(refresh_table_snapshot(&shared).await.map_err(|e| anyhow::anyhow!(e))?, Some(1));
+        assert_eq!(refresh_table_snapshot(&shared, true).await.map_err(|e| anyhow::anyhow!(e))?, Some(1));
         Ok(())
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -214,6 +214,11 @@ fn should_refresh_table(current_version: Option<u64>, last_written_version: Opti
     }
 }
 
+/// Max commits behind for the append-only fast catch-up in `refresh_table_snapshot`:
+/// each commit in the range costs one log read for the Remove check, so cap it
+/// and let larger gaps take the single full re-materialize instead.
+const REFRESH_APPEND_CATCHUP_MAX_GAP: u64 = 64;
+
 /// Refresh `table`'s snapshot WITHOUT holding the write lock across
 /// `update_state()` — that's a full Delta log replay plus object-store IO
 /// (1s+ per refresh on prod's 40k-action log), and every query refreshes
@@ -244,7 +249,36 @@ pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>) -> s
         }
     }
     let mut fresh = table.read().await.clone();
-    fresh.update_state().await?;
+    // Fast path: when incremental snapshots are on and the catch-up range is
+    // append-only, advance by appending the new files instead of re-collecting
+    // the whole active set — the O(active files) re-materialize `update_state`
+    // pays (2-8s on the 26k-file unified table). Falls back to the full update
+    // when not applicable (removes in range, gap too large, not materialized).
+    // try_config (not config()) — refresh runs in the E2E harness too, which
+    // wires a Database without the global singleton; default to the flag's
+    // default (on) when unset.
+    let incremental = crate::config::try_config().is_none_or(|c| c.maintenance.timefusion_incremental_snapshot);
+    let advanced = if incremental {
+        let log_store = fresh.log_store();
+        match fresh.state.as_mut() {
+            Some(state) => match state.advance_appends_only(log_store.as_ref(), REFRESH_APPEND_CATCHUP_MAX_GAP).await {
+                Ok(advanced) => advanced,
+                // Non-fatal: the full update_state below re-attempts the same IO
+                // and surfaces any persistent error; log so a table silently
+                // never taking the fast path is at least visible.
+                Err(e) => {
+                    debug!("append-only catch-up failed, falling back to full update_state: {e}");
+                    false
+                }
+            },
+            None => false,
+        }
+    } else {
+        false
+    };
+    if !advanced {
+        fresh.update_state().await?;
+    }
     let fresh_version = fresh.version();
     let mut guard = table.write().await;
     // Option<u64> ordering: None < Some(_), so an unloaded handle always swaps.

--- a/src/plan_cache.rs
+++ b/src/plan_cache.rs
@@ -260,16 +260,17 @@ async fn try_fast_path_insert(plan: &LogicalPlan, session_context: &SessionConte
     Ok(Some(rows))
 }
 
-/// Mirror of the vendored `datafusion_postgres::handlers::dml_completion`,
+/// Mirror of `datafusion_postgres::handlers::dml_completion`,
 /// which is `pub(super)` and so unreachable from outside the crate.
 ///
-/// **Re-vendor checklist.** When bumping the vendored `datafusion-postgres`,
-/// diff `vendored handlers.rs::dml_completion` against this implementation —
-/// upstream changes to the tag format ("INSERT 0 N" oid + count), the
-/// `count` column name, or the count column's Arrow type are silent
+/// **Re-sync checklist.** When bumping the patched `datafusion-postgres` git dep
+/// (apitoolkit/datafusion-postgres @ `timefusion-df54`, see the `[patch.crates-io]`
+/// in Cargo.toml), diff its `handlers.rs::dml_completion` against this
+/// implementation — upstream changes to the tag format ("INSERT 0 N" oid +
+/// count), the `count` column name, or the count column's Arrow type are silent
 /// divergence here (no compile error, wrong wire response). Search for the
-/// `RE-VENDOR-DML-COMPLETION` marker below and confirm parity.
-// RE-VENDOR-DML-COMPLETION: keep in sync with vendor/datafusion-postgres/src/handlers.rs.
+/// `RE-SYNC-DML-COMPLETION` marker below and confirm parity.
+// RE-SYNC-DML-COMPLETION: keep in sync with apitoolkit/datafusion-postgres@timefusion-df54 src/handlers.rs.
 async fn dml_completion(df: datafusion::dataframe::DataFrame) -> PgWireResult<Option<Response>> {
     let tag = match df.logical_plan() {
         LogicalPlan::Dml(d) => match d.op {
@@ -373,8 +374,8 @@ impl QueryHook for PlanCacheHook {
     /// canonical text would never produce a hit. The vendored
     /// datafusion-postgres `SimpleQueryHandler::do_query` still runs
     /// `state.optimize()` per call because `was_pre_optimized` returns false
-    /// for canonical SQL not present in our cache — see
-    /// `vendor/datafusion-postgres/PATCHES.md`.
+    /// for canonical SQL not present in our cache — see the optimize-skip patch
+    /// on apitoolkit/datafusion-postgres@timefusion-df54.
     async fn handle_simple_query(
         &self, _statement: &Statement, _session_context: &SessionContext, _client: &mut dyn HookClient,
     ) -> Option<PgWireResult<Response>> {
@@ -416,9 +417,9 @@ impl QueryHook for PlanCacheHook {
         let plan = crate::insert_coerce::rewrite_plan(plan);
         // Pre-optimize at cache-miss time, not per-query. With OLAP traffic
         // (one-time plan build, millions of executions) this turns a per-
-        // query 30ms cost into a one-time amortization. Vendored
-        // datafusion-postgres skips its `state.optimize()` call when the
-        // hook returns Some — see `vendor/datafusion-postgres/src/handlers.rs`.
+        // query 30ms cost into a one-time amortization. The patched
+        // datafusion-postgres skips its `state.optimize()` call when the hook
+        // returns Some — see apitoolkit/datafusion-postgres@timefusion-df54 src/handlers.rs.
         // The plan still goes through `replace_params_with_values` at exec
         // time, but optimization rules that aren't constant-fold are
         // parameter-independent and stay valid across all bound values.


### PR DESCRIPTION
## Why

After the post-commit fast advance (#75) shipped, prod still showed `scan_type=full, add_files_seen=26120, 2–4s` on most `flush_completed_buckets` spans. Span attribution traced it to the **pre-commit** `refresh_table_snapshot → update_state`: when the unified multi-tenant table is behind (it usually is — every tenant's flush advances it), `update_state` re-collects the *entire* active file set (`scan_metadata_from` re-shapes and re-processes all 26k existing rows). That's the same O(active-files) cost the post-commit hook now avoids — it just also lived in the refresh path.

## What

Try an **append-only fast catch-up** before the full re-materialize (fork `advance_appends_only`, rev `0752b7ea`):
- verify the range since our version is append-only — one bounded log read per commit to check for `Remove` actions;
- if so, carry the materialized file list forward and append just the delta (via `advance_append`), O(files added) instead of O(active files);
- **fall back** to the full `update_state` when the range carries removes (optimize/dedup), the gap exceeds `REFRESH_APPEND_CATCHUP_MAX_GAP` (64 commits), or the snapshot isn't materialized.

Gated by `TIMEFUSION_INCREMENTAL_SNAPSHOT` (same flag, default on, instant rollback).

## Correctness

Fork test `advance_appends_only_catches_up_and_guards_removes`: an append-only catch-up matches a full `update` **byte-for-byte**; a range containing an Overwrite (Removes) **refuses** the fast path (returns false → caller does the full reconcile). The removes-guard makes it correct by construction — removes can never be silently dropped.

## Merge order

Requires **tonyalaribe/delta-rs-timefusion#1** (pins its commit `0752b7ea`). Builds clean against it now.