### PR TITLE
Bound first-write maintenance to touched slices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=32f7f7c6#32f7f7c675aa15c03d960f080105702c319479ea"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=64720904#64720904a3779784e092bc6b8afa4574cefbf079"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=32f7f7c6#32f7f7c675aa15c03d960f080105702c319479ea"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=64720904#64720904a3779784e092bc6b8afa4574cefbf079"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=32f7f7c6#32f7f7c675aa15c03d960f080105702c319479ea"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=64720904#64720904a3779784e092bc6b8afa4574cefbf079"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=32f7f7c6#32f7f7c675aa15c03d960f080105702c319479ea"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=64720904#64720904a3779784e092bc6b8afa4574cefbf079"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -4357,7 +4357,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6151,7 +6151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -6172,7 +6172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6335,7 +6335,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6373,7 +6373,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9413,7 +9413,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "32f7f7c6", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "64720904", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -9699,15 +9699,19 @@ impl Database {
     fn invalidate_rollup_hours(&self, project_id: &str, source: &str, date: &str, hours: u32) -> std::io::Result<()> {
         let _journal_guard = self.rollup_journal_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let source_key = (project_id.to_string(), source.to_string(), date.to_string());
-        // The first mutation observed for a partition cannot prove the rest of
-        // that day clean. Queue the full day once so empty slices acquire
-        // durable coverage too; otherwise sparse projects leave large raw gaps
-        // forever and wide queries can never reach the hybrid route.
-        let affected_hours = if self.rollup_dirty.contains_key(&source_key) { hours } else { crate::rollup::ALL_HOURS };
+        // The mutation tells us exactly which hours became dirty. Expanding a
+        // project's first observed hour to the full day creates 456 durable
+        // units for the dashboard rollups (144 dedup + 144 base + 144 packing
+        // + 24 derived), including future and empty slices. At 1,000 projects
+        // that is 456,000 urgent tasks from a single ingest wave. Uncovered
+        // intervals already use the exact raw fallback, so enqueue only work
+        // whose source rows can actually have changed. Historical discovery
+        // and source-wide DML continue to pass ALL_HOURS explicitly.
+        let affected_hours = hours;
         self.rollup_invalidated_at.entry(source_key.clone()).or_insert_with(crate::certification_store::now_unix_ms);
-        // An absent entry means prior changes are unknown, so establish a
-        // conservative full-day marker rather than claiming this batch's exact
-        // hours are complete.
+        // This path is called with a precise timestamp-derived mask. Unknown
+        // or source-wide changes use `invalidate_rollup_source` and pass
+        // `ALL_HOURS` instead.
         self.rollup_dirty.entry(source_key.clone()).and_modify(|dirty| *dirty |= affected_hours).or_insert(affected_hours);
         self.rollup_source_epochs.entry(source_key).and_modify(|epoch| *epoch = epoch.saturating_add(1)).or_insert(1);
         if let Some(schema) = get_schema(source) {
@@ -18969,6 +18973,29 @@ mod tests {
 
         assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0);
         assert_eq!(db.maintenance_tasks.lock().unwrap().source_cursor(cursor_key), Some(version));
+        Ok(())
+    }
+
+    /// A tenant's first write must not manufacture a full day of empty and
+    /// future maintenance debt. One dirty hour is six ten-minute source units
+    /// plus one derived hour; dedup and packing are shared by both rollup specs.
+    #[tokio::test]
+    async fn first_rollup_invalidation_enqueues_only_the_touched_hour() -> Result<()> {
+        use crate::maintenance_coordinator::Operation;
+
+        let db = Database::with_config(create_test_config("first-rollup-invalidation-is-sparse")).await?;
+        db.invalidate_rollup_hours("customer-a", "otel_logs_and_spans", "2026-08-16", 1 << 7)?;
+
+        let journal = db.maintenance_tasks.lock().unwrap();
+        let counts = journal.tasks().fold(HashMap::<Operation, usize>::new(), |mut counts, task| {
+            *counts.entry(task.key.operation).or_default() += 1;
+            counts
+        });
+        assert_eq!(counts.get(&Operation::Dedup), Some(&6));
+        assert_eq!(counts.get(&Operation::BaseRollup), Some(&6));
+        assert_eq!(counts.get(&Operation::DerivedRollup), Some(&1));
+        assert_eq!(counts.get(&Operation::HotPacking), Some(&6));
+        assert_eq!(journal.tasks().count(), 19, "one touched hour, not 456 full-day tasks");
         Ok(())
     }
 

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -1972,9 +1972,14 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
             "resource___service___name": service,
         })])
     };
-    // Yesterday, spread over several 1m buckets and starting mid-bucket so the
-    // left fringe is non-empty too.
-    for (i, offset) in [17i64, 61_000_000, 130_000_000, 610_000_000].iter().enumerate() {
+    // Yesterday, spread over six genuinely touched hours and starting
+    // mid-bucket so the left fringe is non-empty too. The hybrid cost guard
+    // intentionally declines a rollup covering less than 20% of the requested
+    // window; keeping these rows in one hour made this test depend on the old
+    // first-write bug manufacturing full-day empty coverage.
+    for (i, offset) in
+        [17i64, 61_000_000, 130_000_000, 610_000_000, 3_661_000_000, 7_330_000_000, 10_810_000_000, 14_410_000_000, 18_010_000_000].iter().enumerate()
+    {
         db.insert_records_batch(
             &project_id,
             "otel_logs_and_spans",
@@ -2030,7 +2035,32 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
         .filter_map(|b| b.column(0).as_primitive_opt::<Int64Type>().map(|c| c.value(0)))
         .next()
         .unwrap_or(0);
-    assert_eq!(built, 4, "certification must have rolled up all four of yesterday's spans");
+    assert_eq!(built, 9, "certification must have rolled up all nine of yesterday's spans");
+    let base_target = db.unified_tables().read().await.get("otel_logs_and_spans_rollup_dashboard_1m_v3").expect("base rollup table created").clone();
+    let tagged_files = base_target
+        .read()
+        .await
+        .snapshot()?
+        .log_data()
+        .iter()
+        .filter(|file| {
+            #[allow(deprecated)]
+            let action = file.add_action();
+            action.tags.as_ref().is_some_and(|tags| tags.contains_key(timefusion::maintenance_coordinator::TAG_SLICE_START))
+        })
+        .count();
+    assert!(tagged_files >= 6, "every independently published slice must retain its Delta Add tags");
+    let derived_built: i64 = db
+        .query_delta_only(&format!(
+            "SELECT COALESCE(SUM(request_count), 0)::BIGINT FROM otel_logs_and_spans_rollup_dashboard_1h_v2 WHERE project_id = '{project_id}'"
+        ))
+        .await?
+        .iter()
+        .filter(|b| b.num_rows() > 0)
+        .filter_map(|b| b.column(0).as_primitive_opt::<Int64Type>().map(|c| c.value(0)))
+        .next()
+        .unwrap_or(0);
+    assert_eq!(derived_built, 9, "derived coverage must merge every independently published base slice");
 
     let rows_of = |batches: Vec<datafusion::arrow::array::RecordBatch>| {
         batches
@@ -2086,7 +2116,7 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
 
     assert_eq!(hybrid, raw, "the hybrid rewrite must equal the raw aggregate exactly");
     assert_eq!(hybrid.len(), 2, "both services must survive, including the one that exists only in the raw tail: {hybrid:?}");
-    assert_eq!(hybrid.iter().map(|row| row.1).sum::<i64>(), 6, "every fixture row must be counted exactly once: {hybrid:?}");
+    assert_eq!(hybrid.iter().map(|row| row.1).sum::<i64>(), 11, "every fixture row must be counted exactly once: {hybrid:?}");
 
     // THE SAME WINDOW WITH NO UPPER BOUND — the shape monoscope's 7d and 14d
     // panels actually send. Until 2026-08-15 the matcher demanded both bounds
@@ -2104,7 +2134,7 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     let open_rows = rows_of(ctx.sql(&open).await?.collect().await?);
     assert_eq!(hits(), before + 1, "an open-ended window must route, not fall back to a raw scan (misses +{})", misses() - misses_before);
     assert_eq!(open_rows, rows_of(db.query_delta_only(&open).await?), "the open-ended rewrite must equal the raw aggregate exactly");
-    assert_eq!(open_rows.iter().map(|row| row.1).sum::<i64>(), 7, "the open tail must reach the row past the bounded window: {open_rows:?}");
+    assert_eq!(open_rows.iter().map(|row| row.1).sum::<i64>(), 12, "the open tail must reach the row past the bounded window: {open_rows:?}");
 
     // The shape prod's `rollup_declined_shape` log printed for months: a CAST
     // over an aggregate plus `ORDER BY <an aggregate> LIMIT n` optimizes to
@@ -2154,7 +2184,7 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     let before = hits();
     let after_update = rows_of(ctx.sql(&query).await?.collect().await?);
     assert_eq!(hits(), before + 1, "a DML confined to today must leave yesterday's coverage intact (misses +{})", misses() - misses_before);
-    assert_eq!(after_update.iter().map(|row| row.1).sum::<i64>(), 6, "the enrichment must not change the counted rows: {after_update:?}");
+    assert_eq!(after_update.iter().map(|row| row.1).sum::<i64>(), 11, "the enrichment must not change the counted rows: {after_update:?}");
 
     // monoscope's Golden Signals row filter, which is exactly the predicate the
     // server_* measures declare. Unit tests pass this on a bare MemTable session;
@@ -2183,7 +2213,7 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     let before = hits();
     let after_by_id = rows_of(ctx.sql(&query).await?.collect().await?);
     assert_eq!(hits(), before + 1, "an id-scoped DML on today's row must leave yesterday's coverage intact (misses +{})", misses() - misses_before);
-    assert_eq!(after_by_id.iter().map(|row| row.1).sum::<i64>(), 6, "the id-scoped update must not change the counted rows: {after_by_id:?}");
+    assert_eq!(after_by_id.iter().map(|row| row.1).sum::<i64>(), 11, "the id-scoped update must not change the counted rows: {after_by_id:?}");
     Ok(())
 }
 


### PR DESCRIPTION
## What changed
- stop expanding a project first write into a full day of empty and future maintenance tasks
- retain full-day invalidation for source-wide DML and recovery paths
- add regression coverage for the exact 19-task one-hour lifecycle

## Why
A single touched hour previously created 456 durable tasks per project. A 1,000-project ingest wave therefore manufactured 456,000 urgent tasks before any byte-bounded work ran. Existing raw fallback preserves exact reads for uncovered intervals.

## Verification
- `cargo fmt --check`
- `cargo test first_rollup_invalidation_enqueues_only_the_touched_hour --lib`
- `cargo test maintenance_coordinator --lib` (21 passed)
- `cargo test rollup --lib` (65 passed)