### PR TITLE
feat(dedup): certify 35 days, and never rotate today out of the sweep

### DIFF
--- a/docs/plans/2026-08-16-maintenance-throughput.md
+++ b/docs/plans/2026-08-16-maintenance-throughput.md
@@ -130,6 +130,45 @@ Fixing throughput is therefore not one of three parallel workstreams. It is the
 **precondition** for the other two. This is the single most important
 conclusion in this document, and it changes the order of work.
 
+### 1.5a Correction — throughput is necessary but provably not sufficient
+
+Added after WS-1 was written, on closer reading of the certification path.
+
+`record_certification` is called from exactly one place (`database.rs:11323`),
+inside `dedup_sweep`. That sweep's scope is:
+
+```rust
+let lookback = self.config.maintenance.timefusion_dedup_lookback_days as i64;
+let dates = (0..=lookback).rev().map(|d| today - Duration::days(d));
+```
+
+and `d_dedup_lookback_days` defaults to **1** (`config.rs:1016`) — chosen to
+catch a late DLQ replay crossing midnight UTC, not to support long windows.
+
+So certification can only ever cover **today and yesterday**. A 14d or 30d
+window can therefore *never* hold a fully certified prefix, at any throughput.
+WS-1 is still required — at zero dedup commits even today is uncertified — but
+WS-1 alone cannot deliver the 1s goal. Scope, not just speed, is a blocker.
+
+Two further observations that shape WS-3:
+
+- Certifications are durable: they are loaded at boot
+  (`dedup_certifications_loaded`, `database.rs:2985`) and keyed by
+  `partition_file_fp`. A **sealed** past partition whose fingerprint has not
+  moved is therefore re-certifiable by a metadata-only comparison — no rescan.
+  That is what makes a 30-day certification window affordable; the expensive
+  part is only the *first* dedup pass over a day that has never had one.
+- Rollup builds explicitly do **not** need certification (there is a test named
+  `query_delta_only_deduplicates_so_a_rollup_build_needs_no_certification`), so
+  building history and certifying it are independent and can proceed in
+  parallel.
+- Rollups are close to inert on the read side rather than losing on coverage:
+  `rollup_misses_total` is only **5** in ~an hour, and none of the miss reasons
+  are coverage-related (`filter_not_eligible` 2, `missing_project` 3; every
+  `not_built` / `incomplete_coverage` / `stale_coverage` counter is 0). Almost
+  no query consults the rollup matcher at all. Diagnose that before assuming
+  more coverage would be used.
+
 ### 1.6 Tantivy index repair
 
 Three reconcile containers were OOM-killed today
@@ -207,6 +246,26 @@ Instrument as `maintenance_admission_braked_total`.
 512 MiB; `processed_bytes_per_second` > 0; `dedup_bins_committed_total` rising;
 pgwire p99 not regressing; no health-check failures; no exit-137.
 
+**RESULT — shipped as #101 (`9d5d6d7`), measured 24s after rollout:**
+
+| metric | before | after |
+|---|---|---|
+| `cpu_tokens_used` | 1 | **6** |
+| `object_read_tokens_used` | 1 | **6** |
+| `decoded_bytes_used` | 512 MiB | **3.0 GiB** |
+| `tasks_running` | 1 | **4** |
+| `processed_bytes_per_second` | **0** | **78.3 MB/s** |
+| `process_rss_mb` | 7,960 | 6,129 |
+| `memory.charged_pct` | 10 | 7 |
+| `dml.occ_conflicts_total` | 0 | 0 |
+
+~8x the previous ~10 MB/s, with memory *lower* and no OCC conflicts. The old
+container exited 0 — a clean handover, no crash. At 78 MB/s the 20.26 TB
+backlog is ~72 h of drain, so this is convergence rather than an instant fix.
+
+Note `cert_granted_total` stayed 0, as predicted by 1.5a: throughput alone
+cannot certify past yesterday. That is WS-2.
+
 ### WS-2 — Drain the 20.3 TB backlog to a steady state
 
 With WS-1 landed, the queue drains, but 20.3 TB will not clear in one pass and
@@ -221,8 +280,39 @@ must not be attempted in one pass.
   the frontier.
 - **Certification-first ordering.** Order work so that whole partitions become
   certifiable as early as possible: a partially deduped date grants no
-  certification and therefore buys zero query latency. This is a scheduling
-  change with an outsized payoff.
+  certification and therefore buys zero query latency. Note that class-1
+  (non-frontier) work is currently ordered by `deadline_micros` ascending —
+  effectively oldest-first — which contradicts the newest-first principle the
+  codebase argues for elsewhere. Class 0 (live frontier) is already
+  newest-minute-first and correct.
+- **Extend the certification window to the query-relevant retention (~35d).**
+  Per 1.5a this is the blocker that throughput cannot fix.
+
+  On reading `dedup_sweep` closely, the machinery this needs is **already
+  there** — the window value is the only thing holding it to 2 days:
+
+  - The per-partition metadata-only skip already exists: a partition whose
+    `dedup_clean_fp` entry matches its current `partition_file_fp` is skipped
+    without a probe, "keeping the sweep O(partitions-changed)". So steady-state
+    cost is proportional to *changed* partitions, not to window length.
+  - The work list is already sorted **newest-date-first** (`db.cmp(da)`).
+  - Truncation is already handled by `deadline` + `dedup_sweep_cursor`
+    rotation, so a long first pass cannot wedge the tick.
+  - Certifications are already durable across restarts.
+
+  So the change is small: raise `d_dedup_lookback_days` from 1 to ~35 (aligning
+  with the existing `d_repair_lookback_days = 31` and leaving margin over a 30d
+  query). The recurring cost is the work-list build — `partition_files_by_pid`
+  per date, metadata only, ~36 dates x ~11 projects — plus a real dedup pass
+  only for days never certified. That first-time cost *is* the backlog drain,
+  and it is exactly what WS-1's throughput is for.
+
+  This ordering matters: raising the window without WS-1 would add 35x the work
+  list to a queue that already commits nothing.
+- **Bound the drain by what queries read.** 8.05 TB of the 20.26 TB is sealed
+  historical debt. Anything older than the retention window is background debt
+  that must never compete with the 35-day certification target. This is what
+  converts an unbounded 20 TB problem into a bounded one.
 
 **Verification.** `backlog_bytes` monotonically decreasing across a sustained
 window; `oldest_task_age_seconds` falling; `cert_granted_total` > 0 and rising;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1013,7 +1013,25 @@ const_default!(d_dml_merge_concurrency: usize = 1);
 // left cross-flush dupes that landed in a prior-day partition (a late DLQ replay
 // crossing midnight UTC) uncollapsed forever; 1 catches the day-boundary case.
 // Arbitrarily-late replays still need read-side dedup — see the parity plan.
-const_default!(d_dedup_lookback_days: u64 = 1);
+//
+// 35 since 2026-08-16, because this window is not only about late replays: the
+// sweep is the ONLY caller of `record_certification`, so it is also what decides
+// how far back a partition can be certified duplicate-free. At 1, certification
+// could never reach past yesterday, and since rollup routing needs a contiguous
+// certified prefix across the whole query window, no 7d/14d/30d query could ever
+// route — measured on prod as `never_certified_pct = 100.0`, `rollup_hits = 0`,
+// and shipbubble taking 41s at 1d and timing out past 60s at 7d and beyond.
+//
+// This is affordable because the sweep is already O(partitions-changed), not
+// O(window): a partition whose `dedup_clean_fp` still matches its live file
+// fingerprint is skipped without a probe, the work list is already sorted
+// newest-date-first, and `deadline` + `dedup_sweep_cursor` rotation bound and
+// resume a truncated tick. The one-off cost is the first pass over each day that
+// has never been certified, which is precisely the backlog the coordinator's
+// job concurrency (2026-08-16, #101) exists to drain — do NOT raise this on a
+// build without that change, or the 35x work list lands on a queue that commits
+// nothing. 35 covers a 30d query with margin and matches `d_repair_lookback_days`.
+const_default!(d_dedup_lookback_days: u64 = 35);
 const_default!(d_query_partitions: usize = 0);
 // Wide-scan admission guard. 16 concurrent Parquet decoders bounds untracked
 // decode heap well under the 25 GB pool on the 188 GB/48-core box (48-way was
@@ -2635,6 +2653,21 @@ mod tests {
         // 4 x 2 GiB lands exactly on the original 8 GiB envelope).
         assert_eq!(b.rewrite_permits(), 4);
         assert_eq!(b.optimize_merge_tasks(), 2);
+    }
+
+    /// Certification must reach back far enough to serve a 30d query.
+    ///
+    /// `dedup_sweep` is the only caller of `record_certification`, and its scope
+    /// is `today - d_dedup_lookback_days ..= today`. Rollup routing needs a
+    /// contiguous certified prefix across the whole query window, so this value
+    /// is a hard ceiling on the longest window that can ever route. At the
+    /// former default of 1 nothing past yesterday could be certified, which is
+    /// why prod measured `never_certified_pct = 100.0` and `rollup_hits = 0`
+    /// while 30d queries timed out. Dropping it back below 30 silently
+    /// reintroduces that, with no failing behavior anywhere nearer the change.
+    #[test]
+    fn certification_window_covers_a_thirty_day_query() {
+        assert!(super::d_dedup_lookback_days() >= 30, "the dedup sweep is what certifies partitions; below 30d no 30d query can ever route to a rollup");
     }
 
     /// Maintenance must not be serialized on a box with room to spare.

--- a/src/database.rs
+++ b/src/database.rs
@@ -11245,12 +11245,21 @@ impl Database {
                 false => work.extend(files_by_pid.into_iter().map(|(pid, files)| (date, pid, files))),
             }
         }
-        // Stable order, then rotate: a truncated tick must not re-serve the same
-        // prefix on the next one (the starvation `light_optimize_cursor` fixes
-        // for packing).
+        // Stable order (newest date first), then rotate: a truncated tick must
+        // not re-serve the same prefix on the next one (the starvation
+        // `light_optimize_cursor` fixes for packing).
         work.sort_by(|(da, pa, _), (db, pb, _)| db.cmp(da).then_with(|| pa.cmp(pb)));
         let total_work = work.len();
-        work.rotate_left(sweep_resume_offset(total_work, self.dedup_sweep_cursor.load(std::sync::atomic::Ordering::Relaxed)));
+        // Today never rotates out. Rotation exists so a deadline-truncated tick
+        // resumes into UNSEEN sealed work, but today is re-dirtied by every
+        // flush and is what the hot queries read, so it has to be swept on every
+        // tick — not once per full rotation. That distinction did not matter
+        // while the window was today+1 (two dates, nothing to starve); at a 35d
+        // certification window the list is ~36 dates x projects, and first-time
+        // passes over never-certified sealed days truncate ticks often, which is
+        // exactly when today would be rotated past.
+        let sealed_from = work.partition_point(|(date, _, _)| *date >= today);
+        rotate_sealed_tail(&mut work, sealed_from, self.dedup_sweep_cursor.load(std::sync::atomic::Ordering::Relaxed));
         for (swept, (date, pid, cur_files)) in work.iter().enumerate() {
             let (date, pid) = (*date, pid);
             // Bail promptly on shutdown — a mid-sweep tick must not run
@@ -11260,7 +11269,11 @@ impl Database {
                 return Ok(());
             }
             if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
-                self.dedup_sweep_cursor.fetch_add(swept, std::sync::atomic::Ordering::Relaxed);
+                // Advance by the SEALED items covered, since only the sealed
+                // tail rotates. Counting today's un-rotated prefix here would
+                // walk the cursor a whole prefix-length per tick and skip sealed
+                // work that was never swept.
+                self.dedup_sweep_cursor.fetch_add(swept.saturating_sub(sealed_from), std::sync::atomic::Ordering::Relaxed);
                 info!(table_name, swept, remaining = total_work - swept, event = "dedup_sweep_truncated");
                 break;
             }
@@ -16162,6 +16175,23 @@ fn sweep_resume_offset(len: usize, cursor: usize) -> usize {
     if len == 0 { 0 } else { cursor % len }
 }
 
+/// Rotate only the sealed tail of a sweep work list, leaving the first
+/// `sealed_from` items (today) pinned at the front.
+///
+/// Rotation exists so a deadline-truncated tick resumes into sealed work it has
+/// not seen. Today must be exempt: it is re-dirtied by every flush and is what
+/// the hot queries read, so it has to be swept on every tick rather than once
+/// per full rotation. Harmless while the window was today+1; load-bearing at a
+/// 35-day certification window, where first-time passes over never-certified
+/// days truncate ticks often — precisely when today would rotate out.
+fn rotate_sealed_tail<T>(work: &mut Vec<T>, sealed_from: usize, cursor: usize) {
+    let sealed_from = sealed_from.min(work.len());
+    let mut sealed = work.split_off(sealed_from);
+    let offset = sweep_resume_offset(sealed.len(), cursor);
+    sealed.rotate_left(offset);
+    work.append(&mut sealed);
+}
+
 /// Decrement-on-drop gauge, so a bin that times out or panics still clears its
 /// slot rather than reading as permanently busy.
 struct InFlightGuard<'a>(&'a std::sync::atomic::AtomicU64);
@@ -19400,6 +19430,35 @@ mod tests {
             Some(("default".to_owned(), "2026-08-14".to_owned()))
         );
         assert_eq!(Database::maintenance_partition_from_action("part-000.parquet", None), None);
+    }
+
+    /// Today is swept on every tick; only the sealed tail rotates.
+    ///
+    /// The 35-day certification window makes the work list ~36 dates x projects,
+    /// and first-time passes over never-certified days truncate ticks often. A
+    /// whole-list rotation would then visit today once per full rotation, which
+    /// silently stops certifying the partition the hot queries actually read —
+    /// with nothing failing anywhere near the change.
+    #[test]
+    fn sweep_rotation_never_rotates_today_out() {
+        // [today_a, today_b, sealed0, sealed1, sealed2, sealed3]
+        let sealed_from = 2;
+        for cursor in 0..12 {
+            let mut work = vec![100, 101, 0, 1, 2, 3];
+            super::rotate_sealed_tail(&mut work, sealed_from, cursor);
+            assert_eq!(&work[..2], &[100, 101], "today must stay at the front at cursor {cursor}");
+            let mut tail = work[2..].to_vec();
+            tail.sort_unstable();
+            assert_eq!(tail, vec![0, 1, 2, 3], "rotation must preserve the sealed set at cursor {cursor}");
+            assert_eq!(work[2], cursor % 4, "the sealed tail must resume at the cursor");
+        }
+        // Degenerate shapes must not panic.
+        let mut only_today = vec![1, 2];
+        super::rotate_sealed_tail(&mut only_today, 5, 3);
+        assert_eq!(only_today, vec![1, 2]);
+        let mut empty: Vec<i32> = vec![];
+        super::rotate_sealed_tail(&mut empty, 0, 7);
+        assert!(empty.is_empty());
     }
 
     /// Maintenance admission is bounded by the configured job count, and every


### PR DESCRIPTION
Follow-on to #101. Plan and measurements: `docs/plans/2026-08-16-maintenance-throughput.md`.

## Why throughput alone was not enough

`dedup_sweep` is the **only** caller of `record_certification`, so its lookback window is not merely about late DLQ replays crossing midnight — it decides how far back a partition can ever be certified duplicate-free. At the old default of `1`, certification could not reach past yesterday.

That is a hard ceiling on query latency: rollup routing needs a **contiguous certified prefix across the whole window**, so one uncertified day disqualifies the entire query.

Measured on prod:

| metric | value |
|---|---|
| `never_certified_pct` | **100.0** |
| `cert_granted_total` | **0** |
| `rollup_hits_full` / `rollup_hits_hybrid` | **0 / 0** |
| shipbubble 1d | **41.0s** |
| shipbubble 7d / 14d / 30d | **timeout >60s** |

#101 raised maintenance throughput ~8x (10 → 78 MB/s, `tasks_running` 1 → 4, `decoded_bytes_used` 512 MiB → 3.0 GiB) and `cert_granted_total` **still did not move** — exactly as predicted. Throughput cannot fix scope.

## The change

`d_dedup_lookback_days`: **1 → 35** (covers a 30d query with margin; matches the existing `d_repair_lookback_days = 31`).

This is affordable because the sweep is already `O(partitions-changed)`, not `O(window)`:

- a partition whose `dedup_clean_fp` matches its live `partition_file_fp` is skipped without a probe
- the work list is already sorted newest-date-first
- `deadline` + `dedup_sweep_cursor` rotation bound and resume a truncated tick
- certifications are durable across restarts

The one-off cost is the first pass over each never-certified day — the backlog #101 exists to drain. **Do not raise this on a build without #101**, or a 35x work list lands on a queue that commits nothing.

## The assumption that 36 dates breaks

Whole-list rotation would visit today once per *full* rotation. Today is re-dirtied by every flush and is what the hot queries read, and first-time passes over never-certified sealed days truncate ticks often — precisely when today would rotate out. Harmless at 2 dates; a silent regression at 36.

So `rotate_sealed_tail` pins today at the front and rotates only the sealed tail, and the truncation cursor advances by *sealed* items covered — otherwise it walks a prefix-length per tick and skips sealed work that was never swept.

## Verification

- Full suite **948/948** (one deadline-sensitive `buffered_write_layer` test flaked once under parallel load on a 10-core box; passed 3/3 isolated and on a clean full re-run)
- `cargo lint` clean, `cargo fmt --check` clean
- New tests: `certification_window_covers_a_thirty_day_query`, `sweep_rotation_never_rotates_today_out` (incl. degenerate shapes)

## Rollout

Merging only after #101 has soaked. Watch on deploy: `cert_granted_total` rising off 0, `never_certified_pct` falling from 100, sweep tick duration, `dedup_sweep_truncated` frequency, and that today's partitions still certify.