### PR TITLE
perf(write): remove-aware incremental snapshot advance (Tier C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -6037,7 +6037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -6058,7 +6058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9285,7 +9285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=0752b7eab70899d833b6fb4b3735953c14a872b1#0752b7eab70899d833b6fb4b3735953c14a872b1"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=68bdbcf318dbd6d798db6b20f4aadf7c8de2497a#68bdbcf318dbd6d798db6b20f4aadf7c8de2497a"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -6037,7 +6037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -6058,7 +6058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9285,7 +9285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "68bdbcf318dbd6d798db6b20f4aadf7c8de2497a", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "dc6d24c3ce8f3f605443f612eb1caddad145b510", features = [
   "datafusion",
   "s3",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "0752b7eab70899d833b6fb4b3735953c14a872b1", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "68bdbcf318dbd6d798db6b20f4aadf7c8de2497a", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -250,20 +250,21 @@ pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>, incr
     }
     let mut fresh = table.read().await.clone();
     // Fast path (gated by the caller's `incremental` flag, i.e. self.config):
-    // when the catch-up range is append-only, advance by appending the new
-    // files instead of re-collecting the whole active set — the O(active files)
-    // re-materialize `update_state` pays (2-8s on the 26k-file unified table).
-    // Falls back to the full update when not applicable (removes in range, gap
-    // too large, not materialized). The fallback path is slightly *more*
-    // expensive than a bare update_state — it pays advance_appends_only's
-    // probe (one get_latest_version + cached commit GETs) before the full
-    // update_state's uncached `_delta_log` LIST + re-materialize. That recurs
-    // on the first refresh after each compaction (light-optimize removes files
-    // every ~5 min); acceptable since the common append-only case is the win.
+    // carry the materialized file list forward over the catch-up range —
+    // appending the new files and dropping the tombstoned ones (compaction /
+    // replace_where) — instead of re-collecting the whole active set, the
+    // O(active files) re-materialize `update_state` pays (2-8s on the 26k-file
+    // unified table). Falls back to the full update when not applicable (gap
+    // too large, not materialized, unreadable commit). The fallback path is
+    // slightly *more* expensive than a bare update_state — it pays
+    // advance_catchup's probe (one get_latest_version + cached commit GETs)
+    // before the full update_state's uncached `_delta_log` LIST + re-materialize
+    // — but the common case (in-gap, materialized) is always the win now that
+    // removes no longer force the fallback.
     let advanced = if incremental {
         let log_store = fresh.log_store();
         match fresh.state.as_mut() {
-            Some(state) => match state.advance_appends_only(log_store.as_ref(), REFRESH_APPEND_CATCHUP_MAX_GAP).await {
+            Some(state) => match state.advance_catchup(log_store.as_ref(), REFRESH_APPEND_CATCHUP_MAX_GAP).await {
                 Ok(advanced) => advanced,
                 // Non-fatal: the full update_state below re-attempts the same IO
                 // and surfaces any persistent error; log so a table silently
@@ -2826,17 +2827,15 @@ impl Database {
 
         // Hoist out of the retry loop — the watermark is the same on every attempt.
         let commit_properties = watermark.map(build_watermark_commit_properties);
-        // Let the post-commit hook advance the snapshot by appending the
-        // committed files instead of re-materializing the whole active set.
-        // Applied to both the staged (pure-append) and schema-evolution merge
-        // paths: the hook takes the fast path only when the commit has no Remove
-        // actions, so it can never drop files. A schema-evolution commit
-        // (MetaData + Add, no Remove) is still safe — the hook rebuilds the
-        // kernel snapshot from the log, so the MetaData/schema change IS applied;
-        // only the file-list re-materialization is skipped. Removes (overwrite/
-        // delete) fall back to the full update.
+        // Let the post-commit hook advance the snapshot incrementally — carry
+        // the materialized file list forward, append the committed files, drop
+        // any removed ones — instead of re-materializing the whole active set.
+        // Safe for the staged (pure-append) and schema-evolution merge paths
+        // alike: the hook rebuilds the kernel snapshot from the log, so a
+        // MetaData/schema change IS applied; only the file-list re-materialize
+        // is skipped.
         let commit_properties = if self.config.maintenance.timefusion_incremental_snapshot {
-            Some(commit_properties.unwrap_or_default().with_fast_append_advance(true))
+            Some(commit_properties.unwrap_or_default().with_incremental_advance(true))
         } else {
             commit_properties
         };
@@ -3292,6 +3291,7 @@ impl Database {
             .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
             .with_writer_properties(writer_properties)
             .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
+            .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
             // Avoid the BinaryView read for Variant columns (same issue as
             // optimize_table_light); delta-rs's internal session defaults to
             // schema_force_view_types=true.
@@ -3503,6 +3503,7 @@ impl Database {
             .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
             .with_writer_properties(writer_properties)
             .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
+            .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
             .with_session_state(Arc::new(build_optimize_session_state(self.config.memory.timefusion_query_partitions)))
             .await;
 
@@ -3718,13 +3719,21 @@ impl Database {
                     table.clone()
                 };
                 let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
-                let result = table_clone
+                // Apply this replace_where's Add+Remove to the materialized
+                // snapshot incrementally (drop tombstoned paths, append new)
+                // instead of the post-commit hook re-materializing all active
+                // files — the 2-8s/commit full scan on the 26k-file unified
+                // table that the dedup sweep otherwise pays under the commit lock.
+                let mut write = table_clone
                     .write(deduped.clone())
                     .with_partition_columns(schema.partitions.clone())
                     .with_writer_properties(writer_properties.clone())
                     .with_save_mode(deltalake::protocol::SaveMode::Overwrite)
-                    .with_replace_where(predicate.clone())
-                    .await;
+                    .with_replace_where(predicate.clone());
+                if self.config.maintenance.timefusion_incremental_snapshot {
+                    write = write.with_commit_properties(CommitProperties::default().with_incremental_advance(true));
+                }
+                let result = write.await;
                 match result {
                     Ok(new_table) => {
                         // Swap + warm-added/evict-removed exactly like the optimize
@@ -3891,6 +3900,10 @@ impl Database {
                 .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
                 .with_writer_properties(writer_properties.clone())
                 .with_min_commit_interval(tokio::time::Duration::from_secs(30))
+                // Apply the compaction's Add+Remove to the materialized snapshot
+                // incrementally rather than re-materializing all active files in
+                // the post-commit hook (see the dedup path).
+                .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
                 // Variant columns are stored as Struct{Binary, Binary} on disk; if
                 // the optimize-internal Parquet read uses `schema_force_view_types=true`
                 // (delta-rs's default), it returns BinaryView and the rewrite blows up
@@ -5680,6 +5693,71 @@ mod tests {
             max_wait < wait / 2,
             "readers stalled {max_wait:?} behind an in-flight refresh (refresh took {refresh_took:?}) — write lock is being held across update_state"
         );
+        Ok(())
+    }
+
+    /// Tier-C correctness guard: advancing a materialized snapshot incrementally
+    /// across a `replace_where` (Add + Remove) must yield exactly the active
+    /// file set a full re-materialize produces. This is the path the
+    /// dedup/compaction sweeps take (`with_incremental_advance`) and that
+    /// `refresh_table_snapshot(.., true)` → `advance_catchup` takes on catch-up.
+    /// Drift here silently corrupts query results — by keeping a tombstoned file
+    /// or dropping a live one — so it must be pinned in this repo, not only in
+    /// the fork's EagerSnapshot tests.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn refresh_incremental_matches_full_across_removes() -> Result<()> {
+        use datafusion::arrow::{
+            array::{Int32Array, RecordBatch, StringArray},
+            datatypes::{DataType as ArrowDataType, Field, Schema},
+        };
+        use deltalake::kernel::{DataType, PrimitiveType, StructField};
+        use deltalake::protocol::SaveMode;
+
+        let mem = Arc::new(object_store::memory::InMemory::new());
+        let url = Url::parse("memory:///tierc_removes")?;
+        let backend = || DeltaTableBuilder::from_url(url.clone()).unwrap().with_storage_backend(mem.clone(), url.clone());
+
+        // v0: partitioned table.
+        let cols = vec![
+            StructField::new("id", DataType::Primitive(PrimitiveType::Integer), true),
+            StructField::new("p", DataType::Primitive(PrimitiveType::String), true),
+        ];
+        let table = backend().build()?.create().with_columns(cols).with_partition_columns(["p".to_string()]).await?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", ArrowDataType::Int32, true), Field::new("p", ArrowDataType::Utf8, true)]));
+        let batch = |ids: Vec<i32>, ps: Vec<&str>| {
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(ids)) as _, Arc::new(StringArray::from(ps)) as _]).unwrap()
+        };
+
+        // v1: append p=a, v2: append p=b (two partition files). These plain writes
+        // set no incremental flag, so the returned `table` is the authoritative
+        // full re-materialize at every step.
+        let table = table.write(vec![batch(vec![1, 2], vec!["a", "a"])]).with_save_mode(SaveMode::Append).await?;
+        let table = table.write(vec![batch(vec![3], vec!["b"])]).with_save_mode(SaveMode::Append).await?;
+        assert_eq!(table.version(), Some(2));
+
+        // v3: replace_where p=a → tombstones v1's file, adds a new one (Add + Remove).
+        let table = table
+            .write(vec![batch(vec![10, 11], vec!["a", "a"])])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("p = 'a'")
+            .await?;
+        assert_eq!(table.version(), Some(3));
+
+        let uris = |t: &DeltaTable| t.get_file_uris().map(|it| it.collect::<std::collections::HashSet<String>>()).unwrap_or_default();
+        let truth = uris(&table); // authoritative v3 set (full re-materialize)
+        assert_eq!(truth.len(), 2, "v3 active set = p=b file + replaced p=a file");
+
+        // Stale handle pinned at v2, advanced to v3 via the Tier-C incremental
+        // path (refresh_table_snapshot → advance_catchup over the replace_where).
+        let stale = backend().with_version(2).load().await?;
+        assert!(stale.state.as_ref().is_some_and(|s| s.has_materialized_files()), "stale handle must be materialized to exercise the fast path");
+        let shared = Arc::new(RwLock::new(stale));
+        refresh_table_snapshot(&shared, true).await?;
+
+        let advanced = shared.read().await;
+        assert_eq!(advanced.version(), Some(3), "incremental catch-up reached the latest version");
+        assert_eq!(uris(&advanced), truth, "incremental advance across replace_where must equal the full re-materialize");
         Ok(())
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -270,7 +270,7 @@ pub(crate) async fn refresh_table_snapshot(table: &Arc<RwLock<DeltaTable>>, incr
                 // and surfaces any persistent error; log so a table silently
                 // never taking the fast path is at least visible.
                 Err(e) => {
-                    debug!("append-only catch-up failed, falling back to full update_state: {e}");
+                    debug!("incremental catch-up failed, falling back to full update_state: {e}");
                     false
                 }
             },
@@ -559,6 +559,14 @@ fn build_watermark_commit_properties(watermark: &crate::buffered_write_layer::De
     let mut meta = std::collections::HashMap::new();
     meta.insert(WAL_WATERMARK_KEY.to_string(), serde_json::Value::Object(entries));
     CommitProperties::default().with_metadata(meta)
+}
+
+/// `CommitProperties` for a compaction/dedup commit (Add + Remove): when
+/// `enabled`, the post-commit hook advances the materialized snapshot
+/// incrementally instead of re-materializing every active file. `false` is the
+/// plain full-update behaviour.
+fn incremental_commit_properties(enabled: bool) -> CommitProperties {
+    CommitProperties::default().with_incremental_advance(enabled)
 }
 
 /// write. No-op for any column that's not a Variant struct or already in
@@ -3291,7 +3299,7 @@ impl Database {
             .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
             .with_writer_properties(writer_properties)
             .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
-            .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
+            .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
             // Avoid the BinaryView read for Variant columns (same issue as
             // optimize_table_light); delta-rs's internal session defaults to
             // schema_force_view_types=true.
@@ -3503,7 +3511,7 @@ impl Database {
             .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
             .with_writer_properties(writer_properties)
             .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
-            .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
+            .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
             .with_session_state(Arc::new(build_optimize_session_state(self.config.memory.timefusion_query_partitions)))
             .await;
 
@@ -3724,16 +3732,14 @@ impl Database {
                 // instead of the post-commit hook re-materializing all active
                 // files — the 2-8s/commit full scan on the 26k-file unified
                 // table that the dedup sweep otherwise pays under the commit lock.
-                let mut write = table_clone
+                let result = table_clone
                     .write(deduped.clone())
                     .with_partition_columns(schema.partitions.clone())
                     .with_writer_properties(writer_properties.clone())
                     .with_save_mode(deltalake::protocol::SaveMode::Overwrite)
-                    .with_replace_where(predicate.clone());
-                if self.config.maintenance.timefusion_incremental_snapshot {
-                    write = write.with_commit_properties(CommitProperties::default().with_incremental_advance(true));
-                }
-                let result = write.await;
+                    .with_replace_where(predicate.clone())
+                    .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
+                    .await;
                 match result {
                     Ok(new_table) => {
                         // Swap + warm-added/evict-removed exactly like the optimize
@@ -3903,7 +3909,7 @@ impl Database {
                 // Apply the compaction's Add+Remove to the materialized snapshot
                 // incrementally rather than re-materializing all active files in
                 // the post-commit hook (see the dedup path).
-                .with_commit_properties(CommitProperties::default().with_incremental_advance(self.config.maintenance.timefusion_incremental_snapshot))
+                .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
                 // Variant columns are stored as Struct{Binary, Binary} on disk; if
                 // the optimize-internal Parquet read uses `schema_force_view_types=true`
                 // (delta-rs's default), it returns BinaryView and the rewrite blows up
@@ -5753,20 +5759,25 @@ mod tests {
         let truth = uris(&table); // authoritative v3 set (full re-materialize)
         assert_eq!(truth.len(), 2, "v3 active set = p=b file + replaced p=a file");
 
-        // Stale handle pinned at v2, advanced to v3 via the Tier-C incremental
-        // path (refresh_table_snapshot → advance_catchup over the replace_where).
-        let stale = backend().with_version(2).load().await?;
+        // Stale handle pinned at v2. Drive the Tier-C catch-up directly (the
+        // path refresh_table_snapshot takes) and assert it RETURNED TRUE — i.e.
+        // actually took the incremental path across the replace_where, rather
+        // than silently falling back to a full update_state (which would also
+        // produce a correct set and so hide a broken incremental path).
+        let mut stale = backend().with_version(2).load().await?;
         assert!(
             stale.state.as_ref().is_some_and(|s| s.has_materialized_files()),
             "stale handle must be materialized to exercise the fast path"
         );
-        let shared = Arc::new(RwLock::new(stale));
-        refresh_table_snapshot(&shared, true).await?;
-
-        let advanced = shared.read().await;
-        assert_eq!(advanced.version(), Some(3), "incremental catch-up reached the latest version");
+        let log_store = stale.log_store();
+        let took_fast_path = stale.state.as_mut().unwrap().advance_catchup(log_store.as_ref(), REFRESH_APPEND_CATCHUP_MAX_GAP).await?;
+        assert!(
+            took_fast_path,
+            "advance_catchup must take the incremental path over the replace_where, not fall back to a full update"
+        );
+        assert_eq!(stale.version(), Some(3), "incremental catch-up reached the latest version");
         assert_eq!(
-            uris(&advanced),
+            uris(&stale),
             truth,
             "incremental advance across replace_where must equal the full re-materialize"
         );

--- a/src/database.rs
+++ b/src/database.rs
@@ -5710,8 +5710,10 @@ mod tests {
             array::{Int32Array, RecordBatch, StringArray},
             datatypes::{DataType as ArrowDataType, Field, Schema},
         };
-        use deltalake::kernel::{DataType, PrimitiveType, StructField};
-        use deltalake::protocol::SaveMode;
+        use deltalake::{
+            kernel::{DataType, PrimitiveType, StructField},
+            protocol::SaveMode,
+        };
 
         let mem = Arc::new(object_store::memory::InMemory::new());
         let url = Url::parse("memory:///tierc_removes")?;
@@ -5724,7 +5726,10 @@ mod tests {
         ];
         let table = backend().build()?.create().with_columns(cols).with_partition_columns(["p".to_string()]).await?;
 
-        let schema = Arc::new(Schema::new(vec![Field::new("id", ArrowDataType::Int32, true), Field::new("p", ArrowDataType::Utf8, true)]));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", ArrowDataType::Int32, true),
+            Field::new("p", ArrowDataType::Utf8, true),
+        ]));
         let batch = |ids: Vec<i32>, ps: Vec<&str>| {
             RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(ids)) as _, Arc::new(StringArray::from(ps)) as _]).unwrap()
         };
@@ -5751,13 +5756,20 @@ mod tests {
         // Stale handle pinned at v2, advanced to v3 via the Tier-C incremental
         // path (refresh_table_snapshot → advance_catchup over the replace_where).
         let stale = backend().with_version(2).load().await?;
-        assert!(stale.state.as_ref().is_some_and(|s| s.has_materialized_files()), "stale handle must be materialized to exercise the fast path");
+        assert!(
+            stale.state.as_ref().is_some_and(|s| s.has_materialized_files()),
+            "stale handle must be materialized to exercise the fast path"
+        );
         let shared = Arc::new(RwLock::new(stale));
         refresh_table_snapshot(&shared, true).await?;
 
         let advanced = shared.read().await;
         assert_eq!(advanced.version(), Some(3), "incremental catch-up reached the latest version");
-        assert_eq!(uris(&advanced), truth, "incremental advance across replace_where must equal the full re-materialize");
+        assert_eq!(
+            uris(&advanced),
+            truth,
+            "incremental advance across replace_where must equal the full re-materialize"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Tier A/B (PR #76) made the **append** post-commit advance O(files-added). But compaction and dedup **`replace_where`** commits carry `Remove` actions, so their post-commit snapshot refresh still fell back to a full **O(active files)** re-materialize — re-streaming every active file's stats through the kernel scan-metadata visitor.

Prod evidence (live on `d00f40f`): in a 12-min window, **22 full scans of ~26,300 files, 1.8–8.5s each** (`write mode=Overwrite` = the dedup `replace_where` sweep), all serialized under the in-process `delta_commit_lock` that flush appends also take. That's ~15% of wall-clock spent re-materializing the table, and it throttles flush drain whenever ingest spikes (the membuffer backed up to 8.9 GB / 100% pressure / 91h-old buckets before it cleared).

## Fix (Tier C)

Apply a commit's **Add + Remove** to the materialized file list directly instead of re-materializing:
- **Fork** (`tonyalaribe/delta-rs-timefusion` @ `68bdbcf3`): `advance_with_removes` carries the materialized batches forward by Arc-clone, drops tombstoned paths with a **vectorized columnar filter**, and appends only the freshly-scanned added files. `advance_appends_only` → `advance_catchup` (collects removes across the catch-up range). Post-commit flag `fast_append_advance` → `incremental_advance`; the hook reads removed paths straight from the committed actions (no log re-read).
- **TF**: flush/staged commits, the dedup `replace_where`, and all three optimize/compaction commits now set the incremental flag (gated on `TIMEFUSION_INCREMENTAL_SNAPSHOT`). `refresh_table_snapshot(.., true)` uses `advance_catchup`.

Each compaction/dedup commit goes from ~6s → milliseconds, and the commit lock is released far sooner, so flush drain no longer depends on ingest staying quiet.

## Correctness

The whole risk surface is: does the incremental carry-forward produce a **byte-identical active file set** to a full re-materialize, *across Removes*?

- Fork: `incremental_advance_applies_removes`, `advance_catchup_applies_adds_and_removes` (assert incremental == full update over `replace_where`); metadata-change test retained.
- TF: **`refresh_incremental_matches_full_across_removes`** — writes rows, runs a `replace_where` (forces Removes), advances a stale handle via `refresh_table_snapshot(.., true)`, and asserts `get_file_uris()` equals a full re-materialize. ✅ passes locally.

## Validation

- Fork: 47 snapshot tests pass; clippy clean on changed files.
- TF: builds, clippy clean, new test passes. **e2e to be confirmed by CI** (Docker unavailable locally).

## Merge note

Pins the fork to `68bdbcf3` on the `feat/expose-materialize-files` integration branch (consumed by SHA, same pattern as the Tier A/B rev). The temporary local `[patch]` used during iteration has been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)