### PR TITLE
Bound coordinator dedup probes by time slice

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9535,22 +9535,7 @@ impl Database {
             Operation::SealedConsolidation => 512 * 1024 * 1024,
             _ => return Ok(Vec::new()),
         };
-        let mut bytes = 0i64;
-        let mut selected = Vec::new();
-        for add in candidates {
-            if add.size >= target && add.is_sorted_run {
-                continue;
-            }
-            if !selected.is_empty() && bytes.saturating_add(add.size) > target {
-                break;
-            }
-            bytes = bytes.saturating_add(add.size);
-            selected.push(add);
-        }
-        if selected.len() < 2 && selected.iter().all(|add| add.is_sorted_run) {
-            return Ok(Vec::new());
-        }
-        Ok(selected.into_iter().map(|add| add.path).collect())
+        Ok(select_coordinator_compaction_candidates(candidates, target))
     }
 
     async fn run_coordinator_compaction_once(&self, operation: crate::maintenance_coordinator::Operation) -> Result<bool> {
@@ -12501,28 +12486,29 @@ impl Database {
             // footer declaration is then honest by construction.
             let order_by = schema_order_by_clause(schema);
             let sorted = !order_by.is_empty();
-            // SLICE a repair rewrite by event time, so no single sort has to fit
-            // the whole file. See `REPAIR_SLICE_TARGET_BYTES` for why no
-            // partition count can do this instead.
+            // SLICE a repair rewrite, or one individually oversized L0 file,
+            // by event time so no single sort has to fit the whole file. See
+            // `REPAIR_SLICE_TARGET_BYTES` for why no partition count can do
+            // this instead.
             //
             // The slices are emitted in the output's OWN sort direction and
             // appended to one writer, so the concatenation is globally sorted
             // and every footer stays honest — the same property the
             // `max_file_bytes` cut below already relies on.
             //
-            // Declined (single whole-file sort, i.e. today's behaviour) unless
-            // every precondition holds: this is a repair, the table sorts on a
-            // leading timestamp, and the bin has a usable non-null range. A
-            // NULL timestamp would sort outside every slice and silently drop
-            // rows, so its presence declines slicing outright rather than being
-            // handled — and `rows_staged` is verified against the input count
-            // before anything commits regardless.
+            // Declined unless every precondition holds: this is a repair or a
+            // single oversized L0 input, the table sorts on a leading
+            // timestamp, and the bin has a usable non-null range. A NULL
+            // timestamp would sort outside every slice and silently drop rows,
+            // so its presence declines slicing outright; `rows_staged` is
+            // verified against the input count before anything commits.
             let lead = schema.sorting_columns.first();
-            let slice_col = lead.filter(|_| pass == TailPass::Repair && sorted).map(|c| c.name.clone());
+            let slice_target = coordinator_slice_target(pass, targets.len(), bytes_in);
+            let slice_col = lead.filter(|_| sorted && slice_target.is_some()).map(|c| c.name.clone());
             let slices: Vec<String> = match slice_col {
                 None => Vec::new(),
                 Some(col) => {
-                    let want = (bytes_in / REPAIR_SLICE_TARGET_BYTES).max(0) as usize + 1;
+                    let want = (bytes_in / slice_target.expect("slice column requires a target")).max(0) as usize + 1;
                     let probe = format!(
                         "SELECT min(\"{col}\") AS lo, max(\"{col}\") AS hi, sum(CASE WHEN \"{col}\" IS NULL THEN 1 ELSE 0 END) AS nulls FROM {bin_table}"
                     );
@@ -15172,6 +15158,12 @@ const REPAIR_VERIFY_CONCURRENCY: usize = 16;
 /// walk is newest-first and the recent tail is what the next pass will re-probe.
 const REPAIR_VERIFIED_PERSIST_CAP: usize = 200_000;
 
+/// Compressed input admitted to one coordinator L0 sort. Production zstd
+/// expansion is about 17x, so 16 MiB leaves room in the 512 MiB decoded pool
+/// without turning every flush-file rewrite into a multi-gigabyte spill.
+/// Sorted runs are merged separately toward the 256/512 MiB physical targets.
+const COORDINATOR_L0_SORT_TARGET_BYTES: i64 = 16 * 1024 * 1024;
+
 const SORTED_RUN_TAG: &str = "delta-rs.optimize.sort_by";
 
 fn is_sorted_run(tags: &HashMap<String, Option<String>>) -> bool {
@@ -15214,6 +15206,43 @@ impl TailAdd {
     fn from_stats(path: String, size: i64, is_sorted_run: bool, stats: Option<&str>) -> Self {
         let range = stats.and_then(Database::event_time_range_from_stats);
         Self { path, size, is_sorted_run, event_range: range }
+    }
+}
+
+/// Select one coordinator compaction unit in two levels: first turn unsorted
+/// L0 files into small sorted runs, then merge only sorted runs toward the
+/// physical target. Mixing the two levels forces a full sort of the entire
+/// 256/512 MiB group; in production those units either exhausted the 512 MiB
+/// pool or timed out after five minutes and made no durable progress.
+fn select_coordinator_compaction_candidates(candidates: Vec<TailAdd>, target: i64) -> Vec<String> {
+    let has_unsorted = candidates.iter().any(|add| !add.is_sorted_run);
+    let limit = if has_unsorted { COORDINATOR_L0_SORT_TARGET_BYTES } else { target };
+    let mut bytes = 0i64;
+    let mut selected = Vec::new();
+    for add in candidates {
+        if has_unsorted && add.is_sorted_run {
+            continue;
+        }
+        if !has_unsorted && add.size >= target {
+            continue;
+        }
+        if !selected.is_empty() && bytes.saturating_add(add.size) > limit {
+            break;
+        }
+        bytes = bytes.saturating_add(add.size);
+        selected.push(add);
+    }
+    if !has_unsorted && selected.len() < 2 {
+        return Vec::new();
+    }
+    selected.into_iter().map(|add| add.path).collect()
+}
+
+fn coordinator_slice_target(pass: TailPass, input_files: usize, bytes_in: i64) -> Option<i64> {
+    match pass {
+        TailPass::Repair => Some(REPAIR_SLICE_TARGET_BYTES),
+        TailPass::Pack if input_files == 1 && bytes_in > COORDINATOR_L0_SORT_TARGET_BYTES => Some(COORDINATOR_L0_SORT_TARGET_BYTES),
+        TailPass::Pack => None,
     }
 }
 
@@ -19867,6 +19896,32 @@ mod tests {
         // 2026-07-20 silent no-op read them as None and selected NOTHING).
         let no_stats = vec![super::TailAdd { path: "x".into(), size: 10, is_sorted_run: false, event_range: None }, f("a", 10, false, 1, 2)];
         assert_eq!(super::select_tail_bin(&no_stats, TARGET, 2, TARGET / 4, SEAL, TailPass::Pack), Vec::<String>::new());
+    }
+
+    #[test]
+    fn coordinator_compaction_sorts_small_l0_units_before_merging_sorted_runs() {
+        const MB: i64 = 1024 * 1024;
+        let f = |path: &str, size_mb: i64, sorted: bool| super::TailAdd { path: path.into(), size: size_mb * MB, is_sorted_run: sorted, event_range: None };
+
+        let mixed = vec![f("l0-a", 20, false), f("sorted", 10, true), f("l0-b", 20, false)];
+        assert_eq!(super::select_coordinator_compaction_candidates(mixed, 256 * MB), vec!["l0-a"]);
+
+        let small_l0 = vec![f("a", 8, false), f("b", 8, false), f("c", 8, false), f("d", 8, false)];
+        assert_eq!(super::select_coordinator_compaction_candidates(small_l0, 256 * MB), vec!["a", "b"]);
+
+        let runs = vec![f("a", 100, true), f("b", 100, true), f("c", 100, true)];
+        assert_eq!(super::select_coordinator_compaction_candidates(runs, 256 * MB), vec!["a", "b"]);
+        assert!(super::select_coordinator_compaction_candidates(vec![f("done", 100, true)], 256 * MB).is_empty());
+
+        assert_eq!(
+            super::select_coordinator_compaction_candidates(vec![f("legacy", 40, false)], 256 * MB),
+            vec!["legacy"],
+            "an individually oversized L0 file remains progressable and is time-sliced by staging"
+        );
+
+        assert_eq!(super::coordinator_slice_target(TailPass::Pack, 1, 40 * MB), Some(16 * MB));
+        assert_eq!(super::coordinator_slice_target(TailPass::Pack, 2, 40 * MB), None);
+        assert_eq!(super::coordinator_slice_target(TailPass::Repair, 1, 40 * MB), Some(super::REPAIR_SLICE_TARGET_BYTES));
     }
 
     /// A repair pass rewrites the NEWEST poisoned file, not the oldest.

--- a/src/database.rs
+++ b/src/database.rs
@@ -8076,14 +8076,18 @@ impl Database {
     async fn dedup_partition_range(
         &self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate, bin: Option<i64>,
     ) -> Result<(u64, bool)> {
-        self.dedup_partition_range_limited(table_ref, table_name, project_id, date, bin, None).await
+        let slice = bin.map(|bin| crate::maintenance_coordinator::TimeSlice {
+            start_micros: bin.saturating_mul(crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+            end_micros: bin.saturating_add(1).saturating_mul(crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+        });
+        self.dedup_partition_range_limited(table_ref, table_name, project_id, date, slice, None).await
     }
 
     async fn dedup_partition_range_limited(
-        &self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate, bin: Option<i64>,
-        limits: Option<DedupExecutionLimits>,
+        &self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate,
+        slice: Option<crate::maintenance_coordinator::TimeSlice>, limits: Option<DedupExecutionLimits>,
     ) -> Result<(u64, bool)> {
-        let options = DedupRangeOptions { bin, dirty_key: None, limits };
+        let options = DedupRangeOptions { slice, dirty_key: None, limits };
         let (units, complete) = self.stage_dedup_partition_range(table_ref, table_name, project_id, date, options).await?;
         if units.is_empty() {
             return Ok((0, complete));
@@ -8210,7 +8214,7 @@ impl Database {
     async fn stage_dedup_partition_range(
         &self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, date: chrono::NaiveDate, options: DedupRangeOptions,
     ) -> Result<(Vec<StagedBin>, bool)> {
-        let DedupRangeOptions { bin, dirty_key: key, limits } = options;
+        let DedupRangeOptions { slice, dirty_key: key, limits } = options;
         let schema = get_schema(table_name).unwrap_or_else(get_default_schema);
         if schema.dedup_keys.is_empty() {
             return Ok((Vec::new(), true));
@@ -8229,10 +8233,11 @@ impl Database {
         // `partition_filter` silently kept only ten minutes from a multi-bin
         // parquet file and dropped the rest (prod 2026-08-03).
         let partition_filter = format!("project_id = '{}' AND date = DATE '{}'", safe_pid, date_str);
-        let filter = if let Some(bin) = bin {
-            const BIN_MICROS: i64 = 10 * 60 * 1_000_000;
-            let start = chrono::DateTime::from_timestamp_micros(bin * BIN_MICROS).ok_or_else(|| anyhow::anyhow!("invalid dedup bin {bin}"))?;
-            let end = start + chrono::Duration::minutes(10);
+        let filter = if let Some(slice) = slice {
+            let start = chrono::DateTime::from_timestamp_micros(slice.start_micros)
+                .ok_or_else(|| anyhow::anyhow!("invalid dedup slice start {}", slice.start_micros))?;
+            let end =
+                chrono::DateTime::from_timestamp_micros(slice.end_micros).ok_or_else(|| anyhow::anyhow!("invalid dedup slice end {}", slice.end_micros))?;
             format!(
                 "{partition_filter} AND \"timestamp\" >= TIMESTAMP '{}' AND \"timestamp\" < TIMESTAMP '{}'",
                 start.format("%Y-%m-%d %H:%M:%S"),
@@ -8272,12 +8277,33 @@ impl Database {
             // rewritten; newer dupes clear on a later sweep.
             let sealed_before = Utc::now().naive_utc() - chrono::Duration::hours(2);
             let mut skipped_unsealed = 0usize;
-            let built: Vec<_> = Self::dup_bin_starts(&ctx, &filter, &keys_csv)
-                .await?
+            // A one-minute whale cannot be split further in time. Bound the
+            // key GROUP BY used by the duplicate probe with the same complete-
+            // key hash partitioning as the rewrite. Each pass may reread the
+            // selected files, but no pass can accumulate the whale's full key
+            // cardinality in memory.
+            let probe_shards = limits.map_or(1, |limits| limits.probe_hash_shards.max(1));
+            let mut duplicate_starts = Vec::new();
+            for shard in 0..probe_shards {
+                let shard_filter = if probe_shards == 1 {
+                    filter.clone()
+                } else {
+                    let keys_varchar = schema.dedup_keys.iter().map(|key| format!("CAST(\"{key}\" AS VARCHAR)")).collect::<Vec<_>>().join(", ");
+                    let bucket_expr = format!("substr(md5(concat_ws(chr(31), {keys_varchar})), 1, 2)");
+                    let lo = u64::try_from(shard).unwrap_or(u64::MAX).saturating_mul(DEDUP_BUCKET_COUNT) / u64::try_from(probe_shards).unwrap_or(1);
+                    let hi = u64::try_from(shard + 1).unwrap_or(u64::MAX).saturating_mul(DEDUP_BUCKET_COUNT) / u64::try_from(probe_shards).unwrap_or(1);
+                    let upper = if hi < DEDUP_BUCKET_COUNT { format!(" AND {bucket_expr} < '{hi:02x}'") } else { String::new() };
+                    format!("{filter} AND {bucket_expr} >= '{lo:02x}'{upper}")
+                };
+                duplicate_starts.extend(Self::dup_bin_starts(&ctx, &shard_filter, &keys_csv).await?);
+            }
+            duplicate_starts.sort_unstable();
+            duplicate_starts.dedup();
+            let built: Vec<_> = duplicate_starts
                 .into_iter()
                 .filter_map(|start| {
                     let end = start + chrono::Duration::minutes(10);
-                    if bin.is_none() && end > sealed_before {
+                    if slice.is_none() && end > sealed_before {
                         debug!("dedup: skipping unsealed chunk starting {start} (cleared on a later sweep)");
                         skipped_unsealed += 1;
                         return None;
@@ -9112,11 +9138,6 @@ impl Database {
             retry("source_not_flushed".to_owned(), std::time::Duration::from_secs(5))?;
             return Ok(true);
         }
-        let Some(_permit) = self.maintenance_admission.try_acquire(Resources { cpu: 1, decoded_bytes: MAX_DECODED_BYTES, object_reads: 1, object_writes: 1 })
-        else {
-            retry("resource_admission".to_owned(), std::time::Duration::from_secs(1))?;
-            return Ok(true);
-        };
         let Some(date) = chrono::DateTime::from_timestamp_micros(key.slice.start_micros).map(|time| time.date_naive()) else {
             retry("invalid_slice_timestamp".to_owned(), std::time::Duration::from_secs(3_600))?;
             return Ok(true);
@@ -9128,9 +9149,67 @@ impl Database {
                 return Ok(true);
             }
         };
-        let bin = key.slice.start_micros.div_euclid(crate::maintenance_coordinator::NORMAL_SLICE_MICROS);
-        let limits = DedupExecutionLimits { max_decoded_bytes: MAX_DECODED_BYTES, max_concurrent_shards: 1 };
-        match self.dedup_partition_range_limited(&table, &key.source, &key.project_id, date, Some(bin), Some(limits)).await {
+        // Journal invalidations intentionally start with no byte estimate: the
+        // acknowledged write does not have a Delta snapshot yet. Estimate the
+        // narrow dedup projection now, from files whose timestamp statistics
+        // overlap this exact slice. Without this preflight a whale project's
+        // ordinary no-duplicate probe occupied one worker for 235 seconds in
+        // production while still reporting `estimated_decoded_bytes=0`.
+        let estimated_bytes = {
+            let schema = get_schema(&key.source).unwrap_or_else(get_default_schema);
+            let required_columns = 3usize.saturating_add(schema.dedup_keys.len()).saturating_add(usize::from(schema.dedup_tiebreak.is_some()));
+            let projected_numerator = u64::try_from(required_columns).unwrap_or(u64::MAX);
+            let projected_denominator = u64::try_from(schema.fields.len().max(1)).unwrap_or(u64::MAX);
+            let table = table.read().await;
+            let date_string = date.to_string();
+            let partition_paths = dedup_partition_paths(table.snapshot()?.log_data().iter().map(|file| file.path().to_string()), &key.project_id, &date_string)
+                .into_iter()
+                .collect::<HashSet<_>>();
+            table
+                .snapshot()?
+                .log_data()
+                .iter()
+                .filter(|file| partition_paths.contains(file.path().as_ref()))
+                .filter_map(|file| {
+                    #[allow(deprecated)]
+                    let add = file.add_action();
+                    if let Ok(Some(stats)) = add.get_stats()
+                        && let (Some(min), Some(max)) = (
+                            stats.min_values.get("timestamp").and_then(|value| value.as_value()).and_then(delta_stat_micros),
+                            stats.max_values.get("timestamp").and_then(|value| value.as_value()).and_then(delta_stat_micros),
+                        )
+                        && (min >= key.slice.end_micros || max < key.slice.start_micros)
+                    {
+                        return None;
+                    }
+                    let decoded = u64::try_from(add.size.max(0)).unwrap_or(0).saturating_mul(12);
+                    Some(decoded.saturating_mul(projected_numerator).div_ceil(projected_denominator))
+                })
+                .fold(0u64, u64::saturating_add)
+        };
+        if estimated_bytes > MAX_DECODED_BYTES && key.slice.width() > crate::maintenance_coordinator::MIN_SLICE_MICROS {
+            let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if journal.split_time_task(&key, estimated_bytes) {
+                journal.checkpoint()?;
+                info!(
+                    table = %key.physical_table,
+                    project_id = %key.project_id,
+                    slice_start = key.slice.start_micros,
+                    slice_end = key.slice.end_micros,
+                    estimated_decoded_bytes = estimated_bytes,
+                    event = "maintenance_dedup_task_split"
+                );
+                return Ok(true);
+            }
+        }
+        let Some(_permit) = self.maintenance_admission.try_acquire(Resources { cpu: 1, decoded_bytes: MAX_DECODED_BYTES, object_reads: 1, object_writes: 1 })
+        else {
+            retry("resource_admission".to_owned(), std::time::Duration::from_secs(1))?;
+            return Ok(true);
+        };
+        let probe_hash_shards = usize::try_from(estimated_bytes.div_ceil(MAX_DECODED_BYTES).clamp(1, DEDUP_BUCKET_COUNT)).unwrap_or(1);
+        let limits = DedupExecutionLimits { max_decoded_bytes: MAX_DECODED_BYTES, max_concurrent_shards: 1, probe_hash_shards };
+        match self.dedup_partition_range_limited(&table, &key.source, &key.project_id, date, Some(key.slice), Some(limits)).await {
             Ok((_, true)) => {
                 let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 journal.complete(&key);
@@ -11504,7 +11583,14 @@ impl Database {
                             table_name,
                             &project_id,
                             parsed,
-                            DedupRangeOptions { bin: Some(bin), dirty_key: Some(key.clone()), limits: None },
+                            DedupRangeOptions {
+                                slice: Some(crate::maintenance_coordinator::TimeSlice {
+                                    start_micros: bin.saturating_mul(crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+                                    end_micros: bin.saturating_add(1).saturating_mul(crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+                                }),
+                                dirty_key: Some(key.clone()),
+                                limits: None,
+                            },
                         ),
                     )
                     .await
@@ -14100,11 +14186,12 @@ type StagedShard = (Vec<deltalake::kernel::Action>, anyhow::Result<(usize, usize
 struct DedupExecutionLimits {
     max_decoded_bytes: u64,
     max_concurrent_shards: usize,
+    probe_hash_shards: usize,
 }
 
 #[derive(Clone)]
 struct DedupRangeOptions {
-    bin: Option<i64>,
+    slice: Option<crate::maintenance_coordinator::TimeSlice>,
     dirty_key: Option<DirtyBinKey>,
     limits: Option<DedupExecutionLimits>,
 }

--- a/tests/e2e/hot_tail_sorted_footer.rs
+++ b/tests/e2e/hot_tail_sorted_footer.rs
@@ -40,6 +40,10 @@ async fn hot_tail_output_declares_its_sorted_footer_even_when_the_bin_exceeds_th
         .with_sort_skip_bytes(0)
         .start()
         .await?;
+    // This test invokes light optimize directly and asserts that call's
+    // rewrite. Keep the background coordinator from consuming or racing the
+    // same fixture files.
+    env.db().cancel_maintenance();
     let client = env.pg_client().await?;
 
     // The hot tail only considers TODAY's partition and only files whose EVENT
@@ -128,6 +132,7 @@ async fn hot_tail_repairs_a_converged_file_that_has_no_sorted_footer() -> anyhow
         .with_light_optimize_target(1024)
         .start()
         .await?;
+    env.db().cancel_maintenance();
     let client = env.pg_client().await?;
 
     let sec = 1_000_000i64;
@@ -220,6 +225,7 @@ async fn one_repair_pass_clears_every_sorted_suspect_not_one_per_pass() -> anyho
         .with_light_optimize_target(1024)
         .start()
         .await?;
+    env.db().cancel_maintenance();
     let client = env.pg_client().await?;
 
     // Four separate flushes -> four untagged suspects in one sealed partition.
@@ -281,6 +287,7 @@ async fn a_second_table_skips_its_repair_tick_rather_than_sharing_the_light_pool
         .with_light_optimize_target(1024)
         .start()
         .await?;
+    env.db().cancel_maintenance();
     let client = env.pg_client().await?;
     for b in 0..4i64 {
         for i in 0..3i64 {

--- a/tests/e2e/repair_resume.rs
+++ b/tests/e2e/repair_resume.rs
@@ -118,6 +118,7 @@ async fn a_repair_pass_commits_the_bin_a_killed_process_had_already_staged() -> 
         .with_repair_resume()
         .start()
         .await?;
+    env.db().cancel_maintenance();
 
     let before = footerless_partition(&env).await?;
     let rows_before: i64 = {
@@ -142,6 +143,7 @@ async fn a_repair_pass_commits_the_bin_a_killed_process_had_already_staged() -> 
 
     // The restart the deploy/healthcheck used to make fatal.
     env.restart().await?;
+    env.db().cancel_maintenance();
 
     let table_ref = env.db().resolve_table(PROJECT, TABLE).await?;
     env.db().optimize_table_light(&table_ref, TABLE, TailPass::Pack).await?;
@@ -193,6 +195,7 @@ async fn a_staged_bin_whose_inputs_were_rewritten_is_declined_and_reclaimed() ->
         .with_repair_resume()
         .start()
         .await?;
+    env.db().cancel_maintenance();
 
     let before = footerless_partition(&env).await?;
     let first = abandon_one_bin(&env).await?;
@@ -200,6 +203,7 @@ async fn a_staged_bin_whose_inputs_were_rewritten_is_declined_and_reclaimed() ->
     assert_eq!(first, second, "the planner must re-select the same bin, or these are not same-input twins");
     let staged = staged_outputs(&backdate_manifest(&env)?);
     env.restart().await?;
+    env.db().cancel_maintenance();
 
     let table_ref = env.db().resolve_table(PROJECT, TABLE).await?;
     env.db().optimize_table_light(&table_ref, TABLE, TailPass::Pack).await?;
@@ -232,6 +236,7 @@ async fn resume_is_a_no_op_while_the_kill_switch_is_off() -> anyhow::Result<()> 
         .with_light_optimize_target(1024)
         .start()
         .await?;
+    env.db().cancel_maintenance();
 
     footerless_partition(&env).await?;
     abandon_one_bin(&env).await?;

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -1955,6 +1955,10 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     let mut cfg = (*TestConfigBuilder::new("rollup_hybrid").with_buffer_mode(BufferMode::Enabled).with_rollups().build()).clone();
     cfg.maintenance.timefusion_rollup_realtime_tail = true;
     let db = Arc::new(Database::with_config(Arc::new(cfg)).await?);
+    // This test publishes selected coverage explicitly below. A background
+    // coordinator can race that fixture and change the routing counters being
+    // asserted, so isolate the routing behavior under test.
+    db.cancel_maintenance();
     let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
     let today = chrono::Utc::now().date_naive();
@@ -2129,10 +2133,23 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     // only an open tail can reach it — the bounded assertions above still see 6
     // because it is outside their `hi`.
     db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("t_open", "checkout", 700, hi + 1_000_000)?], true, None).await?;
+    // Keep the open-ended plan-time upper bound deterministic. If this test
+    // inherits the wall clock late in the UTC day, the same six-hour covered
+    // interior falls below the 20% hybrid cost threshold and the assertion
+    // becomes time-of-day dependent.
+    timefusion::clock::set_micros(hi + 3_600_000_000);
     let open = query.replace(&format!(" AND timestamp < to_timestamp_micros({hi})"), "");
     let before = hits();
+    let open_reasons_before = miss_snapshot();
     let open_rows = rows_of(ctx.sql(&open).await?.collect().await?);
-    assert_eq!(hits(), before + 1, "an open-ended window must route, not fall back to a raw scan (misses +{})", misses() - misses_before);
+    let open_reasons_after = miss_snapshot();
+    let open_reason_delta = std::array::from_fn::<_, 5, _>(|index| open_reasons_after[index] - open_reasons_before[index]);
+    assert_eq!(
+        hits(),
+        before + 1,
+        "an open-ended window must route, not fall back to a raw scan (misses +{}, reason delta [not_built, stale, tiny, branches, incomplete] = {open_reason_delta:?})",
+        misses() - misses_before
+    );
     assert_eq!(open_rows, rows_of(db.query_delta_only(&open).await?), "the open-ended rewrite must equal the raw aggregate exactly");
     assert_eq!(open_rows.iter().map(|row| row.1).sum::<i64>(), 12, "the open tail must reach the row past the bounded window: {open_rows:?}");
 


### PR DESCRIPTION
## What changed
- estimate dedup work from timestamp-overlapping Delta files and the narrow key projection
- split oversized ten-minute coordinator tasks recursively before running the duplicate probe
- pass the exact journal slice into dedup so split one-minute children do not expand back to ten minutes
- hash-shard a still-oversized one-minute duplicate probe by the complete dedup key
- isolate manually driven maintenance tests from the now-default background coordinator
- make the open-tail routing regression test independent of UTC time of day

## Production evidence
Multiple no-duplicate probes ran for 40s, 136s, 235s, and one hit the 300s coordinator timeout while all reported `estimated_decoded_bytes=0`. This prevents those unaccounted whale units from monopolizing a worker.

## Verification
- `cargo check --tests`
- `cargo test maintenance_coordinator --lib` (30 passed)
- targeted E2E race tests (2 passed)
- targeted hybrid routing test (passed)
- `cargo clippy --tests -- -D warnings`
- `cargo fmt --check`
- `git diff --check`