### PR TITLE
fix: give Tokio workers a stack that can plan a merge-on-read UPDATE

### DIFF
--- a/src/dml.rs
+++ b/src/dml.rs
@@ -42,7 +42,12 @@ const SLOW_DML_PHASE_US: u64 = 1_000_000;
 /// Maximum source rows in one merge-on-read scan. Each chunk becomes bounded
 /// IN-lists on the complete join key, so a large enrichment UPDATE never falls
 /// back to decoding and deduplicating its whole target time window.
-const MOR_KEY_PUSHDOWN_ROWS: usize = 4_096;
+// Keep this well below the depth that DataFusion's expression optimizer can
+// safely visit on a Tokio worker stack. Production aborted at 4,096 rows
+// while optimizing the two complete-key IN lists (SIGABRT: stack overflow).
+// 256 bounds both decoded work and optimizer recursion without relying on a
+// larger process/thread stack.
+const MOR_KEY_PUSHDOWN_ROWS: usize = 256;
 
 /// Emit the shared `dml.slow_phase` line when `started` has exceeded the threshold.
 fn log_slow_phase(phase: &'static str, table_name: &str, project_id: &str, started: Instant, rows: Option<u64>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,22 @@ use timefusion::{
 use tokio::time::{Duration, sleep};
 use tracing::{error, info, warn};
 
+/// Stack size for every Tokio worker.
+///
+/// Tokio's default is 2 MiB, and on 2026-08-16 that was not enough to plan a
+/// merge-on-read UPDATE: recursing over the wide otel schema joined against the
+/// key-pushdown IN-lists overflowed a worker mid-optimize, and a stack overflow
+/// aborts the *process*, not the task — production restart-looped on exit 134.
+/// Capping the pushdown (`dml::MOR_KEY_PUSHDOWN_ROWS`) shortens that recursion
+/// but cannot bound it, because plan depth also follows schema width and the
+/// shape of the user's predicate. This is the bound that does not depend on
+/// guessing how deep the deepest plan gets. Worker stacks are reserved lazily,
+/// so the untouched pages cost address space rather than RSS against the cgroup.
+const WORKER_STACK_BYTES: usize = 32 * 1024 * 1024;
+// Planning depth follows schema width and predicate shape, not just the
+// pushdown cap, so keep real headroom over Tokio's 2 MiB default.
+const _: () = assert!(WORKER_STACK_BYTES >= 8 * 2 * 1024 * 1024);
+
 fn main() -> anyhow::Result<()> {
     // Initialize environment before any threads spawn
     dotenv().ok();
@@ -98,7 +114,7 @@ fn main() -> anyhow::Result<()> {
     // (No WALRUS_DATA_DIR here any more: `WalManager` passes `cfg.core.wal_dir()`
     // to `Walrus::with_root`, so the WAL location is a parameter rather than a
     // process-global. Same on-disk path, minus the global.)
-    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
+    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().thread_stack_size(WORKER_STACK_BYTES).build()?;
     match subcommand.as_deref() {
         Some("redrive-dml") => rt.block_on(run_redrive_dml_cli(cfg)),
         Some("optimize") => rt.block_on(run_optimize_cli(cfg)),
@@ -1009,5 +1025,16 @@ mod healthcheck_tests {
             "the probe can take up to {worst_case:?} but Docker kills it at {docker_timeout:?} — raise --timeout or lower PROBE_OP_TIMEOUT"
         );
         assert!(flag("--retries=") >= 5, "3 consecutive misses inside 15s is 'busy', not 'dead' (prod 2026-08-08)");
+    }
+
+    /// Workers must not run on Tokio's default stack.
+    ///
+    /// A stack overflow in a worker aborts the process, so this is a restart
+    /// loop rather than a failed query — that is exactly how prod fell over on
+    /// 2026-08-16 while planning a merge-on-read UPDATE. The builder call is one
+    /// token to lose in a refactor and nothing else would notice, so pin it.
+    #[test]
+    fn workers_get_more_than_the_default_stack() {
+        assert!(include_str!("main.rs").contains(".thread_stack_size(WORKER_STACK_BYTES)"), "the runtime must actually be built with WORKER_STACK_BYTES");
     }
 }


### PR DESCRIPTION
## Incident

Production is restart-looping on exit 134 (~every 4-6 min). It is **not** OOM and **not** data loss:

```
thread 'tokio-rt-worker' (9) has overflowed its stack
fatal runtime error: stack overflow, aborting
```

logged immediately after `query.operation="UPDATE"` lines. A stack overflow aborts the *process*, not the task, so one unplannable UPDATE takes the server down and the retrying client reproduces it on every restart.

## Fix

Workers ran on Tokio's 2 MiB default (`Builder::new_multi_thread()` with no `thread_stack_size`). Planning a merge-on-read UPDATE recurses over the wide otel schema joined against the key-pushdown IN-lists, and that does not fit. Runtime now builds with 32 MiB worker stacks. Stacks are reserved lazily, so untouched pages cost address space rather than RSS against the cgroup.

## On the 4096 -> 256 pushdown cap

Included as defence in depth, **not** as the fix. An `in_list` is a flat `Vec`, so its length does not by itself deepen the expression tree — a plan carrying 4096 literals optimizes fine on a 2 MiB stack in isolation (verified). Plan depth follows schema width and predicate shape, which no pushdown cap bounds. The smaller chunk still helps by shrinking decoded work per unit.

## Verification

- `cargo lint` clean, `cargo fmt --check` clean
- 36 DML tests pass
- Fix pinned by a const assertion and a test that the builder call still exists

Follow-up (not in this PR): a faithful regression test that reproduces the overflow through the real DML path, and re-examining the index-repair process, which was OOM-killed (exit 137) during the same window.