### PR TITLE
fix(maintenance): bound coordinator unit runtime

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -3656,18 +3656,27 @@ impl Database {
                                     if cancel.is_cancelled() {
                                         return;
                                     }
-                                    match db.run_maintenance_coordinator_once().await {
-                                        Ok(true) => tokio::task::yield_now().await,
-                                        Ok(false) => tokio::select! {
+                                    const UNIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+                                    match tokio::time::timeout(UNIT_TIMEOUT, db.run_maintenance_coordinator_once()).await {
+                                        Ok(Ok(true)) => tokio::task::yield_now().await,
+                                        Ok(Ok(false)) => tokio::select! {
                                             _ = cancel.cancelled() => return,
                                             _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
                                         },
-                                        Err(error) => {
+                                        Ok(Err(error)) => {
                                             warn!(worker, %error, event = "maintenance_coordinator_error");
                                             tokio::select! {
                                                 _ = cancel.cancelled() => return,
                                                 _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
                                             }
+                                        }
+                                        Err(_) => {
+                                            // Dropping the future drops its TaskLease, which
+                                            // durably requeues the claimed unit and releases
+                                            // every admission token. A whale or wedged object
+                                            // read therefore costs one bounded turn instead of
+                                            // freezing maintenance for every project forever.
+                                            warn!(worker, timeout_seconds = UNIT_TIMEOUT.as_secs(), event = "maintenance_coordinator_unit_timed_out");
                                         }
                                     }
                                 }
@@ -9089,6 +9098,8 @@ impl Database {
         };
         let Some(task) = task else { return Ok(false) };
         let key = task.key.clone();
+        info!(operation = ?key.operation, table = %key.physical_table, project_id = %key.project_id, slice_start = key.slice.start_micros, slice_end = key.slice.end_micros,
+            estimated_decoded_bytes = task.estimated_decoded_bytes, attempts = task.attempts, event = "maintenance_task_started");
         let _lease = crate::maintenance_coordinator::TaskLease::new(Arc::clone(&self.maintenance_tasks), key.clone());
         let retry = |reason: String, delay: std::time::Duration| -> Result<()> {
             let delay_micros = i64::try_from(delay.as_micros()).unwrap_or(i64::MAX);
@@ -9154,6 +9165,8 @@ impl Database {
         };
         let Some(task) = task else { return Ok(false) };
         let key = task.key.clone();
+        info!(operation = ?key.operation, table = %key.physical_table, project_id = %key.project_id, slice_start = key.slice.start_micros, slice_end = key.slice.end_micros,
+            estimated_decoded_bytes = task.estimated_decoded_bytes, attempts = task.attempts, event = "maintenance_task_started");
         let _lease = crate::maintenance_coordinator::TaskLease::new(Arc::clone(&self.maintenance_tasks), key.clone());
         let retry = |reason: String, delay: std::time::Duration| -> Result<()> {
             let delay = i64::try_from(delay.as_micros()).unwrap_or(i64::MAX);
@@ -9548,6 +9561,8 @@ impl Database {
         };
         let Some(task) = task else { return Ok(false) };
         let key = task.key.clone();
+        info!(operation = ?key.operation, table = %key.physical_table, project_id = %key.project_id, slice_start = key.slice.start_micros, slice_end = key.slice.end_micros,
+            estimated_decoded_bytes = task.estimated_decoded_bytes, attempts = task.attempts, event = "maintenance_task_started");
         let _lease = TaskLease::new(Arc::clone(&self.maintenance_tasks), key.clone());
         let retry = |reason: String, seconds: u64| -> Result<()> {
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -218,7 +218,9 @@ impl Drop for TaskLease {
     fn drop(&mut self) {
         let mut journal = self.journal.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if journal.state(&self.key) == Some(TaskState::Running) {
-            journal.retry(&self.key, "worker_error".to_owned(), crate::clock::now_micros().saturating_add(1_000_000));
+            let attempts = journal.task_indices.get(&self.key).and_then(|index| journal.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts).min(8);
+            let delay_micros = i64::try_from((1u64 << attempts).saturating_mul(1_000_000)).unwrap_or(i64::MAX);
+            journal.retry(&self.key, "worker_error".to_owned(), crate::clock::now_micros().saturating_add(delay_micros));
             if let Err(error) = journal.checkpoint() {
                 tracing::error!(error = %error, task = ?self.key, "failed to checkpoint maintenance task lease recovery");
             }
@@ -1134,9 +1136,15 @@ mod tests {
         assert!(journal.mark_running(&key));
         journal.checkpoint().expect("running checkpoint");
         let journal = Arc::new(Mutex::new(journal));
+        let before_drop = crate::clock::now_micros();
         drop(TaskLease::new(Arc::clone(&journal), key.clone()));
 
-        assert_eq!(journal.lock().expect("lock").state(&key), Some(TaskState::Retry));
+        let journal_guard = journal.lock().expect("lock");
+        assert_eq!(journal_guard.state(&key), Some(TaskState::Retry));
+        let task = journal_guard.snapshot.tasks.iter().find(|task| task.key == key).expect("requeued task");
+        assert_eq!(task.retry_reason.as_deref(), Some("worker_error"));
+        assert!(task.deadline_micros >= before_drop + 2_000_000, "first failed attempt must use the same exponential backoff as explicit worker errors");
+        drop(journal_guard);
         let loaded = TaskJournal::load(dir.path()).expect("load checkpoint");
         assert_eq!(loaded.state(&key), Some(TaskState::Retry));
     }


### PR DESCRIPTION
## Production finding

After deploying #91, production restored 20,751 durable tasks safely, but the first claimed unit held the only coordinator slot for more than 10 minutes with zero completed tasks or processed-byte progress. Foreground reads and ingest remained healthy, but maintenance lag increased.

## Change

- Bound each coordinator turn to five minutes.
- On timeout, cancellation drops the existing TaskLease, which durably requeues the task and releases CPU/memory/object tokens; fair project rotation can continue.
- Emit exact operation/table/project/slice/estimate metadata when a unit starts and one summarized timeout event.
- No component or configuration is disabled.

## Verification

- `cargo check --locked`
- `cargo fmt --check`
- Existing TaskLease test covers cancellation/drop requeue semantics.
- Production evidence before change: tasks_complete=477, tasks_running=1, processed_bytes_total=8404128782 unchanged for >10 minutes; service healthy and fresh throughout.