### PR TITLE
perf(maintenance): raise coordinator jobs to cores/4 (cap 12)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -478,8 +478,19 @@ impl DerivedBudget {
     pub fn coordinator_jobs(&self) -> usize {
         std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").ok().and_then(|v| v.parse::<usize>().ok()).filter(|n| *n > 0).unwrap_or_else(|| {
             let mem_bound = self.maintenance_pool_bytes / (512 * 1024 * 1024);
-            let cpu_bound = self.cores / 8;
-            mem_bound.min(cpu_bound).clamp(1, 6)
+            // cores/8 (cap 6) was the first step off the hard-coded 1, chosen
+            // conservatively because nothing had been measured yet. Six hours on
+            // prod since then: 6 jobs held ~3 GiB of tracked decode with RSS at
+            // 12% of the cgroup, zero OCC conflicts, zero restarts, and the live
+            // frontier keeping up (`eligible_watermark_lag_seconds` 0) — while
+            // the 8 TB sealed-compaction debt did not drain at all and
+            // `oldest_task_age_seconds` kept climbing. The box is not the
+            // constraint; the clamp is. cores/4 (cap 12) is 6 GiB of tracked
+            // decode against 85.9 GiB, still far below the 48-way exposure that
+            // starved health checks on 2026-08-16, and the dedicated maintenance
+            // runtime is what protects liveness either way.
+            let cpu_bound = self.cores / 4;
+            mem_bound.min(cpu_bound).clamp(1, 12)
         })
     }
 


### PR DESCRIPTION
Follow-on to #101, which took coordinator job concurrency from a hard-coded **1** to `cores/8` capped at **6**. That cap was chosen conservatively because nothing had been measured yet.

## Six hours of prod says the box is not the constraint

| | |
|---|---|
| tracked decode at 6 jobs | ~3 GiB |
| `memory.charged_pct` | **12** |
| RSS | ~10 GiB of 85.9 GiB |
| `dml.occ_conflicts_total` | **0** |
| restarts | **0** |
| `eligible_watermark_lag_seconds` | **0** |

So the **live frontier keeps up**. What does not move is the historical debt: `sealed_compaction_debt_bytes` sat at **8.05 TB** all night and `oldest_task_age_seconds` climbed past **12h**.

That debt is exactly what a 14d/30d query needs certified in order to route to a rollup, so draining it is the goal itself, not a background nicety.

## Change

`cores/8` cap 6 → `cores/4` cap 12. On prod (48 cores, 16.9 GiB pool) that is **12 jobs**, ~6 GiB of tracked decode against an 85.9 GiB cgroup — still far below the 48-way exposure that starved health checks on 2026-08-16. The dedicated maintenance runtime, not the token count, is what actually protects liveness.

The existing `coordinator_jobs_scale_with_the_box` test already asserts the concurrent 512 MiB reservations still fit the maintenance pool (6 GiB ≤ 16.9 GiB).

## Watch on deploy

pgwire p99, health checks, `occ_conflicts_total`, `rollup_occ_retries_total`, RSS — and that `sealed_compaction_debt_bytes` finally trends down.

Kill switch: `TIMEFUSION_COORDINATOR_JOB_WORKERS=<n>`.

## Verification

Full suite **948/948**, `cargo lint` clean, `cargo fmt --check` clean.