### PR TITLE
perf(write): eliminate dedup full-table scan + OCC conflict storm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=1de46a01c3a814854e57839896f5c993559e43b1#1de46a01c3a814854e57839896f5c993559e43b1"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=1de46a01c3a814854e57839896f5c993559e43b1#1de46a01c3a814854e57839896f5c993559e43b1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=1de46a01c3a814854e57839896f5c993559e43b1#1de46a01c3a814854e57839896f5c993559e43b1"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=dc6d24c3ce8f3f605443f612eb1caddad145b510#dc6d24c3ce8f3f605443f612eb1caddad145b510"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=1de46a01c3a814854e57839896f5c993559e43b1#1de46a01c3a814854e57839896f5c993559e43b1"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -6037,7 +6037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -6058,7 +6058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9285,7 +9285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "dc6d24c3ce8f3f605443f612eb1caddad145b510", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "1de46a01c3a814854e57839896f5c993559e43b1", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -3717,11 +3717,21 @@ impl Database {
             let mut last_err: Option<deltalake::DeltaTableError> = None;
             let mut committed = false;
             for attempt in 0..MAX_RETRIES {
-                // Clone under the commit lock and hold it through the commit:
-                // with no append able to land in between, the rebase sees no
-                // newer commits and the OCC checker (which errors on our
-                // bare-string timestamp predicate) never runs.
+                // Refresh UNDER the lock before cloning, exactly like the flush
+                // staged-commit path. Holding the lock alone is NOT enough: a
+                // prior committer advances the Delta log but our in-memory
+                // `table_ref` handle lags it, so building the replace_where on
+                // the stale handle commits a base_version behind latest and the
+                // OCC checker rebases — re-running the full file-matching scan
+                // every attempt (the conflicts_checked>0 retry storm seen in
+                // prod). Refreshing here makes base_version == latest, so the
+                // commit lands first-try and the bare-string predicate's OCC
+                // checker never runs. Refresh is probe-cheap (404-short-circuit
+                // when already current).
                 let commit_guard = self.delta_commit_lock.lock().await;
+                if let Err(e) = refresh_table_snapshot(table_ref, self.config.maintenance.timefusion_incremental_snapshot).await {
+                    debug!("dedup pre-commit refresh failed (attempt {}): {}", attempt + 1, e);
+                }
                 let table_clone = {
                     let table = table_ref.read().await;
                     table.clone()


### PR DESCRIPTION
Follow-up to #77 (Tier C). Measured in prod after #77 deployed (`e8bbb64`): the drain didn't improve — the buffer climbed to 100% pressure and inserts backpressured. Investigation showed Tier C optimized the post-commit hook, but the dedup `replace_where` sweep's cost is **upstream** of it, in two compounding places. This PR fixes both.

## Lever 2 — OCC conflict storm (`database.rs`)
The dedup retry loop took `delta_commit_lock` but, unlike the flush staged-commit path, **never refreshed the snapshot under the lock** — so it committed a `base_version` behind latest and delta-rs's OCC checker rebased on *every* attempt (`conflicts_checked=2`, `table updated during transaction` in prod), re-running the full file-matching scan ~7× per commit. Fix: `refresh_table_snapshot` under the lock before cloning, exactly the pattern the flush path already uses → `base_version == latest` → commit lands first try.

## Lever 1 — full-table planning scan (delta-rs fork → rev `1de46a01`)
The dedup `replace_where` predicate compares `Date32 date` / `Timestamp timestamp` columns to **Utf8 string literals** (the bare-string, commit-serializable form). `parse_predicate_expression` doesn't coerce; the row filter gets coerced by physical planning, but the **file-skipping** predicate was converted to a kernel predicate *uncoerced* — so the kernel couldn't evaluate `Date32 <op> Utf8View`, the scan fell open, and it read **all ~26k files** (`predicate_filtered=0`) on every dedup commit.

Fork fix (`find_files.rs` `coerce_skipping_terms`): coerce + const-fold the skipping conjuncts' literals to the column types (`TypeCoercionRewriter` + `ExprSimplifier`) before converting to the kernel predicate, so it prunes to the target `project_id/date` partition. Terms that can't be coerced pass through unchanged.

## Combined effect
Each dedup commit drops from ~7 full-table (26k-file) scans to **one partition-scoped scan**, collapsing the `delta_commit_lock` hold that was starving flush drain.

## Tests
- Fork: `find_files_partition_prunes_with_mixed_string_literal_predicate` — errored (`Date32 <= Utf8View`) before the fix, now asserts the file-matching scan reads only the target partition's data files. 15 find_files + 89 write tests green.
- TF: existing `refresh_incremental_matches_full_across_removes` passes against the new fork rev.

## Prod validation after deploy
`conflicts_checked → 0`, `predicate_filtered > 0`, planning-scan `add_files_seen` drops 26k → one partition, buffer drains.

## Known follow-up
The partition-only path (`scan_memory_table`, used by DELETE/UPDATE with a `Date32`-partition string predicate) isn't coerced yet — latent, not the dedup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)