### PR TITLE
perf(delta): hold _delta_log to a 6h window + reconcile on existing tables

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -220,12 +220,15 @@ const_default!(d_stats_cache_size: usize = 50);
 // compaction churn at the 7-day delta default accumulated 38.5k tombstones
 // (93% of checkpoint actions) replayed on every snapshot refresh.
 const_default!(d_vacuum_retention: u64 = 24);
-// Delta _delta_log (transaction-log) retention. Default 1 day keeps the log
-// directory small (~commit-rate × 1d files) so every commit's version-discovery
-// LIST stays cheap. Delta's default is 30 DAYS — which let the log grow to 68k
-// objects and made each commit's list take ~35s (the 2026-06-25 DLQ-drain
-// incident). delta.enableExpiredLogCleanup (default true) prunes during checkpoints.
-const_default!(d_log_retention: u64 = 24);
+// Delta _delta_log (transaction-log) retention. Keeps the log directory small
+// (~commit-rate × retention files) so every commit's version-discovery LIST stays
+// cheap. Delta's default is 30 DAYS — which let the log grow to 68k objects and
+// made each commit's list take ~35s (2026-06-25 DLQ-drain incident). Even 1 day
+// regrew to ~6.7k objects (~3-5s/commit) under the multi-tenant per-project commit
+// rate (2026-06-26), so hold a tighter 6h window. enableExpiredLogCleanup (default
+// true) prunes during checkpoints; cross-project flush coalescing cuts the commit
+// rate that drives growth.
+const_default!(d_log_retention: u64 = 6);
 const_default!(d_optimize_window_hours: u64 = 48);
 const_default!(d_compact_min_files: usize = 5);
 const_default!(d_light_optimize_target: i64 = 16 * 1024 * 1024);

--- a/src/database.rs
+++ b/src/database.rs
@@ -2261,6 +2261,14 @@ impl Database {
                         "delta.checkpointInterval".to_string(),
                         self.config.parquet.timefusion_checkpoint_interval.to_string(),
                     ),
+                    // Reconcile _delta_log retention on EXISTING tables too — a config
+                    // change alone wouldn't shrink a table that baked in the old value
+                    // at create (the live otel_logs_and_spans sat at 1 day and regrew
+                    // its log to ~6.7k objects → 3-5s commits, 2026-06-26).
+                    (
+                        "delta.logRetentionDuration".to_string(),
+                        format!("interval {} hours", self.config.maintenance.timefusion_log_retention_hours),
+                    ),
                 ]);
                 Ok(ensure_table_properties(table, desired).await)
             }


### PR DESCRIPTION
## Problem

Every Delta commit was spending **3–5s in a `slow_list` of `_delta_log`**, which had regrown to **~6,700 objects** — the 1-day `logRetentionDuration` × the multi-tenant per-project commit rate (~4.7 commits/min). This throttled flush throughput (and was the same root cause as the 2026-06-25 68k-object incident, just smaller). Manual log truncation restored ~0.4s commits in prod on 2026-06-26; this makes the fix durable.

## Changes

- **`d_log_retention` 24h → 6h** (config.rs): at ~4.7 commits/min, 1 day ≈ 6.7k log objects; 6h caps it ~4× lower so per-commit version-discovery LISTs stay cheap.
- **Reconcile `delta.logRetentionDuration` on existing tables at load** (database.rs `create_or_load_delta_table`), alongside the existing `deletedFileRetentionDuration` / `checkpointInterval` reconcile. A config change alone leaves a table that baked in the old value at create untouched — which is exactly why the live `otel_logs_and_spans` sat at 1 day. Uses the existing fork-safe `ensure_table_properties`.

## Note on scope

Investigation showed the DLQ **drain rate is consumer-bound (~200/min), not TF-flush-bound** — so this PR is about TF *health/durability* (keeping commits fast, pressure low, avoiding the OOM-adjacent pressure-100 thrash), **not** about speeding the drain directly. The originally-planned cross-project flush coalescing (Lever 3) is **deferred**: it's a TF-flush optimization that wouldn't move a consumer-bound drain, and it's a data-loss-sensitive WAL-advance refactor not worth the risk for marginal gain.

Builds clean (`cargo build`).