### PR TITLE
Isolate sealed dedup from foreground runtime

### DIFF
--- a/bench/concurrent_load.py
+++ b/bench/concurrent_load.py
@@ -110,6 +110,47 @@ def load_rows(limit: int | None = None) -> list[dict]:
     return rows
 
 
+def synthetic_rows(count: int) -> list[dict]:
+    """Build deterministic wide rows when a production sample is unavailable.
+
+    Keep the same 88-column INSERT path as production.  The payload distribution
+    deliberately includes JSON and text fields used by dashboard filters, while
+    leaving nullable fields unset.  This makes the benchmark reproducible in CI
+    and on developer machines without granting either access to production.
+    """
+    now = datetime.now(timezone.utc)
+    rows: list[dict] = []
+    for i in range(count):
+        ts = now - timedelta(seconds=count - i)
+        row = dict.fromkeys(COLUMNS)
+        row.update({
+            "timestamp": ts.isoformat(),
+            "observed_timestamp": ts.isoformat(),
+            "start_time": ts.isoformat(),
+            "end_time": (ts + timedelta(milliseconds=i % 500)).isoformat(),
+            "id": f"synthetic-{i}",
+            "hashes": [f"hash-{i % 97}"],
+            "name": ("GET /checkout" if i % 7 == 0 else "GET /products"),
+            "kind": ("server" if i % 3 else "client"),
+            "status_code": ("ERROR" if i % 101 == 0 else "OK"),
+            "level": ("ERROR" if i % 101 == 0 else "INFO"),
+            "body": json.dumps({"message": f"synthetic event {i}", "iteration": i}),
+            "duration": i % 500_000_000,
+            "context": json.dumps({"trace_id": f"{i:032x}"}),
+            "context___trace_id": f"{i:032x}",
+            "context___span_id": f"{i:016x}",
+            "attributes": json.dumps({"http.route": "/products", "bench.bucket": i % 16}),
+            "resource": json.dumps({"service.name": f"service-{i % 12}"}),
+            "resource___service___name": f"service-{i % 12}",
+            "project_id": "synthetic-template",
+            "summary": ["synthetic", f"service-{i % 12}"],
+            "date": ts.date().isoformat(),
+            "message_size_bytes": 700 + i % 900,
+        })
+        rows.append(row)
+    return rows
+
+
 def shift_for_project(rows: list[dict], project_id: str, shift: timedelta) -> list[dict]:
     """Re-stamp rows for a synthetic project. Returns shallow copies (cheap)."""
     out: list[dict] = []
@@ -138,20 +179,24 @@ class Stats:
         self.query_errors: list[str] = []
 
 
-def writer(stop: threading.Event, pid: str, rows: list[dict], batch_size: int, stats: Stats, rows_per_sec: float):
+def writer(stop: threading.Event, project_rows: list[tuple[str, list[dict]]], batch_size: int, stats: Stats, rows_per_sec: float):
     placeholders = "(" + ", ".join(["%s"] * len(COLUMNS)) + ")"
     base_sql = f"INSERT INTO otel_logs_and_spans ({', '.join(COLUMNS)}) VALUES "
     per_batch_sleep = batch_size / rows_per_sec if rows_per_sec > 0 else 0.0
 
     with psycopg.connect(LOCAL_URL, autocommit=True) as conn, conn.cursor() as cur:
-        idx = 0
+        indexes = {pid: 0 for pid, _ in project_rows}
+        project_idx = 0
         next_send = time.perf_counter()
         while not stop.is_set():
+            pid, rows = project_rows[project_idx]
+            project_idx = (project_idx + 1) % len(project_rows)
+            idx = indexes[pid]
             batch = rows[idx:idx+batch_size]
             if not batch:
-                idx = 0
+                indexes[pid] = 0
                 continue
-            idx += batch_size
+            indexes[pid] = idx + batch_size
             flat: list[Any] = []
             for r in batch:
                 for c in COLUMNS:
@@ -218,34 +263,41 @@ def pct(xs: list[float], p: float) -> float:
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--writers", type=int, default=5, help="concurrent writer threads / projects")
+    ap.add_argument("--projects", type=int, help="tenant count (default: same as --writers)")
     ap.add_argument("--readers", type=int, default=4, help="concurrent reader threads")
     ap.add_argument("--duration", type=int, default=60, help="seconds to run")
     ap.add_argument("--batch", type=int, default=30, help="rows per INSERT (prod-shape: ~30)")
     ap.add_argument("--row-limit", type=int, default=80000, help="max rows preloaded per project")
+    ap.add_argument("--synthetic", action="store_true",
+                    help="generate deterministic production-shaped rows; do not require bench/data/sample.jsonl.gz")
     ap.add_argument("--budget-ms", type=float, default=100.0, help="read latency budget for PASS")
     ap.add_argument("--writer-rate", type=float, default=0,
                     help="per-writer ingest rate cap in rows/sec (default 0 = unlimited)")
     args = ap.parse_args()
+    project_count = args.projects or args.writers
+    if project_count < args.writers:
+        sys.exit("--projects must be greater than or equal to --writers")
 
-    if not DUMP.exists():
+    if not args.synthetic and not DUMP.exists():
         sys.exit(f"missing dump at {DUMP} — run replay_prod_load.py download first")
 
-    print(f"loading dump (limit {args.row_limit} rows per writer)…", flush=True)
-    raw = load_rows(args.row_limit)
+    source = "synthetic rows" if args.synthetic else "dump"
+    print(f"loading {source} (limit {args.row_limit} rows per writer)…", flush=True)
+    raw = synthetic_rows(args.row_limit) if args.synthetic else load_rows(args.row_limit)
     if not raw: sys.exit("dump is empty")
 
     # Shift so the LATEST original row lands at now() for each project
     max_ts = max(datetime.fromisoformat(r["timestamp"]) for r in raw)
     base_shift = datetime.now(timezone.utc) - max_ts
 
-    pids = [f"bench-{i:02d}-{uuid.uuid4().hex[:8]}" for i in range(args.writers)]
+    pids = [f"bench-{i:04d}-{uuid.uuid4().hex[:8]}" for i in range(project_count)]
     per_project: dict[str, list[dict]] = {}
     for pid in pids:
         # Tiny per-project jitter on the shift so projects aren't synchronised
         jitter = timedelta(seconds=random.uniform(-30, 30))
         per_project[pid] = shift_for_project(raw, pid, base_shift + jitter)
 
-    print(f"projects={len(pids)} rows/project={len(raw)} duration={args.duration}s "
+    print(f"projects={len(pids)} writers={args.writers} rows/project={len(raw)} duration={args.duration}s "
           f"readers={args.readers} batch={args.batch}", flush=True)
 
     stats = Stats()
@@ -254,8 +306,11 @@ def main():
     t0 = time.perf_counter()
 
     with ThreadPoolExecutor(max_workers=args.writers + args.readers) as ex:
-        for pid in pids:
-            ex.submit(writer, stop, pid, per_project[pid], args.batch, stats, args.writer_rate)
+        assignments = [[] for _ in range(args.writers)]
+        for i, pid in enumerate(pids):
+            assignments[i % args.writers].append((pid, per_project[pid]))
+        for assignment in assignments:
+            ex.submit(writer, stop, assignment, args.batch, stats, args.writer_rate)
         for _ in range(args.readers):
             ex.submit(reader, stop, pids, stats)
         # Snapshot stats every 15s so it's visible mid-run
@@ -325,6 +380,17 @@ def main():
     if post.get('mem_buffer.total_rows', 0) > 0:
         bpr = post.get('mem_buffer.estimated_bytes_approx', 0) / post['mem_buffer.total_rows']
         print(f"  bytes/row (end)           {bpr:>10.0f}   target <2048")
+
+    print("\n# maintenance safety")
+    safety = [
+        ("decoded reservation", post.get("maintenance.decoded_bytes_used", 0), 512 * 1024 * 1024, "<= 512 MiB"),
+        ("singleton failures delta", diff("maintenance.rollup_singleton_failures_total"), 0, "= 0"),
+        ("memory charged", post.get("memory.charged_pct", 0), 75, "<= 75%"),
+    ]
+    for name, value, ceiling, target in safety:
+        ok = value <= ceiling
+        overall_pass &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name:26s} {value:,.0f}  target {target}")
 
     print(f"\n# overall: {'PASS' if overall_pass else 'FAIL'}")
     sys.exit(0 if overall_pass else 1)

--- a/src/database.rs
+++ b/src/database.rs
@@ -1052,6 +1052,18 @@ where
     F: Fn() -> Fut + Send + 'static,
     Fut: std::future::Future<Output = ()> + Send + 'static,
 {
+    spawn_cron_job_on(name, schedule, cancel, None, job);
+}
+
+/// Schedule like [`spawn_cron_job`], but execute each job body on `executor`.
+/// The lightweight wall-clock timer remains on the caller's runtime so shutdown
+/// and tick accounting retain one owner; CPU and I/O polling for the job itself
+/// stay off the foreground PGWire runtime.
+fn spawn_cron_job_on<F, Fut>(name: &'static str, schedule: &str, cancel: Arc<CancellationToken>, executor: Option<tokio::runtime::Handle>, job: F)
+where
+    F: Fn() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
     if schedule.trim().is_empty() {
         info!("{name} job scheduling skipped - empty schedule");
         return;
@@ -1115,7 +1127,11 @@ where
                     }
                     crate::metrics::maintenance_stats().cron_ticks_fired.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     running_since = Some(std::time::Instant::now());
-                    running = Some(tokio::spawn(job()));
+                    let future = job();
+                    running = Some(match &executor {
+                        Some(handle) => handle.spawn(future),
+                        None => tokio::spawn(future),
+                    });
                 }
             }
         }
@@ -3854,7 +3870,7 @@ impl Database {
         // cron, decoupled from hot compaction above. Keeps the job_sem so it stays
         // serialized against the full optimize job (the other job_sem holder).
         // spawn_cron_job skips overlapping ticks.
-        spawn_cron_job("Dedup", &self.config.maintenance.timefusion_dedup_schedule, cancel.clone(), {
+        spawn_cron_job_on("Dedup", &self.config.maintenance.timefusion_dedup_schedule, cancel.clone(), self.maintenance_executor.get().cloned(), {
             let db = db.clone();
             move || {
                 let db = db.clone();
@@ -19280,6 +19296,26 @@ mod tests {
         let after_cancel = count.load(Ordering::SeqCst);
         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
         assert_eq!(count.load(Ordering::SeqCst), after_cancel, "no fires after cancel");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn spawn_cron_job_on_runs_body_on_the_selected_runtime() {
+        let isolated =
+            tokio::runtime::Builder::new_multi_thread().worker_threads(1).thread_name("cron-isolated").enable_all().build().expect("isolated runtime");
+        let cancel = Arc::new(CancellationToken::new());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        spawn_cron_job_on("isolated-test", "* * * * * *", cancel.clone(), Some(isolated.handle().clone()), move || {
+            let tx = tx.clone();
+            async move {
+                let name = std::thread::current().name().unwrap_or("unnamed").to_owned();
+                let _ = tx.send(name);
+            }
+        });
+
+        let thread_name = tokio::time::timeout(std::time::Duration::from_millis(2500), rx.recv()).await.expect("cron fired").expect("sender alive");
+        cancel.cancel();
+        assert!(thread_name.starts_with("cron-isolated"), "job ran on {thread_name}, not the isolated executor");
+        isolated.shutdown_background();
     }
 
     /// A wedged job body must not freeze the cron loop: later ticks are skipped


### PR DESCRIPTION
## Why
Production still showed Tokio scheduling-lag spikes after the coordinator rollout. The legacy sealed-partition Dedup cron remained on the foreground runtime; a 3.3s spike overlapped its 12:50 pass.

## Change
- keep Dedup enabled and on the same schedule
- execute its job body on the existing isolated maintenance runtime
- preserve timer ownership, overlap suppression, cancellation, and cron metrics
- add a regression test proving executor selection
- make the load harness credential-independent and decouple 1,000 projects from writer-thread count

## Verification
- all four cron scheduler tests pass
- isolated executor test observes the `cron-isolated` thread
- 1,000-project calibration: 29,370 rows/10s, zero insert errors, query p95 26-30ms, zero singleton failures

Production remains on `0f1b39b`; deploy only after CI passes.