### PR TITLE
fix(flush): serialize escalated flush sorts so each owns the sort pool

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1643,6 +1643,22 @@ pub struct Database {
     /// allocates outside every pool, and authorising GBs of that on a 26 GB box
     /// is what took prod down on 2026-08-01.
     flush_sort_runtime_env: Arc<std::sync::OnceLock<Arc<datafusion::execution::runtime_env::RuntimeEnv>>>,
+    /// Admission to the escalated flush sort, so concurrent oversized groups take
+    /// the pool in turn instead of splitting it.
+    ///
+    /// `flush_sort_runtime_env` is ONE shared `FairSpillPool` and flush groups run
+    /// under `buffer_unordered`, so without this N concurrent escalations each get
+    /// ~pool/N. Spilling does not rescue that: it bounds the sort phase, but the
+    /// MERGE phase still needs a minimum reservation, and when it can't get one the
+    /// sort fails and the caller writes the group UNSORTED. On 2026-08-02, 21
+    /// concurrent groups against the 1 GB pool produced `Failed to allocate
+    /// additional 486.5 MB for ExternalSorterMerge[1] ... 312.1 MB remain`. Unsorted
+    /// output costs readers their footer ordering, which is the documented precursor
+    /// to lost TopK pushdown, unbounded read-side dedup, and OOM.
+    ///
+    /// One permit: escalation is the rare path (only oversized buckets reach it), and
+    /// sorted-but-serialized strictly beats parallel-but-unsorted.
+    flush_sort_sem: Arc<tokio::sync::Semaphore>,
     /// Memoized `build_optimize_session_state` results, one per runtime env.
     /// Building a `SessionState` re-registers every analyzer/optimizer rule and
     /// the whole UDF/UDAF set; the maintenance loop did that on EVERY optimize
@@ -2222,6 +2238,7 @@ impl Database {
             maintenance_runtime_env: Arc::new(std::sync::OnceLock::new()),
             light_optimize_runtime_env: Arc::new(std::sync::OnceLock::new()),
             flush_sort_runtime_env: Arc::new(std::sync::OnceLock::new()),
+            flush_sort_sem: Arc::new(tokio::sync::Semaphore::new(1)),
             maintenance_session_state: Arc::new(std::sync::OnceLock::new()),
             light_optimize_session_state: Arc::new(std::sync::OnceLock::new()),
             unified_tables: Arc::new(RwLock::new(HashMap::new())),
@@ -4193,6 +4210,12 @@ impl Database {
         if order_by.is_empty() {
             return None;
         }
+
+        // Held for the whole sort so this group owns the pool outright (see field
+        // doc). Acquire before building the plan — the SessionContext reserves against
+        // the pool as it runs, not at construction. A closed semaphore only happens at
+        // shutdown, where falling back to unsorted beats blocking a draining flush.
+        let _permit = self.flush_sort_sem.acquire().await.ok()?;
 
         let state = build_delta_write_session_state(self.config.memory.timefusion_query_partitions, self.flush_sort_runtime_env());
         let ctx = SessionContext::new_with_state(state);

--- a/src/database.rs
+++ b/src/database.rs
@@ -4213,8 +4213,9 @@ impl Database {
 
         // Held for the whole sort so this group owns the pool outright (see field
         // doc). Acquire before building the plan — the SessionContext reserves against
-        // the pool as it runs, not at construction. A closed semaphore only happens at
-        // shutdown, where falling back to unsorted beats blocking a draining flush.
+        // the pool as it runs, not at construction. Nothing closes this semaphore
+        // today; if some future shutdown path does, `.ok()?` degrades to writing
+        // unsorted, which beats blocking a draining flush.
         let _permit = self.flush_sort_sem.acquire().await.ok()?;
 
         let state = build_delta_write_session_state(self.config.memory.timefusion_query_partitions, self.flush_sort_runtime_env());


### PR DESCRIPTION
## Not urgent — please review before merging

Found while diagnosing the 2026-08-02 outage. **Deliberately not deployed yet**: TF only just recovered, and `src/database.rs` on master has unrelated uncommitted WIP (the `snapshot_duplicate_adds` work), so this is branched off `5e7e672` and left for you to land when convenient.

## The bug

`Database::flush_sort_runtime_env()` is a `get_or_init` — **one** shared `FairSpillPool` sized `timefusion_flush_sort_pool_mb` (default **1024 MB**). But flush groups run concurrently under `buffer_unordered(parallelism)` (`buffered_write_layer.rs:1955`), so N concurrent escalated sorts each get roughly `pool/N`.

The config doc says exceeding the pool "spills to disk, which is the intended degradation". That's true of the **sort** phase only. The **merge** phase still needs a minimum reservation, and when it can't get one the sort fails outright — `sort_flush_group_spilling` returns `None` and the caller writes the group **unsorted**:

```
flush sort: spilling DataFusion sort failed, writing unsorted: Resources exhausted:
Failed to allocate additional 486.5 MB for ExternalSorterMerge[1] with 0.0 B already
allocated - 312.1 MB remain available for the total memory pool: fair(pool_size: 1024.0 MB)
```

That was 21 concurrent groups against the 1 GB pool, during the incident.

Rows are never lost (that fallback is correct), but unsorted output means the parquet footer stops advertising an order — the documented precursor to lost TopK pushdown, unbounded read-side dedup, and OOM.

## The fix

A 1-permit `flush_sort_sem` acquired inside `sort_flush_group_spilling`, before the SessionContext is built (the pool is reserved against as the plan *runs*, not at construction). Concurrent oversized groups now take the pool in turn instead of splitting it.

One permit because escalation is the rare path — only oversized buckets reach it — and sorted-but-serialized strictly beats parallel-but-unsorted. `.ok()?` on the acquire means a closed semaphore (shutdown only) falls back to unsorted rather than blocking a draining flush.

## Alternative

`TIMEFUSION_FLUSH_SORT_POOL_MB` is the env-only mitigation if you'd rather not ship code — but it still restarts TF, and it doesn't fix the sharing, just raises the threshold at which N-way splitting starts failing.

## Testing

`cargo check --lib` and `cargo lint` both clean.

**Test gap, stated honestly:** I did not add a regression test. Reproducing it needs N concurrent escalated sorts against a deliberately small pool with a real `Database`, which is integration-shaped (MinIO) rather than a unit test. Happy to add one under `tests/` if you want it before merging.