### PR TITLE
diag(rollup): log one refused plan per 512 misses, with the reason

### DIFF
--- a/src/dml.rs
+++ b/src/dml.rs
@@ -259,7 +259,24 @@ impl QueryPlanner for DmlQueryPlanner {
                 }
             }
             Ok(None) => {}
-            Err(reason) => crate::metrics::record_rollup_miss(reason),
+            Err(reason) => {
+                crate::metrics::record_rollup_miss(reason);
+                // A miss counter alone cannot be acted on. Prod 2026-08-17 sat at
+                // ~2.7 MissingProject misses/second with rollup_hits at 0, and
+                // there was no way to tell from outside whether the refused plans
+                // were monoscope's parameterized dashboards or ad-hoc literal
+                // queries — the two need opposite fixes. Sampled so a
+                // multiple-per-second rate cannot flood the log, and the plan is
+                // only rendered when a sample is actually taken.
+                if crate::metrics::sample_rollup_miss() {
+                    warn!(
+                        reason = reason.label(),
+                        plan = %fmt_capped(&logical_plan.display_indent().to_string(), 1200),
+                        event = "rollup_miss_sampled",
+                        "rollup routing refused; falling back to the raw plan"
+                    );
+                }
+            }
         }
         match logical_plan {
             LogicalPlan::Dml(dml) if matches!(dml.op, WriteOp::Update | WriteOp::Delete) => {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -545,6 +545,15 @@ pub fn record_rollup_hit(mode: &'static str, grain: &str) {
 /// arm, so `missing_project`, `unbounded_time`, `non_decomposable` and
 /// `rewrite_schema_mismatch` were indistinguishable in prod — 29 misses that
 /// could not be diagnosed without a deploy.
+/// True once every `ROLLUP_MISS_SAMPLE` misses, for logging one refused plan
+/// with context. Misses run at several per second on a busy node, so the
+/// counter is what you alert on and this is what you diagnose with.
+pub fn sample_rollup_miss() -> bool {
+    const ROLLUP_MISS_SAMPLE: u64 = 512;
+    static SEEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed).is_multiple_of(ROLLUP_MISS_SAMPLE)
+}
+
 pub fn record_rollup_miss(reason: crate::rollup::MissReason) {
     use crate::rollup::MissReason as R;
     let stats = maintenance_stats();


### PR DESCRIPTION
## Why

Prod is refusing rollup routing at roughly **2.7 misses/second** with `rollup_hits_full/hybrid` stuck at **0**, and `rollup_miss_missing_project_total` is ~99% of all misses.

`MissingProject` means the matcher found no `project_id = <string literal>` among the collected predicates. But every obvious explanation is ruled out: the optimized plan plainly carries `full_filters=[project_id = Utf8View("…")]`, `source_and_filters` does extend from `scan.filters`, `string_literal` accepts `Utf8View`, and `column_name` compares unqualified.

From outside the process there is no way to tell whether the refused plans are monoscope's parameterized dashboards (where `project_id` could arrive as a placeholder) or ad-hoc literal queries — and **those two need opposite fixes**. A bare counter cannot be acted on.

## What

One sampled `warn!` per 512 misses carrying the reason and the refused logical plan (capped at 1200 chars). Sampled so a multiple-per-second rate cannot flood the log, and the plan is only rendered when a sample is actually taken.

Deliberately a diagnostic, not a fix — I am not guessing at a fix for a cause I cannot yet name.

## Verification

- Full suite **948/948**, `cargo lint` clean, `cargo fmt --check` clean