### PR TITLE
fix(rollup): count coordinator publications, not just the retired cohort path

### DIFF
--- a/docs/plans/2026-08-16-maintenance-throughput.md
+++ b/docs/plans/2026-08-16-maintenance-throughput.md
@@ -336,6 +336,66 @@ Only meaningful once WS-2 produces certified prefixes.
 **Verification.** shipbubble 14d and 30d complete in ~1s, served by rollups; the
 same for the other projects; `rollup_hits_*` > 0.
 
+**RESULT after WS-2 (`12009ab`), measured 2026-08-17 ~00:30Z.**
+
+The certification window worked, and it is the largest read-path win so far:
+
+| metric | before WS-2 | after WS-2 |
+|---|---|---|
+| `scan.dedup_skipped_pct` | **0.4%** (3 / 710) | **65.4%** (595 / 910) |
+
+`DedupExec` is now out of roughly two thirds of query plans.
+
+Latency, however, has NOT reached the goal. shipbubble still times out past 60s
+at 7d/14d/30d, including for a rollup-routable dashboard shape
+(`time_bucket(...) ... GROUP BY 1`). The 1d number is noisy across restarts
+(41s → 17s after WS-1 → 32s on a cold process mid-backlog-drain) and should be
+re-measured on a warm process once the backlog settles.
+
+**Two counters proved actively misleading, and both cost real diagnosis time:**
+
+1. `rollup_output_rows_total` / `rollup_staged_projects_total` /
+   `rollup_scan_*` were wired ONLY to the retired cohort path
+   (`rebuild_rollup_cohort` -> `stage_and_commit_rollup_inputs` ->
+   `stage_rollup_wave`). The coordinator publishes through its own path and
+   incremented none of them, so they read 0 while the rollup table held 1,220
+   real rows for shipbubble. I concluded "rollups publish nothing" from this and
+   was wrong. Fixed by instrumenting the coordinator publish path, guarded by a
+   test that fails without the wiring.
+2. `cert_granted_total` counts only *fresh* grants — a certification reloaded
+   from disk at boot takes the `prior.is_some()` branch. It therefore reads 0
+   on a healthy, fully certified system. `dedup_skipped_pct` is the honest
+   signal; prefer it.
+
+**Open: rollup routing is still refused.** `rollup_hits_full/hybrid` remain 0,
+and `rollup_miss_missing_project_total` is ~99% of all misses. `MissingProject`
+means the matcher found no `project_id = <string literal>` among the collected
+predicates. But the optimized plan plainly carries it:
+
+```
+TableScan: otel_logs_and_spans projection=[timestamp],
+  full_filters=[otel_logs_and_spans.project_id = Utf8View("28f62f01-…")],
+  partial_filters=[otel_logs_and_spans.timestamp >= TimestampMicrosecond(…)]
+```
+
+and `source_and_filters` does extend from `scan.filters`, `string_literal`
+accepts `Utf8View`, and `column_name` compares unqualified. So the obvious
+explanations are all ruled out. Two candidates remain:
+
+- the matcher is also invoked on inner/per-leg plans (mem, hot, delta) where
+  `ProjectRoutingTable` has already consumed the project predicate, and those
+  inner calls are what the counter is dominated by; or
+- the misses are dominated by monoscope's own prepared-statement traffic, where
+  `project_id` arrives as a placeholder rather than a literal and `eq_literal`
+  cannot match it.
+
+The two are distinguishable by attribution, not by reading more code, and the
+per-reason counters do not sum to `rollup_misses_total` (a 180s idle sample
+moved the total by 230 with only 10 attributed), so the counters cannot settle
+it either. Next step is a reproduction against a provider that claims **Exact**
+pushdown like `ProjectRoutingTable` does — the in-module tests use a `MemTable`,
+which does not, and so cannot reproduce prod's plan shape at all.
+
 ### WS-4 — Tantivy index repair, in-process and bounded
 
 - Move reconcile/backfill **into the coordinator** as a task `Operation`, so it

--- a/src/database.rs
+++ b/src/database.rs
@@ -9625,6 +9625,16 @@ impl Database {
         let mut actions = replaced.iter().map(|add| Action::Remove(remove_for_add(add, true))).collect::<Vec<_>>();
         actions.extend(adds.iter().cloned());
 
+        // Counted before the commit consumes `actions`, and published below only
+        // if this unit actually lands. The rollup_* stats were wired ONLY to the
+        // retired cohort path (`stage_rollup_wave`), so on prod they read
+        // rollup_output_rows_total = 0 / rollup_staged_projects_total = 0 while
+        // the coordinator was publishing real rows — the rollup table held 1,220
+        // rows for a project the counters called empty. A metric that reads zero
+        // while the system works is worse than no metric: it cost a whole
+        // diagnosis pass chasing a rollup outage that was not happening.
+        let (action_count, output_files) = (actions.len() as u64, adds.len() as u64);
+
         let still_running = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state(&key) == Some(TaskState::Running);
         if !still_running {
             Self::cleanup_orphaned_parquet(&stage_store, &adds).await;
@@ -9662,7 +9672,19 @@ impl Database {
             );
             journal.publish(&key, crate::maintenance_coordinator::Publication { source_fingerprint: source_fp, generation: generation.clone(), rows });
             journal.checkpoint()?;
-            crate::metrics::maintenance_stats().maintenance_processed_bytes.fetch_add(estimated_bytes, Relaxed);
+            let stats = crate::metrics::maintenance_stats();
+            stats.maintenance_processed_bytes.fetch_add(estimated_bytes, Relaxed);
+            stats.rollup_output_rows.fetch_add(rows, Relaxed);
+            stats.rollup_output_files.fetch_add(output_files, Relaxed);
+            stats.rollup_commit_actions.fetch_add(action_count, Relaxed);
+            // One coordinator unit is one (project, slice) publication, which is
+            // what "staged project" counts on the cohort path too.
+            stats.rollup_staged_projects.fetch_add(1, Relaxed);
+            if derived {
+                stats.rollup_rebuilds_incremental.fetch_add(1, Relaxed);
+            } else {
+                stats.rollup_rebuilds_full.fetch_add(1, Relaxed);
+            }
         }
         Ok(true)
     }

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -1903,6 +1903,20 @@ async fn certifying_a_partition_builds_rollup_buckets_that_match_the_raw_aggrega
     assert_eq!(rolled, raw_total, "rollup request_count must sum to the raw row count, or every Traffic panel is silently wrong");
     assert!(raw_total > 0, "precondition: the fixture actually wrote rows");
 
+    // The publication counters must move on the COORDINATOR path, not only on
+    // the retired cohort path (`stage_rollup_wave`) they were originally wired
+    // to. Prod 2026-08-16 reported rollup_output_rows_total = 0 and
+    // rollup_staged_projects_total = 0 while this very table held 1,220 rows for
+    // a live project — a metric reading zero while the system works is worse
+    // than no metric, and it cost a full diagnosis pass chasing a rollup outage
+    // that was not happening. nextest gives each test its own process, so these
+    // process-global counters are this test's alone.
+    let stats = timefusion::metrics::maintenance_stats();
+    let ordering = std::sync::atomic::Ordering::Relaxed;
+    assert!(stats.rollup_output_rows.load(ordering) > 0, "the coordinator published rollup rows but rollup_output_rows_total stayed 0");
+    assert!(stats.rollup_staged_projects.load(ordering) > 0, "the coordinator published a slice but rollup_staged_projects_total stayed 0");
+    assert!(stats.rollup_commit_actions.load(ordering) > 0, "the coordinator committed Delta actions but rollup_commit_actions_total stayed 0");
+
     // Certify again: the build must replace, not append.
     db.dedup_today_partitions(&table_ref, "otel_logs_and_spans", "otel_logs_and_spans").await?;
     let after_rebuild = total_from_rollup(Arc::clone(&db), project_id.clone()).await?;


### PR DESCRIPTION
## The problem

`rollup_output_rows_total`, `rollup_staged_projects_total`, `rollup_commit_actions_total` and the `rollup_scan_*` family were wired **only** to `stage_rollup_wave`, reached from `rebuild_rollup_cohort` — the pre-coordinator cohort path. The coordinator publishes through `run_coordinator_rollup_once` and incremented none of them.

On prod tonight every one of those read **0** while `otel_logs_and_spans_rollup_dashboard_1m_v3` held **1,220 rows** for a live project. I read the zeros, concluded rollups were building nothing, and spent a full diagnosis pass on an outage that was not happening.

A metric that reads zero while the system works is worse than no metric.

## The fix

Increment them where the coordinator actually publishes — counted before the commit consumes `actions`, applied only when the unit lands (inside the still-`Running` guard), alongside the existing `processed_bytes`.

## Guard

`certifying_a_partition_builds_rollup_buckets_that_match_the_raw_aggregate` drives the coordinator via `run_maintenance_units`, so the assertions sit on the real path. **Verified the guard bites**: with the increments reverted it fails with

```
the coordinator published rollup rows but rollup_output_rows_total stayed 0
```

nextest gives each test its own process, so these process-global counters are that test's alone.

## Related counter caveat (documented, not changed here)

`cert_granted_total` is misleading in the same family: it counts only *fresh* grants, so a certification reloaded from disk at boot takes the `prior.is_some()` branch and it reads 0 on a healthy, fully certified system. `dedup_skipped_pct` is the honest signal — it moved 0.4% → 65.4% after #102.

## Verification

- Full suite **948/948**, `cargo lint` clean, `cargo fmt --check` clean