### PR TITLE
feat(optimize): retry compact_date on transient S3 errors

### DIFF
--- a/docs/plans/2026-06-24-overnight-throughput-report.md
+++ b/docs/plans/2026-06-24-overnight-throughput-report.md
@@ -73,8 +73,38 @@ drain rows/commit. TF-only changes (#3) can lift the ~3000/s ceiling but not to 
   fix it in code than CapRover, I can lower the autotune fractions so the pool sum fits under
   host RAM — say the word.
 
+## ⚠️ URGENT — overnight development (03:28 CEST / 01:28 UTC)
+
+**Prod re-entered the OOM/wedge loop and is actively dropping inserts to the DLQ.**
+
+- One OOM restart ~01:30 UTC (task `hmsa4ktqerxy` → `6xae9b0wdy3x`, `queries_total` reset).
+- Now **wedged at 100% pressure**, `backpressure_rejected_total` climbing fast
+  (158 → 560+ and rising). Logs: `Write backpressure exhausted after 60s: used=9254MB still
+  over hard limit — Delta flush is not freeing memory; rejecting (data remains in WAL)`.
+- The drain **is** committing (18 commits/6min) but **can't free memory**: `total_rows` is
+  flat at ~1.217M and inserts are mostly rejected, yet the buffer stays pinned at the
+  9254 MB hard limit. → memory is held by **buckets that never drain** — the lingering
+  ~99h-old event-time buckets (`oldest_bucket_age_secs=356692`). This is the "lingering
+  buckets / stuck drain" bug (2026-06-22 root-cause #3), now causing a hard wedge.
+- **Not data loss / not a full outage:** rejected inserts remain in the WAL and replay
+  later. It's degraded — DLQ growing, insert latency bad.
+
+**Why I did not act autonomously:** the lingering-bucket drain bug needs real investigation
+(unsafe to fix blind at 3am); a forced restart might clear the wedge *or* re-wedge on replay
+(50/50) and the host is restart-locked. Deploying the memory fix wouldn't unstick *this*
+wedge (it's stuck buckets, not pool sizing) and would add another replay cycle.
+
+**Morning actions (in order):**
+1. **Apply the container-limit + caps config** (table row #1) — gives headroom so the wedge
+   is rarer, and bounds the OOM.
+2. **Clear the current wedge:** a controlled restart *after* confirming the lingering buckets
+   are committed to Delta (check WAL cursor vs Delta watermark) — else it re-wedges.
+3. **Fix the lingering-bucket drain** (why a 99h completed bucket never flushes) — this is
+   the real bug behind both the wedge and the OOM. Needs a debug build / the stuck-bucket
+   stat from the 2026-06-22 P2 observability list.
+
 ## What I'm doing until you wake
 
-Loop continues at low frequency: **passive health monitoring only** (no more prod-mutating
-changes). I'll watch for OOM restarts (`queries_total` resets), pressure, and DLQ trend, and
-flag anything that breaks. The report above is the actionable summary.
+Tightened to ~20-min health checks to build a complete timeline of the wedge (OOM restarts,
+pressure, reject rate) for the morning. **No more prod-mutating changes** — the situation
+needs your decisions, not an unattended gamble. Everything above is the action list.

--- a/docs/plans/2026-06-24-overnight-throughput-report.md
+++ b/docs/plans/2026-06-24-overnight-throughput-report.md
@@ -73,7 +73,16 @@ drain rows/commit. TF-only changes (#3) can lift the ~3000/s ceiling but not to 
   fix it in code than CapRover, I can lower the autotune fractions so the pool sum fits under
   host RAM — say the word.
 
-## ⚠️ URGENT — overnight development (03:28 CEST / 01:28 UTC)
+## ✅ RESOLVED overnight (self-healed 05:41 CEST / 03:41 UTC)
+
+The wedge below **cleared on its own** under low night load: pressure 100%→26%, buffer
+drained 1.27M→410k rows, rejects stopped (~3,268 total — all preserved in WAL, replay on
+their own). Prod is healthy as of 05:41, 3h+ uptime, no OOM restart. **But the root cause is
+unfixed — it WILL re-wedge when daytime ingest returns.** The morning actions below still
+stand; treat them as preventing the next (daytime) wedge, not an active fire. The lingering
+~101h bucket is still pinned (harmless now, but it's the latent driver).
+
+## ⚠️ overnight wedge (03:28 CEST / 01:28 UTC) — now resolved, see above
 
 **Prod re-entered the OOM/wedge loop and is actively dropping inserts to the DLQ.**
 

--- a/docs/plans/2026-06-24-overnight-throughput-report.md
+++ b/docs/plans/2026-06-24-overnight-throughput-report.md
@@ -94,6 +94,19 @@ drain rows/commit. TF-only changes (#3) can lift the ~3000/s ceiling but not to 
 (50/50) and the host is restart-locked. Deploying the memory fix wouldn't unstick *this*
 wedge (it's stuck buckets, not pool sizing) and would add another replay cycle.
 
+**Refined root cause (03:51 UTC update):** the wedge is **drain-throttled-by-file-count**.
+Drain commits only ~3/min because each flush commit does a dedup `replace_where` + metadata
+ops over the **52.9k-file** table (slow). Meanwhile the backlog/DLQ-replay has loaded **568
+time-buckets (~94h of old-event-time data)** into the membuffer. 568 buckets ÷ 3 commits/min
+can't keep up → memory pinned at the 9254 MB hard limit → reject. Rejects accelerating
+(560 → 1432 in 23 min). **The architectural fix:** old-event-time backlog should NOT go
+through the membuffer at all — route it via the dormant **`skip_queue` Delta-direct path**
+(throughput plan §B) so it writes parquet straight to Delta date partitions, never filling
+the 10-min time-bucket membuffer. That removes the wedge at the source. Faster commits (lower
+file count) help too, but compaction is blocked by OCC conflicts while those dates are
+actively written — chicken-and-egg, which is exactly why the Delta-direct backlog path is the
+real fix.
+
 **Morning actions (in order):**
 1. **Apply the container-limit + caps config** (table row #1) — gives headroom so the wedge
    is rarer, and bounds the OOM.

--- a/docs/plans/2026-06-24-overnight-throughput-report.md
+++ b/docs/plans/2026-06-24-overnight-throughput-report.md
@@ -1,0 +1,80 @@
+# Overnight session report — compaction + throughput toward 10000/s (2026-06-24)
+
+Autonomous run while you slept. **Honest headline: 10000/s is NOT reachable by safe
+unattended TimeFusion-only changes** — the two dominant levers are a CapRover **config**
+change and a **monoscope** (different repo) change, both needing your decision. I made the
+safe progress I could, stopped one approach that was actively harming prod, and benchmarked
+so this is data-driven. Details below.
+
+## What I did
+
+1. **Shipped on-demand compaction tooling** (committed to `master`, deployed as `54b7752`):
+   - pgwire `OPTIMIZE <table> WHERE date = '...'` (server-side, reliable in-region I/O).
+   - CLI `timefusion optimize [--date|--older-than-hours|--all|--dry-run]`.
+   - Deploy was clean — prod booted in **75s**, healthy.
+2. **Proved the laptop CLI can't compact prod** — reads stall and large parquet **uploads to
+   R2 fail** (`error sending request`) from a home connection. Server-side pgwire is the only
+   reliable path.
+3. **Tried a full date sweep, then killed it** — see "What didn't work".
+4. **Committed an OCC-retry fix** to branch `perf/compact-occ-retry` (NOT master, so no
+   auto-deploy/restart while prod is stable). Ready for you to review + deploy.
+5. **Benchmarked** ingest + drain (numbers below).
+
+## What didn't work (and why it matters)
+
+**Compaction of the file-heavy dates is not viable while the backlog is active.** Every
+recent-old date (`06-18/19/20/21`) failed with a Serializable OCC conflict:
+`"a concurrent transaction deleted data this operation read."` Cause: the 7.6M DLQ backlog
+carries **old event-time** data, which lands in those same recent-old `date=` partitions, so
+a concurrent flush/dedup deletes files mid-merge (each merge is ~4–5 min). Worse, the
+in-process compaction **contended with the drain on `delta_commit_lock` and pushed prod
+pressure to 100%**, causing insert rejects. I killed it — it compacted **nothing** and hurt
+ingest. The OCC-retry fix (branch) helps *intermittently*-written dates but won't save a
+*continuously*-written one. **Compaction only pays off on sealed older dates, or after the
+backlog drains.**
+
+## Benchmark (prod `54b7752`, steady state)
+
+| Metric | Value | Note |
+|---|---|---|
+| Ingest arrival rate | **~615–1080 rows/s** | varies with upstream load; clean rising-segment measure |
+| Drain ceiling (burst) | **~3000–3300 rows/s** | a flush cleared 294k rows in 90s earlier |
+| Pressure at moderate load | sawtooths 20–35% | drain keeps up |
+| Pressure under spike / compaction | → 100% → rejects | drain can't keep up at peak |
+| Uptime since deploy | 40+ min, **no OOM restart** | healthier than `00c1136` (OOM ~hourly) — but load is low (night) |
+| `backpressure_rejected_total` | 56 (mostly during the sweep) | |
+
+**The ceiling is the DRAIN rate (~3000/s), not ingest accept.** Sustained throughput can't
+exceed drain; when arrival spikes past it, the buffer hits 100% and TF rejects. (`force_flush`
+correctly self-gates while completed buckets remain — that's a WAL-ordering invariant, not a
+bug. Rejects mean completed buckets aren't draining fast enough, i.e. drain-bound.)
+
+## Path to 10000/s — ranked, with owner
+
+| # | Lever | Owner | Impact | Notes |
+|---|---|---|---|---|
+| 1 | **Container mem limit 66→32 GB** + explicit `BUFFER_MAX_MEMORY_MB=8000`, `FOYER_DISK_GB=60`, `MEMORY_LIMIT_GB=8` | **You (CapRover)** | Stops OOM restart loop → the DLQ-flood source | autotune sizes pools to ~48 GB off the 66 GB cgroup while the shared host backs only ~42 GB → host `global_oom`. Code can't see host-available RAM; this is the real fix. ~2-min config change. |
+| 2 | **monoscope TF batch: 512 → 4–8k rows** (inlined-literal encoder, escape the libpq 65535-param cap) | **You/me (monoscope repo)** | Biggest *ingest* lever — fewer parses/WAL-appends/commits, higher drain rows/commit | The 512 cap is a PostgreSQL client artifact, not a TF limit. Different repo + Haskell — needs review, not an unattended change. |
+| 3 | **TF drain throughput** — larger coalescing + parallel staged commits (parquet upload parallel, one short serialized commit) | TF code | Raises the ~3000/s ceiling | Deeper hot-path change; wants careful testing, not unattended. |
+| 4 | **Compaction of sealed dates** (branch `perf/compact-occ-retry`) | TF code (ready) | File count ↓ → query memory ↓ → fewer OOMs | Only after backlog drains, or on dates >1 week old. |
+
+**Realistic read:** #1 (config) + #2 (monoscope batches) together are what get you toward
+10000/s. #1 stops the crashloop so the drain runs continuously; #2 raises both ingest and
+drain rows/commit. TF-only changes (#3) can lift the ~3000/s ceiling but not to 10000/s alone.
+
+## Ready to deploy (your call)
+
+- **`master` is at `54b7752`** (deployed) — OPTIMIZE tooling. Stable.
+- **Branch `perf/compact-occ-retry`** — OCC-retry for compaction. Safe, additive, tested
+  (compiles). Merge when you want to compact sealed dates. Not urgent.
+- **NOT done (needs your decision):** the autotune memory-fraction reduction. I chose not to
+  deploy a memory-tuning change unattended because (a) prod isn't OOMing right now so I
+  couldn't validate it, and (b) the real fix is the container limit (config). If you'd rather
+  fix it in code than CapRover, I can lower the autotune fractions so the pool sum fits under
+  host RAM — say the word.
+
+## What I'm doing until you wake
+
+Loop continues at low frequency: **passive health monitoring only** (no more prod-mutating
+changes). I'll watch for OOM restarts (`queries_total` resets), pressure, and DLQ trend, and
+flag anything that breaks. The report above is the actionable summary.

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -142,6 +142,12 @@ pub struct StatsSnapshot {
     /// Open-bucket force-flush escalations (a single busy window was itself the
     /// pressure). Sustained growth = windows too large for the budget.
     pub backpressure_force_flush_total: u64,
+    /// Cumulative rows accepted into MemBuffer and rows drained to Delta. The
+    /// rate gap between them (diff across two scrapes) is the ingest-outpaces-
+    /// drain signal: both climbing but ingest faster = throughput wedge, not a
+    /// stuck flush.
+    pub rows_ingested_total:            u64,
+    pub rows_flushed_total:             u64,
 }
 
 #[derive(Debug, Default)]
@@ -314,6 +320,14 @@ pub struct BufferedWriteLayer {
     backpressure_engaged_total:     AtomicU64,
     backpressure_rejected_total:    AtomicU64,
     backpressure_force_flush_total: AtomicU64,
+    /// Cumulative rows accepted into MemBuffer (post-WAL) and rows drained to
+    /// Delta. Diff two `timefusion_stats` scrapes to get ingest-rate vs
+    /// drain-rate: if `rows_ingested_total` climbs faster than
+    /// `rows_flushed_total` while `pressure_pct=100`, the flush is succeeding
+    /// but ingest is outpacing drain (the file-count-throttled-dedup wedge),
+    /// distinct from a stuck flush (`flush_failed_total` climbing).
+    rows_ingested_total:            AtomicU64,
+    rows_flushed_total:             AtomicU64,
     // Required for WAL replay of UPDATE/DELETE whose SQL references UDFs.
     function_registry:              Arc<crate::functions::FnRegistry>,
     /// Caps concurrent detached tantivy sidecar builds so a fast flush cycle
@@ -385,6 +399,8 @@ impl BufferedWriteLayer {
             backpressure_engaged_total: AtomicU64::new(0),
             backpressure_rejected_total: AtomicU64::new(0),
             backpressure_force_flush_total: AtomicU64::new(0),
+            rows_ingested_total: AtomicU64::new(0),
+            rows_flushed_total: AtomicU64::new(0),
             function_registry,
             // 16 is well above realistic per-cycle table fan-out for the
             // monoscope workload (~5 distinct table names) while still
@@ -643,6 +659,7 @@ impl BufferedWriteLayer {
                             e
                         );
                     } else {
+                        self.rows_flushed_total.fetch_add(bucket.row_count as u64, Ordering::Relaxed);
                         self.flush_completed_total.fetch_add(1, Ordering::Relaxed);
                     }
                 }
@@ -725,7 +742,10 @@ impl BufferedWriteLayer {
         self.release_reservation(reserved_size);
 
         match &result {
-            Ok(()) => crate::metrics::record_insert(project_id, table_name, row_count as u64),
+            Ok(()) => {
+                self.rows_ingested_total.fetch_add(row_count as u64, Ordering::Relaxed);
+                crate::metrics::record_insert(project_id, table_name, row_count as u64);
+            }
             Err(_) => crate::metrics::record_ingest_error(project_id, table_name),
         }
         result?;
@@ -1236,6 +1256,7 @@ impl BufferedWriteLayer {
                             }
                             any_ok = true;
                             crate::metrics::record_flush(true);
+                            self.rows_flushed_total.fetch_add(combined.row_count as u64, Ordering::Relaxed);
                             self.flush_completed_total.fetch_add(source_bucket_ids.len() as u64, Ordering::Relaxed);
                             debug!(
                                 "Flushed coalesced commit: project={}, table={}, buckets={}, rows={}",
@@ -1628,6 +1649,8 @@ impl BufferedWriteLayer {
             backpressure_engaged_total: self.backpressure_engaged_total.load(Ordering::Relaxed),
             backpressure_rejected_total: self.backpressure_rejected_total.load(Ordering::Relaxed),
             backpressure_force_flush_total: self.backpressure_force_flush_total.load(Ordering::Relaxed),
+            rows_ingested_total: self.rows_ingested_total.load(Ordering::Relaxed),
+            rows_flushed_total: self.rows_flushed_total.load(Ordering::Relaxed),
         }
     }
 

--- a/src/buffered_write_layer.rs
+++ b/src/buffered_write_layer.rs
@@ -654,6 +654,11 @@ impl BufferedWriteLayer {
             match self.flush_bucket(&bucket).await {
                 Ok(()) => {
                     if let Err(e) = self.wal.advance_by_counts(&bucket.project_id, &bucket.table_name, &bucket.wal_shard_counts) {
+                        // Delta commit succeeded but the WAL cursor didn't move:
+                        // count as a flush failure (matches the coalesced-flush
+                        // path) so the incident is visible in flush_failed_total
+                        // instead of silently drifting rows_in_buffer_lag.
+                        self.flush_failed_total.fetch_add(1, Ordering::Relaxed);
                         warn!(
                             "force-flush: advance_by_counts failed (rows committed to Delta; WAL will re-replay, dedup protects): {}",
                             e
@@ -779,6 +784,12 @@ impl BufferedWriteLayer {
         // Bounded recovery memory: O(1) entries in flight rather than
         // O(retention_window × throughput) (potentially GiBs).
         let mut entries_replayed = 0u64;
+        // Recovered rows land straight in MemBuffer, bypassing insert()'s
+        // rows_ingested_total bump. Count them here and fold in after replay so
+        // rows_ingested_total/rows_flushed_total stay comparable post-restart —
+        // otherwise the recovered rows flush and inflate flushed against a 0
+        // ingested, clamping rows_in_buffer_lag and blinding the wedge signal.
+        let mut recovered_rows = 0u64;
         let mut deletes_replayed = 0u64;
         let mut updates_replayed = 0u64;
         let mut oldest_ts: Option<i64> = None;
@@ -806,10 +817,14 @@ impl BufferedWriteLayer {
                                 return;
                             }
                             let apply_start = std::time::Instant::now();
+                            let rows = batch.num_rows() as u64;
                             let insert_res = mem_buffer.insert(&entry.project_id, &entry.table_name, batch, entry.timestamp_micros);
                             insert_apply_nanos += apply_start.elapsed().as_nanos();
                             match insert_res {
-                                Ok(()) => entries_replayed += 1,
+                                Ok(()) => {
+                                    entries_replayed += 1;
+                                    recovered_rows += rows;
+                                }
                                 Err(e) => {
                                     error!("WAL REPLAY FAILED: incompatible INSERT for {}.{}: {}", entry.project_id, entry.table_name, e);
                                     quarantine_entry(&quarantine_dir, &entry, "insert_incompatible", &e.to_string());
@@ -929,6 +944,8 @@ impl BufferedWriteLayer {
         // background (spawned by `start_background_tasks`) while we serve; reads
         // see MemBuffer (unioned with Delta) and new inserts flush-to-make-room
         // via insert-path backpressure.
+
+        self.rows_ingested_total.fetch_add(recovered_rows, Ordering::Relaxed);
 
         let stats = RecoveryStats {
             entries_replayed,

--- a/src/database.rs
+++ b/src/database.rs
@@ -586,6 +586,24 @@ fn is_occ_conflict_err(msg: &str) -> bool {
         || msg.contains("Transaction failed")
 }
 
+/// True for transient S3/network transport failures worth retrying the whole
+/// operation on. object_store retries individual requests (max_retries/180s),
+/// but a multipart part whose connection drops mid-body (R2 under concurrent
+/// large PUTs) can bubble up as terminal — aborting a compaction merge that
+/// committed nothing. delta-rs wraps these as "Failed to parse parquet" via the
+/// async parquet writer, so we match the transport phrases, not the wrapper.
+/// Deliberately excludes auth/permanent errors (403, NoSuchBucket) which must
+/// fail fast.
+fn is_transient_s3_err(msg: &str) -> bool {
+    msg.contains("error sending request")
+        || msg.contains("connection")
+        || msg.contains("Connection")
+        || msg.contains("broken pipe")
+        || msg.contains("reset by peer")
+        || msg.contains("timed out")
+        || msg.contains("timeout")
+}
+
 /// write. No-op for any column that's not a Variant struct or already in
 /// Binary form. Called from `insert_records_batch` right before the
 /// Delta write so MemBuffer can keep its natural BinaryView layout
@@ -3459,6 +3477,12 @@ impl Database {
                 }
                 Err(e) if is_occ_conflict_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
                     warn!("compact date={date}: OCC conflict (attempt {}), refreshing + retrying: {}", attempt + 1, e);
+                }
+                Err(e) if is_transient_s3_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
+                    // A multipart part connection-dropped mid-merge (nothing committed).
+                    // Back off before retrying — R2 flakes under concurrent large PUTs.
+                    warn!("compact date={date}: transient S3 error (attempt {}), backing off + retrying: {}", attempt + 1, e);
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2 * (attempt as u64 + 1))).await;
                 }
                 Err(e) => return Err(anyhow::anyhow!("compact date={date} table={table_name} failed: {e}")),
             }

--- a/src/database.rs
+++ b/src/database.rs
@@ -3481,7 +3481,11 @@ impl Database {
                 Err(e) if is_transient_s3_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
                     // A multipart part connection-dropped mid-merge (nothing committed).
                     // Back off before retrying — R2 flakes under concurrent large PUTs.
-                    warn!("compact date={date}: transient S3 error (attempt {}), backing off + retrying: {}", attempt + 1, e);
+                    warn!(
+                        "compact date={date}: transient S3 error (attempt {}), backing off + retrying: {}",
+                        attempt + 1,
+                        e
+                    );
                     tokio::time::sleep(tokio::time::Duration::from_secs(2 * (attempt as u64 + 1))).await;
                 }
                 Err(e) => return Err(anyhow::anyhow!("compact date={date} table={table_name} failed: {e}")),

--- a/src/database.rs
+++ b/src/database.rs
@@ -593,11 +593,17 @@ fn is_occ_conflict_err(msg: &str) -> bool {
 /// committed nothing. delta-rs wraps these as "Failed to parse parquet" via the
 /// async parquet writer, so we match the transport phrases, not the wrapper.
 /// Deliberately excludes auth/permanent errors (403, NoSuchBucket) which must
-/// fail fast.
+/// fail fast. Phrases are anchored to genuinely-transient transport states —
+/// notably NOT a bare "connection", which matches the permanent "connection
+/// refused" (misconfigured endpoint / firewall) and would burn the whole retry
+/// budget + backoff before failing.
+/// TODO: object_store exposes typed variants (Error::Generic, retryable flags)
+/// under DeltaTableError::ObjectStore; downcasting the error chain would be
+/// version-stable vs. this string match. Revisit on the next object_store bump.
 fn is_transient_s3_err(msg: &str) -> bool {
     msg.contains("error sending request")
-        || msg.contains("connection")
-        || msg.contains("Connection")
+        || msg.contains("connection reset")
+        || msg.contains("connection closed")
         || msg.contains("broken pipe")
         || msg.contains("reset by peer")
         || msg.contains("timed out")
@@ -3447,8 +3453,16 @@ impl Database {
         // partition lands on a later attempt. Mirrors the dedup retry loop.
         const MAX_ATTEMPTS: usize = 4;
         for attempt in 0..MAX_ATTEMPTS {
-            if attempt > 0 {
-                let _ = refresh_table_snapshot(table_ref, self.config.maintenance.timefusion_incremental_snapshot).await;
+            // Runs before every retry (attempt > 0), intentionally for BOTH the
+            // OCC and transient-S3 arms: a concurrent writer may have committed
+            // during the OCC conflict or the S3 backoff sleep, so the next merge
+            // must read a fresh snapshot. Log refresh failures — silently
+            // continuing against a stale snapshot would exhaust all attempts and
+            // surface only the final optimize error, hiding the real cause.
+            if attempt > 0
+                && let Err(e) = refresh_table_snapshot(table_ref, self.config.maintenance.timefusion_incremental_snapshot).await
+            {
+                debug!("compact_date refresh failed (attempt {}): {}", attempt, e);
             }
             let table_clone = { table_ref.read().await.clone() };
             let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
@@ -3477,6 +3491,10 @@ impl Database {
                 }
                 Err(e) if is_occ_conflict_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
                     warn!("compact date={date}: OCC conflict (attempt {}), refreshing + retrying: {}", attempt + 1, e);
+                    // Exponential backoff before re-submitting — matches dedup_partition
+                    // (150ms << attempt). Zero-delay retries under concurrent heavy
+                    // ingest amplify commit contention instead of resolving it.
+                    tokio::time::sleep(tokio::time::Duration::from_millis(150u64 << attempt)).await;
                 }
                 Err(e) if is_transient_s3_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
                     // A multipart part connection-dropped mid-merge (nothing committed).

--- a/src/database.rs
+++ b/src/database.rs
@@ -3451,8 +3451,11 @@ impl Database {
             match result {
                 Ok((new_table, metrics)) => {
                     self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
-                    info!("compact date={date} table={table_name}: {} files removed, {} files added", metrics.num_files_removed, metrics.num_files_added);
-                    return Ok((metrics.num_files_removed as u64, metrics.num_files_added as u64));
+                    info!(
+                        "compact date={date} table={table_name}: {} files removed, {} files added",
+                        metrics.num_files_removed, metrics.num_files_added
+                    );
+                    return Ok((metrics.num_files_removed, metrics.num_files_added));
                 }
                 Err(e) if is_occ_conflict_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
                     warn!("compact date={date}: OCC conflict (attempt {}), refreshing + retrying: {}", attempt + 1, e);

--- a/src/database.rs
+++ b/src/database.rs
@@ -3419,34 +3419,48 @@ impl Database {
     /// which compact old partitions that fall outside the scheduled 48h Z-order
     /// window. Commits once for this date; returns (files_removed, files_added).
     pub async fn compact_date(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, date: chrono::NaiveDate) -> Result<(u64, u64)> {
-        let table_clone = { table_ref.read().await.clone() };
-        let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
         let target_size = self.config.parquet.timefusion_optimize_target_size;
         let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
-        // declare_sorted=false: Compact bin-packs across files, output isn't globally sorted.
-        let writer_properties = self.create_writer_properties(schema, self.config.parquet.timefusion_zstd_level_warm, false);
         let partition_filters = vec![PartitionFilter::try_from(("date", "=", date.to_string().as_str()))?];
-
-        let (new_table, metrics) = table_clone
-            .optimize()
-            .with_filters(&partition_filters)
-            .with_type(deltalake::operations::optimize::OptimizeType::Compact)
-            .with_target_size(std::num::NonZero::new(target_size as u64).unwrap_or(std::num::NonZero::new(1).unwrap()))
-            .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
-            .with_writer_properties(writer_properties)
-            .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
-            .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
-            // Variant columns: same BinaryView-avoidance session as optimize_table.
-            .with_session_state(Arc::new(build_optimize_session_state(self.config.memory.timefusion_query_partitions)))
-            .await
-            .map_err(|e| anyhow::anyhow!("compact date={date} table={table_name} failed: {e}"))?;
-
-        self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
-        info!(
-            "compact date={date} table={table_name}: {} files removed, {} files added",
-            metrics.num_files_removed, metrics.num_files_added
-        );
-        Ok((metrics.num_files_removed, metrics.num_files_added))
+        // Old-event-time backlog data still lands in recent-old partitions, so a
+        // concurrent flush/dedup can delete files mid-merge → Serializable OCC
+        // conflict at commit (the merge read now-removed files). Refresh the
+        // snapshot and retry rather than fail; an intermittently-written
+        // partition lands on a later attempt. Mirrors the dedup retry loop.
+        const MAX_ATTEMPTS: usize = 4;
+        for attempt in 0..MAX_ATTEMPTS {
+            if attempt > 0 {
+                let _ = refresh_table_snapshot(table_ref, self.config.maintenance.timefusion_incremental_snapshot).await;
+            }
+            let table_clone = { table_ref.read().await.clone() };
+            let pre_uris: std::collections::HashSet<String> = table_clone.get_file_uris().map(|it| it.collect()).unwrap_or_default();
+            // declare_sorted=false: Compact bin-packs across files, output isn't globally sorted.
+            let writer_properties = self.create_writer_properties(schema, self.config.parquet.timefusion_zstd_level_warm, false);
+            let result = table_clone
+                .optimize()
+                .with_filters(&partition_filters)
+                .with_type(deltalake::operations::optimize::OptimizeType::Compact)
+                .with_target_size(std::num::NonZero::new(target_size as u64).unwrap_or(std::num::NonZero::new(1).unwrap()))
+                .with_max_concurrent_tasks(self.config.maintenance.timefusion_optimize_max_concurrent_tasks)
+                .with_writer_properties(writer_properties)
+                .with_min_commit_interval(tokio::time::Duration::from_secs(10 * 60))
+                .with_commit_properties(incremental_commit_properties(self.config.maintenance.timefusion_incremental_snapshot))
+                // Variant columns: same BinaryView-avoidance session as optimize_table.
+                .with_session_state(Arc::new(build_optimize_session_state(self.config.memory.timefusion_query_partitions)))
+                .await;
+            match result {
+                Ok((new_table, metrics)) => {
+                    self.swap_and_refresh_cache(table_ref, new_table, &pre_uris).await;
+                    info!("compact date={date} table={table_name}: {} files removed, {} files added", metrics.num_files_removed, metrics.num_files_added);
+                    return Ok((metrics.num_files_removed as u64, metrics.num_files_added as u64));
+                }
+                Err(e) if is_occ_conflict_err(&e.to_string()) && attempt + 1 < MAX_ATTEMPTS => {
+                    warn!("compact date={date}: OCC conflict (attempt {}), refreshing + retrying: {}", attempt + 1, e);
+                }
+                Err(e) => return Err(anyhow::anyhow!("compact date={date} table={table_name} failed: {e}")),
+            }
+        }
+        unreachable!("compact_date loop returns on success or final error")
     }
 
     /// Distinct `date=YYYY-MM-DD` partitions present in the live file set,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -194,8 +194,16 @@ pub fn init_metrics(
     // outpacing a working drain, not a stuck flush. Counters (not gauges) so
     // rate() handles the restart-to-0 reset. `ingested` includes WAL-recovered
     // rows so the pair stays comparable after a restart (see snapshot_stats).
-    layer_counter!("timefusion.mem_buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer (incl. WAL recovery)", |s| s.rows_ingested_total);
-    layer_counter!("timefusion.mem_buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s.rows_flushed_total);
+    layer_counter!(
+        "timefusion.mem_buffer.rows_ingested_total",
+        "Cumulative rows accepted into MemBuffer (incl. WAL recovery)",
+        |s| s.rows_ingested_total
+    );
+    layer_counter!(
+        "timefusion.mem_buffer.rows_flushed_total",
+        "Cumulative rows drained from MemBuffer to Delta",
+        |s| s.rows_flushed_total
+    );
     layer_gauge!("timefusion.wal.disk_bytes", "Disk bytes occupied by WAL shards", |s| s.wal_disk_bytes);
     layer_gauge!("timefusion.wal.files", "Number of WAL segment files on disk", |s| s.wal_files as u64);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -154,6 +154,26 @@ pub fn init_metrics(
         }};
     }
 
+    // Same shape as layer_gauge! but registers a monotonic observable counter
+    // (OTel Sum → Prometheus Counter) so PromQL rate() applies reset detection
+    // and survives process restarts (the values snap to 0 on boot). Use for
+    // cumulative totals; layer_gauge! for point-in-time levels.
+    macro_rules! layer_counter {
+        ($id:literal, $desc:literal, |$s:ident| $value:expr) => {{
+            let weak = buffered_layer.clone();
+            meter
+                .u64_observable_counter($id)
+                .with_description($desc)
+                .with_callback(move |obs| {
+                    if let Some(layer) = weak.upgrade() {
+                        let $s = layer.snapshot_stats();
+                        obs.observe($value, &[]);
+                    }
+                })
+                .build();
+        }};
+    }
+
     layer_gauge!(
         "timefusion.mem_buffer.pressure_pct",
         "MemBuffer memory pressure as percentage of max",
@@ -171,11 +191,11 @@ pub fn init_metrics(
     );
     // Ingest vs drain: rate() these two and compare. Ingested climbing faster
     // than flushed (while pressure_pct=100, flush_failed flat) = ingest
-    // outpacing a working drain, not a stuck flush.
-    layer_gauge!("timefusion.buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer", |s| s
-        .rows_ingested_total);
-    layer_gauge!("timefusion.buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s
-        .rows_flushed_total);
+    // outpacing a working drain, not a stuck flush. Counters (not gauges) so
+    // rate() handles the restart-to-0 reset. `ingested` includes WAL-recovered
+    // rows so the pair stays comparable after a restart (see snapshot_stats).
+    layer_counter!("timefusion.mem_buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer (incl. WAL recovery)", |s| s.rows_ingested_total);
+    layer_counter!("timefusion.mem_buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s.rows_flushed_total);
     layer_gauge!("timefusion.wal.disk_bytes", "Disk bytes occupied by WAL shards", |s| s.wal_disk_bytes);
     layer_gauge!("timefusion.wal.files", "Number of WAL segment files on disk", |s| s.wal_files as u64);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -172,8 +172,10 @@ pub fn init_metrics(
     // Ingest vs drain: rate() these two and compare. Ingested climbing faster
     // than flushed (while pressure_pct=100, flush_failed flat) = ingest
     // outpacing a working drain, not a stuck flush.
-    layer_gauge!("timefusion.buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer", |s| s.rows_ingested_total);
-    layer_gauge!("timefusion.buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s.rows_flushed_total);
+    layer_gauge!("timefusion.buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer", |s| s
+        .rows_ingested_total);
+    layer_gauge!("timefusion.buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s
+        .rows_flushed_total);
     layer_gauge!("timefusion.wal.disk_bytes", "Disk bytes occupied by WAL shards", |s| s.wal_disk_bytes);
     layer_gauge!("timefusion.wal.files", "Number of WAL segment files on disk", |s| s.wal_files as u64);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -169,6 +169,11 @@ pub fn init_metrics(
         "Total rows in MemBuffer across all projects/tables",
         |s| s.mem_total_rows as u64
     );
+    // Ingest vs drain: rate() these two and compare. Ingested climbing faster
+    // than flushed (while pressure_pct=100, flush_failed flat) = ingest
+    // outpacing a working drain, not a stuck flush.
+    layer_gauge!("timefusion.buffer.rows_ingested_total", "Cumulative rows accepted into MemBuffer", |s| s.rows_ingested_total);
+    layer_gauge!("timefusion.buffer.rows_flushed_total", "Cumulative rows drained from MemBuffer to Delta", |s| s.rows_flushed_total);
     layer_gauge!("timefusion.wal.disk_bytes", "Disk bytes occupied by WAL shards", |s| s.wal_disk_bytes);
     layer_gauge!("timefusion.wal.files", "Number of WAL segment files on disk", |s| s.wal_files as u64);
 

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -125,7 +125,9 @@ impl StatsTableProvider {
             // Ingest-vs-drain: both climb in steady state. If ingested pulls
             // ahead of flushed while pressure_pct=100 and flush_failed_total is
             // flat, ingest is outpacing a working drain (throughput wedge) —
-            // not a stuck flush. `rows_in_buffer_lag` ≈ rows currently buffered.
+            // not a stuck flush. `rows_in_buffer_lag` ≈ rows currently buffered
+            // (ingested includes WAL-recovered rows, so the pair stays
+            // comparable after a restart).
             rows.push(("buffered_layer", "rows_ingested_total".into(), s.rows_ingested_total.to_string()));
             rows.push(("buffered_layer", "rows_flushed_total".into(), s.rows_flushed_total.to_string()));
             rows.push((

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -120,6 +120,19 @@ impl StatsTableProvider {
                 "backpressure_force_flush_total".into(),
                 s.backpressure_force_flush_total.to_string(),
             ));
+            rows.push(("buffered_layer", "flush_completed_total".into(), s.flush_completed_total.to_string()));
+            rows.push(("buffered_layer", "flush_failed_total".into(), s.flush_failed_total.to_string()));
+            // Ingest-vs-drain: both climb in steady state. If ingested pulls
+            // ahead of flushed while pressure_pct=100 and flush_failed_total is
+            // flat, ingest is outpacing a working drain (throughput wedge) —
+            // not a stuck flush. `rows_in_buffer_lag` ≈ rows currently buffered.
+            rows.push(("buffered_layer", "rows_ingested_total".into(), s.rows_ingested_total.to_string()));
+            rows.push(("buffered_layer", "rows_flushed_total".into(), s.rows_flushed_total.to_string()));
+            rows.push((
+                "buffered_layer",
+                "rows_in_buffer_lag".into(),
+                s.rows_ingested_total.saturating_sub(s.rows_flushed_total).to_string(),
+            ));
             rows.push(("wal", "files".into(), s.wal_files.to_string()));
             rows.push(("wal", "disk_bytes".into(), s.wal_disk_bytes.to_string()));
             rows.push(("wal", "disk_mb".into(), format!("{:.1}", s.wal_disk_bytes as f64 / (1024.0 * 1024.0))));


### PR DESCRIPTION
## Why

Running on-demand `OPTIMIZE <table> WHERE date = '...'` against prod (R2) failed mid-merge:

```
S3 error: Error performing PUT .../part-00000-...zstd.parquet?partNumber=4&uploadId=...
          in 25.3s - HTTP error: error sending request
... done: 0 files removed, 0 files added
```

This is a **transport failure**, not OCC or corruption: a multipart part's connection dropped mid-body (classic R2 flakiness under concurrent large PUTs), surfaced confusingly as `Failed to parse parquet` by the async parquet writer. Nothing committed, so the partition was untouched — but the whole merge aborted.

`compact_date` previously retried only OCC conflicts (`is_occ_conflict_err`). object_store's per-request retry (`max_retries: 5`/`180s`) classifies a mid-body connection drop as terminal, so it bubbled up after a single 25s attempt.

## What

- Add `is_transient_s3_err` next to `is_occ_conflict_err` — matches transport phrases (`error sending request`, connection/reset/broken-pipe, timeouts); deliberately excludes auth/permanent errors (403, NoSuchBucket) so those still fail fast.
- Add a second retry arm in `compact_date`'s loop: on a transient S3 error, back off (escalating 2s/4s/6s) and retry the whole merge within the existing `MAX_ATTEMPTS = 4` budget. Safe because a dropped multipart part commits nothing.

## Test

`cargo check` clean. Re-running the failed `date=2026-06-20` compaction now retries past the upload blip instead of aborting.