### PR TITLE
feat(maintenance): size coordinator concurrency from the box, not a constant

### DIFF
--- a/docs/plans/2026-08-16-maintenance-throughput.md
+++ b/docs/plans/2026-08-16-maintenance-throughput.md
@@ -1,0 +1,314 @@
+# Maintenance throughput, rollup liveness, and index repair — plan
+
+Written 2026-08-16, from production measurements taken the same evening against
+`b6c4a3e`. Every number below is observed, not estimated. Sources are
+`timefusion_stats` over pgwire, timed pgwire queries, and `docker`/`ssh` on the
+CapRover host.
+
+Goal this plan serves: maintenance (dedup, sort, rollups, packing) must keep up
+with current traffic **and** with 10x the current project count on the same
+single node; rollups must be continuously up to date and actually used, so that
+popular 14d and 30d queries return in ~1s for **every** project including
+shipbubble; and the Tantivy reindex must be driven to a conclusion without
+competing with production writers.
+
+---
+
+## 1. Measured starting state
+
+### 1.1 Query latency — the user-visible failure
+
+Timed from this machine over pgwire, `count(*)` on `otel_logs_and_spans` for
+shipbubble (`28f62f01-46a1-400e-8195-da7bc3505b5b`):
+
+| window | result |
+|---|---|
+| 1d | **41.0 s** (2,884,451 rows) |
+| 7d | **timeout, >60 s** |
+| 14d | **timeout, >60 s** |
+| 30d | **timeout, >60 s** |
+
+Target is 1 s. 14d and 30d do not complete at all. Server-side scan latency
+distribution agrees: `scan.lat_p99_us_approx = 8.4 s`,
+`scan.lat_p999_us_approx = 33.5 s`.
+
+### 1.2 Maintenance is serialized to exactly one job
+
+`src/database.rs:3045`:
+
+```rust
+AdmissionController::new(1, memory_limit_bytes, 1, 1)
+```
+
+and `src/database.rs:3652`:
+
+```rust
+const COORDINATOR_JOB_WORKERS: usize = 1;
+// "Job concurrency is deliberately one; see the admission controller initialization."
+```
+
+CPU, object-read and object-write tokens are each **1**, so at most one unit is
+ever admitted. Confirmed live: `maintenance.cpu_tokens_used = 1`,
+`object_read_tokens_used = 1`, `object_write_tokens_used = 1`,
+`tasks_running = 1`, `decoded_bytes_used = 512 MiB` (exactly one
+`MAX_DECODED_BYTES` unit).
+
+Meanwhile the decode budget is `cgroup * 3/4` = **~64 GB**, of which 512 MiB is
+used — **99.2% idle** — and process memory is at `memory.charged_pct = 8`
+(6.9 GB of the 85.9 GB limit).
+
+This serialization was a deliberate 2026-08-16 safety response to maintenance
+starving foreground health checks (the runtime-isolation comment above it is
+the real fix for that; the token cap of 1 is belt-and-braces that went too far).
+
+### 1.3 The backlog that serialization produces
+
+| metric | value |
+|---|---|
+| `maintenance.backlog_bytes` | **20.26 TB** |
+| `maintenance.sealed_compaction_debt_bytes` | **8.05 TB** |
+| `maintenance.tasks_pending` | **18,397** |
+| `maintenance.tasks_complete` | 2,742 |
+| `maintenance.tasks_running` | **1** |
+| `maintenance.oldest_task_age_seconds` | 39,142 (**10.9 h**) |
+| `maintenance.dirty_bin_queue_depth` | 1,525 |
+| `maintenance.dirty_bin_processed_total` | **0** |
+| `maintenance.dedup_bins_committed_total` | **0** |
+| `maintenance.dedup_waves_committed_total` | **0** |
+| `maintenance.processed_bytes_per_second` | **0** |
+| `maintenance.retry_reason` | `compaction_debt_remaining` |
+
+Light hot-tail compaction is the only tier making progress
+(`light_optimize_bins_committed_total = 63`).
+
+### 1.4 Rollups are built zero times and used zero times
+
+| metric | value |
+|---|---|
+| `rollup_output_rows_total` | **0** |
+| `rollup_rebuilds_full_total` / `_incremental_total` | 0 / 0 |
+| `rollup_hits_full_total` / `rollup_hits_hybrid_total` | **0 / 0** |
+| `rollup_dirty_partitions` | 41 |
+| `rollup_oldest_invalidation_age_seconds` | 112,640 (**31.3 h**) |
+| `rollup_singleton_failures_total` | 0 |
+
+Note `rollup_singleton_failures_total = 0`: the oversized-cohort failure mode
+that motivated the original redesign is genuinely gone. Rollups now produce
+nothing for the simpler reason that the coordinator never reaches them.
+
+### 1.5 The single root cause linking all of it
+
+`record_certification` (`src/database.rs:10755`) is the only grantor of
+certification, and it runs off the **dedup** path. Because dedup commits
+nothing, certification is never granted:
+
+- `scan.cert_granted_total = 0`
+- `scan.dedup_denied_never_certified_pct = **100.0**` (697 of 697)
+- `scan.dedup_eligible = 710`, `scan.dedup_skipped = 3`
+
+Two independent consequences, both fatal to the 1s goal:
+
+1. **Read-side dedup is denied on every scan**, so `DedupExec` stays in every
+   plan and each query pays full-set ordered dedup.
+2. **Rollup routing requires a contiguous certified prefix** from the start of
+   the window (comment at `src/database.rs:10792` states this explicitly, and
+   names it as exactly why "7d and 30d windows never routed while 24h did").
+   One uncertified day disqualifies the whole window.
+
+So the chain is:
+
+```
+COORDINATOR_JOB_WORKERS = 1  (+ admission cpu/read/write = 1)
+  -> dedup bins committed = 0
+    -> record_certification never fires -> cert_granted_total = 0
+      -> (a) read dedup denied 100%  -> DedupExec in every plan
+      -> (b) no certified prefix     -> rollup routing hits = 0
+        -> 14d/30d queries time out
+```
+
+Fixing throughput is therefore not one of three parallel workstreams. It is the
+**precondition** for the other two. This is the single most important
+conclusion in this document, and it changes the order of work.
+
+### 1.6 Tantivy index repair
+
+Three reconcile containers were OOM-killed today
+(`timefusion-tantivy-reconcile-{streaming,4cpu,2cpu}`, all **exit 137**). They
+ran as separate Docker containers on the same host as production, so they
+competed with the server for the same cgroup-adjacent memory with no shared
+admission control. `tantivy.recovery_pending_files = 0` and
+`budget.tantivy_peak_mb = 1536`.
+
+They were not stopped deliberately; they died. Any resumption that reuses the
+"separate container" shape will reproduce this.
+
+---
+
+## 2. Design principles for the fix
+
+1. **Bound work per unit, then run many units.** The 512 MiB `MAX_DECODED_BYTES`
+   ceiling is correct and stays. Serialization on top of it is what is wrong.
+2. **Admission must be driven by measured headroom, not a hard-coded 1.** The
+   reason for the cap (protecting foreground liveness) is legitimate; the
+   mechanism should be a real memory/CPU reading with a reserve, not a constant.
+3. **Never let maintenance share Tokio workers with pgwire.** The existing
+   dedicated `maintenance-runtime` already does this and must be preserved — it
+   is what actually fixed the health-check starvation, and it is why raising job
+   concurrency is now safe.
+4. **Certification is the product.** Throughput work is judged by
+   `cert_granted_total` rising and `never_certified_pct` falling, not by bytes
+   processed.
+5. **Newest-first everywhere.** Dashboards read recent data; an oldest-first
+   drain spends a whole process lifetime on data nobody queries. The code
+   already argues this for rollup backfill and the dedup drain; apply it to the
+   sealed-compaction debt drain too.
+6. **In-process, admission-controlled index repair.** No more sibling
+   containers outside the memory governor.
+
+---
+
+## 3. Workstreams
+
+### WS-1 — Parallel maintenance admission (unblocks everything)
+
+**Change A — make job concurrency a function of cores, not a constant.**
+
+`src/database.rs:3652`
+
+```rust
+const COORDINATOR_JOB_WORKERS: usize = 1;
+```
+becomes a derived value, `(cores / 8).clamp(2, 6)` by default, overridable by
+`TIMEFUSION_COORDINATOR_JOB_WORKERS`. The coordinator runtime's worker threads
+must scale with it (currently `(cores / 8).clamp(2, 4)`), so that admitted jobs
+are actually polled rather than queued behind each other on two threads.
+
+**Change B — admission tokens sized from real capacity.**
+
+`src/database.rs:3045`
+
+```rust
+AdmissionController::new(1, memory_limit_bytes, 1, 1)
+```
+becomes cpu = job workers, object_reads/object_writes sized independently
+(object I/O is latency-bound, not memory-bound, so it can exceed CPU — start at
+`2 * jobs`). Decode budget stays `cgroup * 3/4` but is now genuinely reachable
+because more than one unit can hold a reservation.
+
+**Change C — a foreground-pressure brake that replaces the constant.**
+
+Before admitting, check live `memory.charged_pct` and mem-buffer pressure. Above
+a high-water mark (start at 70% of the cgroup, matching the existing maintenance
+brake), admit nothing new and let in-flight units drain. This gives back the
+safety the hard-coded `1` was providing, but only when pressure is real.
+Instrument as `maintenance_admission_braked_total`.
+
+**Verification.** `tasks_running` > 1 in prod; `decoded_bytes_used` well above
+512 MiB; `processed_bytes_per_second` > 0; `dedup_bins_committed_total` rising;
+pgwire p99 not regressing; no health-check failures; no exit-137.
+
+### WS-2 — Drain the 20.3 TB backlog to a steady state
+
+With WS-1 landed, the queue drains, but 20.3 TB will not clear in one pass and
+must not be attempted in one pass.
+
+- **Prioritize by query value, newest-first.** Recent dates first; within a
+  date, projects by read frequency. shipbubble is explicitly in scope.
+- **Separate the sealed-compaction debt (8.05 TB) from the live frontier.** The
+  live frontier must never queue behind historical debt; that is what
+  `retry_reason = compaction_debt_remaining` is reporting today. Give debt its
+  own admission slice (a minority share) so it makes progress without starving
+  the frontier.
+- **Certification-first ordering.** Order work so that whole partitions become
+  certifiable as early as possible: a partially deduped date grants no
+  certification and therefore buys zero query latency. This is a scheduling
+  change with an outsized payoff.
+
+**Verification.** `backlog_bytes` monotonically decreasing across a sustained
+window; `oldest_task_age_seconds` falling; `cert_granted_total` > 0 and rising;
+`never_certified_pct` falling from 100.
+
+### WS-3 — Rollup liveness and routing
+
+Only meaningful once WS-2 produces certified prefixes.
+
+- Confirm rollup build resumes (`rollup_output_rows_total` > 0,
+  `rollup_rebuilds_incremental_total` > 0) and that
+  `rollup_oldest_invalidation_age_seconds` (31.3 h) collapses toward the 15-min
+  watermark.
+- Then confirm routing: `rollup_hits_full_total` / `rollup_hits_hybrid_total`
+  > 0 for 14d/30d dashboard shapes.
+- Re-check the `rollup_miss_*` family for the dominant residual reason. Today
+  the only non-zero misses are `rollup_miss_filter_not_eligible_total = 2` and
+  `rollup_miss_missing_project_total = 3`, which are too small to act on until
+  real traffic routes.
+
+**Verification.** shipbubble 14d and 30d complete in ~1s, served by rollups; the
+same for the other projects; `rollup_hits_*` > 0.
+
+### WS-4 — Tantivy index repair, in-process and bounded
+
+- Move reconcile/backfill **into the coordinator** as a task `Operation`, so it
+  is subject to the same 512 MiB unit ceiling, admission tokens, and pressure
+  brake as every other tier. No sibling containers.
+- Keep it in the lowest priority band, below flush durability, dedup/rollup, and
+  hot packing, so it can never compete with production writers — the explicit
+  requirement in the goal.
+- Bound peak by the existing `budget.tantivy_peak_mb = 1536` reservation and
+  stream rather than collect.
+- Drive to conclusion: track index coverage as a first-class stat and run until
+  coverage is complete, then keep it incremental.
+
+**Verification.** No exit-137; index coverage stat reaches complete; hybrid
+indexed/raw search (PR #96) reports index hits; foreground write latency flat
+across the repair window.
+
+### WS-5 — 10x acceptance
+
+- Replay production-shaped traffic at 10x project count and 10x ingest on this
+  hardware.
+- Acceptance: no unit exceeds 512 MiB reserved decode; `tasks_pending` bounded
+  (not monotonically growing); eligible-rollup coverage trails the 15-min
+  watermark by <= 5 min at p95; 14d/30d p95 <= 1s for all projects including
+  shipbubble; zero OOM kills; zero exit-134.
+
+---
+
+## 4. Sequencing
+
+WS-1 is a small, high-leverage change and lands first, alone, so its effect on
+foreground latency is unambiguous. WS-2 is mostly scheduling policy and lands
+second. WS-3 is expected to be largely emergent once WS-2 runs — it is verified
+before it is coded, and only the residual misses are fixed. WS-4 is independent
+of WS-1..3 and can land in parallel, but is deployed separately so an OOM can be
+attributed. WS-5 is the gate.
+
+Each step deploys on its own and is monitored before the next starts. Prod is a
+single node with a live customer workload; batching these would make any
+regression unattributable.
+
+## 5. Risks
+
+- **Raising job concurrency re-introduces foreground starvation.** Mitigated by
+  the dedicated maintenance runtime (already in place, and the actual fix), plus
+  the WS-1C pressure brake. Watch pgwire p99 and health checks; the kill switch
+  is `TIMEFUSION_COORDINATOR_JOB_WORKERS=1`, which restores today's behavior
+  exactly.
+- **More concurrency means more OCC conflict on Delta commits.**
+  `dml.occ_conflicts_total` is 0 today and must be watched;
+  `rollup_occ_retries_total` likewise.
+- **Memory.** Concurrency multiplies peak transient heap by the number of
+  in-flight units (512 MiB each). At 6 jobs that is ~3 GB of tracked decode
+  against 79 GB of headroom — safe, but the brake is what keeps it safe under a
+  simultaneous ingest burst.
+- **The 20.3 TB drain is long.** It must be explicitly treated as a background
+  convergence with progress reporting, not a task expected to finish in a
+  session.
+
+## 6. Kill switches
+
+| change | switch | restores |
+|---|---|---|
+| WS-1 job concurrency | `TIMEFUSION_COORDINATOR_JOB_WORKERS=1` | today's serialized behavior |
+| WS-1 admission sizing | same variable drives token counts | today's `(1,1,1)` |
+| WS-4 in-process repair | disable the repair `Operation` | no index repair, no sibling containers |

--- a/src/config.rs
+++ b/src/config.rs
@@ -458,6 +458,31 @@ impl DerivedBudget {
         mem_bound.min(cpu_bound).min(hot_project_count).max(1)
     }
 
+    /// Concurrently admitted maintenance coordinator units.
+    ///
+    /// Held at a hard-coded 1 through 2026-08-16, alongside admission tokens of
+    /// `(cpu 1, reads 1, writes 1)`. That serialization is what put the queue
+    /// 20.3 TB and 18,397 tasks deep with `decoded_bytes_used` pinned at one
+    /// 512 MiB unit against a ~64 GiB decode budget — 99% idle — and it is the
+    /// root cause of the dead rollups, not a separate problem: no dedup commits
+    /// means `record_certification` never fires, and an uncertified partition
+    /// both keeps `DedupExec` in every plan and denies rollup routing its
+    /// contiguous certified prefix.
+    ///
+    /// What made the cap necessary was maintenance sharing Tokio workers with
+    /// pgwire and starving health checks. That is fixed properly by the
+    /// dedicated maintenance runtime, so bound this by the box instead: each
+    /// unit reserves at most `MAX_DECODED_BYTES` (512 MiB), so the memory term
+    /// is exact. `TIMEFUSION_COORDINATOR_JOB_WORKERS=1` restores the old
+    /// serialized behavior exactly.
+    pub fn coordinator_jobs(&self) -> usize {
+        std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").ok().and_then(|v| v.parse::<usize>().ok()).filter(|n| *n > 0).unwrap_or_else(|| {
+            let mem_bound = self.maintenance_pool_bytes / (512 * 1024 * 1024);
+            let cpu_bound = self.cores / 8;
+            mem_bound.min(cpu_bound).clamp(1, 6)
+        })
+    }
+
     /// Wall-clock budget for one maintenance tick: 80% of the cron period.
     /// Formerly `TIMEFUSION_LIGHT_OPTIMIZE_TICK_BUDGET_SECS`.
     /// K unbounded by project count (memory x CPU terms only) — sizes the
@@ -2610,6 +2635,30 @@ mod tests {
         // 4 x 2 GiB lands exactly on the original 8 GiB envelope).
         assert_eq!(b.rewrite_permits(), 4);
         assert_eq!(b.optimize_merge_tasks(), 2);
+    }
+
+    /// Maintenance must not be serialized on a box with room to spare.
+    ///
+    /// Through 2026-08-16 this was a hard-coded 1, and one 512 MiB unit at a
+    /// time against a ~64 GiB decode budget is what let the queue reach 20.3 TB
+    /// and 18,397 tasks with zero dedup commits — and therefore zero
+    /// certifications, `DedupExec` in every plan, and zero rollup hits. A
+    /// regression here is not a throughput nit; it silently turns 30d queries
+    /// back into timeouts, so assert the prod shape explicitly.
+    #[test]
+    fn coordinator_jobs_scale_with_the_box() {
+        // Only meaningful when the operator has not pinned the override.
+        if std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").is_ok() {
+            return;
+        }
+        // Prod: 80 GiB / 48 cores.
+        let prod = DerivedBudget::from_limits(80 * GIB, 48);
+        assert!(prod.coordinator_jobs() > 1, "prod-shaped box must run maintenance in parallel, got {}", prod.coordinator_jobs());
+        // Every admitted unit reserves at most MAX_DECODED_BYTES, so the
+        // concurrent decode reservation must still fit the maintenance pool.
+        assert!(prod.coordinator_jobs() * 512 * 1024 * 1024 <= prod.maintenance_pool_bytes(), "concurrent 512 MiB units must fit the maintenance pool");
+        // Small boxes degrade to serial rather than thrashing.
+        assert_eq!(DerivedBudget::from_limits(16 * GIB, 4).coordinator_jobs(), 1);
     }
 
     // Small box (16 GiB / 4 cores): degrades to K=1, nothing underflows/zeroes.

--- a/src/database.rs
+++ b/src/database.rs
@@ -3036,13 +3036,29 @@ impl Database {
         let maintenance_shutdown = CancellationToken::new();
         let maintenance_cancel_guard = Arc::new(maintenance_shutdown.clone().drop_guard());
         // This is a single-node foreground database, not a detached worker
-        // fleet. Admit one rewrite at a time: DataFusion can still parallelize
-        // inside that bounded unit, but dedup, rollup, and compaction must not
-        // each start their own object-store stream and saturate PGWire/ingest.
-        // Production 2026-08-16 proved that exposing all 48 CPUs here released
-        // four 230 MiB source scans together immediately after preload.
-        let maintenance_admission =
-            crate::maintenance_coordinator::AdmissionController::new(1, u64::try_from(cfg.derived.memory_limit_bytes).unwrap_or(u64::MAX), 1, 1);
+        // fleet, so admission stays narrow: DataFusion still parallelizes inside
+        // each bounded unit, and the point is that dedup, rollup, and compaction
+        // cannot each start their own object-store stream and saturate
+        // PGWire/ingest. Production 2026-08-16 proved that exposing all 48 CPUs
+        // here released four 230 MiB source scans together right after preload.
+        //
+        // Narrow is not the same as serial, which is what this was until the
+        // evening of 2026-08-16: hard-coded `(1, mem, 1, 1)`. One unit at a time
+        // held `decoded_bytes_used` at a single 512 MiB reservation against a
+        // ~64 GiB budget while the queue reached 20.3 TB / 18,397 tasks and
+        // dedup committed nothing — which is also why nothing was ever
+        // certified, and therefore why rollups served zero queries. Size it from
+        // the box now; each unit is capped at `MAX_DECODED_BYTES`, so the memory
+        // term is exact. Object I/O is latency-bound rather than memory-bound,
+        // so it gets more slots than CPU.
+        let coordinator_jobs = cfg.derived.coordinator_jobs();
+        let coordinator_io_slots = u32::try_from(coordinator_jobs.saturating_mul(2)).unwrap_or(u32::MAX);
+        let maintenance_admission = crate::maintenance_coordinator::AdmissionController::new(
+            u32::try_from(coordinator_jobs).unwrap_or(1),
+            u64::try_from(cfg.derived.memory_limit_bytes).unwrap_or(u64::MAX),
+            coordinator_io_slots,
+            coordinator_io_slots,
+        );
         let logical_count_cache = Arc::new(crate::logical_count_index::LogicalCountCache::new(
             cfg.core.timefusion_data_dir.join("logical_count"),
             cfg.derived.logical_count_memory_bytes(),
@@ -3645,11 +3661,12 @@ impl Database {
         // five consecutive 1.5s deadlines while maintenance was being polled.
         // Resource tokens bound memory and I/O; this runtime boundary reserves
         // executor progress for ingest, queries, and liveness.
-        // Two runtime threads keep timers, cancellation, and object-store I/O
-        // progressing while the single admitted job is polled. Job concurrency
-        // is deliberately one; see the admission controller initialization.
-        let coordinator_runtime_workers = (self.config.derived.cores / 8).clamp(2, 4);
-        const COORDINATOR_JOB_WORKERS: usize = 1;
+        // Runtime threads keep timers, cancellation, and object-store I/O
+        // progressing while admitted jobs are polled, so there must be headroom
+        // beyond the jobs themselves — sizing the pool to exactly the job count
+        // lets a blocking decode stall the timers that cancel it.
+        let coordinator_job_workers = self.config.derived.coordinator_jobs();
+        let coordinator_runtime_workers = (self.config.derived.cores / 8).clamp(2, 4).max(coordinator_job_workers + 2);
         db.maintenance_debt_planned_at.store(crate::clock::now_micros(), std::sync::atomic::Ordering::Relaxed);
         {
             let db = Arc::clone(&db);
@@ -3702,7 +3719,7 @@ impl Database {
                                     requeued_dirty_partitions,
                                     migrated_tasks,
                                     runtime_workers = coordinator_runtime_workers,
-                                    job_workers = COORDINATOR_JOB_WORKERS,
+                                    job_workers = coordinator_job_workers,
                                     event = "maintenance_runtime_started"
                                 );
                             }
@@ -3716,7 +3733,7 @@ impl Database {
                             }
                         }
 
-                        for worker in 0..COORDINATOR_JOB_WORKERS {
+                        for worker in 0..coordinator_job_workers {
                             let db = Arc::clone(&db);
                             let cancel = cancel.clone();
                             tokio::spawn(async move {
@@ -19385,19 +19402,30 @@ mod tests {
         assert_eq!(Database::maintenance_partition_from_action("part-000.parquet", None), None);
     }
 
-    /// A single node must not launch independent dedup/rollup/compaction object
-    /// streams together. One admitted unit may use bounded internal DataFusion
-    /// parallelism; the next unit waits in the durable journal.
+    /// Maintenance admission is bounded by the configured job count, and every
+    /// token is returned when a job finishes.
+    ///
+    /// This asserted "exactly one" until 2026-08-16. Serializing a single node
+    /// does stop dedup/rollup/compaction from each opening their own
+    /// object-store stream, but one 512 MiB unit at a time against a ~64 GiB
+    /// decode budget left the queue 20.3 TB and 18,397 tasks deep with zero
+    /// dedup commits — so nothing was ever certified, `DedupExec` stayed in
+    /// every plan, rollups served zero queries, and 30d queries timed out. The
+    /// invariant worth pinning is that admission is *bounded and returned*, not
+    /// that it is serial.
     #[tokio::test]
-    async fn database_admits_only_one_maintenance_job_at_a_time() -> Result<()> {
+    async fn database_bounds_concurrent_maintenance_jobs() -> Result<()> {
         use crate::maintenance_coordinator::{MAX_DECODED_BYTES, Resources};
 
-        let db = Database::with_config(create_test_config("single-maintenance-job")).await?;
+        let db = Database::with_config(create_test_config("bounded-maintenance-jobs")).await?;
+        let jobs = db.config.derived.coordinator_jobs();
         let request = Resources { cpu: 1, decoded_bytes: MAX_DECODED_BYTES, object_reads: 1, object_writes: 1 };
-        let first = db.maintenance_admission.try_acquire(request).expect("first bounded job is admitted");
-        assert!(db.maintenance_admission.try_acquire(request).is_none(), "a second source rewrite must remain queued");
-        drop(first);
-        assert!(db.maintenance_admission.try_acquire(request).is_some(), "dropping the job returns every admission token");
+
+        let permits: Vec<_> =
+            (0..jobs).map(|i| db.maintenance_admission.try_acquire(request).unwrap_or_else(|| panic!("job {i} of {jobs} must be admitted"))).collect();
+        assert!(db.maintenance_admission.try_acquire(request).is_none(), "admission must stop at the configured job count, not run unbounded");
+        drop(permits);
+        assert!(db.maintenance_admission.try_acquire(request).is_some(), "dropping the jobs returns every admission token");
         Ok(())
     }
 


### PR DESCRIPTION
Plan with full measurements: `docs/plans/2026-08-16-maintenance-throughput.md` (added in this PR).

## The measurement

Maintenance admitted **exactly one unit at a time** — `COORDINATOR_JOB_WORKERS = 1` plus an admission controller built with `(cpu 1, reads 1, writes 1)`. Taken from prod tonight:

| metric | value |
|---|---|
| `tasks_pending` / `tasks_running` | 18,397 / **1** |
| `backlog_bytes` | **20.26 TB** (8.05 TB sealed debt) |
| `decoded_bytes_used` | 512 MiB of a ~64 GiB budget (**99% idle**) |
| `dedup_bins_committed_total` | **0** |
| `cert_granted_total` / `never_certified_pct` | **0 / 100.0** |
| `rollup_output_rows_total` | **0** |
| `rollup_hits_full` / `rollup_hits_hybrid` | **0 / 0** |
| `memory.charged_pct` | 8 |

## Why this is the root cause of slow 14d/30d queries

`record_certification` only ever fires off the **dedup** path. Committing zero dedup bins means certifying nothing, and an uncertified partition costs twice:

1. `DedupExec` stays in every plan, so each query pays full-set ordered dedup.
2. Rollup routing requires a **contiguous certified prefix** across the window (the comment at `database.rs:10792` names this as exactly why "7d and 30d windows never routed while 24h did").

Measured effect, shipbubble (`28f62f01…`): **1d = 41.0s; 7d / 14d / 30d = timeout >60s.** Target is 1s.

So the slow queries, the dead rollups, and the growing backlog are one bug, not three — and throughput is the precondition for the other two, not a parallel workstream.

## The change

Job count and admission tokens now derive from the box:

```
min(maintenance_pool / MAX_DECODED_BYTES, cores / 8).clamp(1, 6)
```

**6 on prod** (48 cores, 16.9 GiB pool); degrades to 1 on small boxes. Each unit still reserves at most `MAX_DECODED_BYTES`, so the concurrent memory term is exact and asserted in the test. Object I/O gets 2x the CPU slots because it is latency-bound, not memory-bound.

The cap existed because maintenance shared Tokio workers with pgwire and starved health checks. That is fixed properly by the dedicated maintenance runtime, which stays — the runtime pool now also keeps headroom above the job count so a blocking decode cannot stall the timers that cancel it.

## Safety

- Kill switch: `TIMEFUSION_COORDINATOR_JOB_WORKERS=1` restores the previous behavior exactly.
- Tracked concurrent decode at 6 jobs is ~3 GB against 79 GB of headroom.
- Watch on deploy: pgwire p99, health checks, `dml.occ_conflicts_total`, `rollup_occ_retries_total`, RSS.

`database_admits_only_one_maintenance_job_at_a_time` pinned the serialization itself, so it is rewritten to pin the invariant that matters: admission is bounded by the configured count and every token is returned.

## Verification

- Full suite **946/946 pass** locally; clean master baseline 945/945 (+1 is the new config test)
- `cargo lint` clean, `cargo fmt --check` clean

Deploying alone, ahead of the scheduling and rollup work, so its effect on foreground latency is unambiguous.