### PR TITLE
feat(rollup): back-fill sealed days the coordinator never queues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -943,6 +943,9 @@ const_default!(d_repair_max_file_bytes: usize = 512 * MIB);
 const_default!(d_sort_skip_bytes: usize = 2 * GIB);
 const_default!(d_flush_sort_pool_mb: u64 = 1024);
 const_default!(d_light_schedule: String = "0 */5 * * * *");
+// Matches d_dedup_lookback_days: certification and rollup coverage must span
+// the same horizon, or a day is certified but never rolled up (or vice versa).
+const_default!(d_rollup_backfill_days: u16 = 35);
 const_default!(d_rollup_backfill_schedule: String = "0 */10 * * * *");
 const_default!(d_rollup_backfill_concurrency: usize = 3);
 const_default!(d_footer_repair_schedule: String = "0 30 * * * *");
@@ -2165,9 +2168,21 @@ pub struct MaintenanceConfig {
     /// lookback, and routing needs a contiguous certified prefix from the start
     /// of the window — so a 7d or 30d query, the only kind expensive enough to
     /// be worth accelerating, can never route no matter how long the process
-    /// runs. Conservative by default: the first pass certifies each sealed day,
-    /// which is real work on a busy table.
-    #[serde(default)]
+    /// runs.
+    ///
+    /// That paragraph was written as a warning and then left true: this was
+    /// `#[serde(default)]` — 0, disabled — while the only implementation
+    /// (`rollup_backfill_tick`) had been orphaned by the coordinator redesign
+    /// and was reachable solely from tests. Prod 2026-08-17 confirmed it exactly:
+    /// `otel_logs_and_spans_rollup_dashboard_1m_v3` held rows for two dates
+    /// against 30+ days of source data, and every 7d/14d/30d query was refused
+    /// with `not_built`.
+    ///
+    /// 35 matches the dedup certification window so the two horizons cannot
+    /// drift apart. `plan_rollup_backfill` consumes this and is bounded per
+    /// pass, so a wide horizon converges over hours instead of burying the
+    /// journal in one go. Set 0 to disable.
+    #[serde(default = "d_rollup_backfill_days")]
     pub timefusion_rollup_backfill_days: u16,
     #[serde(default = "d_rollup_backfill_schedule")]
     pub timefusion_rollup_backfill_schedule: String,

--- a/src/database.rs
+++ b/src/database.rs
@@ -9204,6 +9204,128 @@ impl Database {
         Ok(count)
     }
 
+    /// Enqueue rollup work for sealed days that have source data but no rollup
+    /// output yet.
+    ///
+    /// Nothing else does this, which is the whole reason it exists.
+    /// `reconcile_maintenance_task_cursors` only enqueues partitions named by
+    /// commits *after* its durable cursor, and DML invalidation only covers what
+    /// it touched. A day written before rollups could reach it is therefore
+    /// never enqueued by anything, and its rollup is never built. The old
+    /// `rollup_backfill_tick` covered exactly this case; the coordinator
+    /// redesign retired its cron without replacing it, leaving that function
+    /// reachable only from tests.
+    ///
+    /// Measured on prod 2026-08-17:
+    /// `otel_logs_and_spans_rollup_dashboard_1m_v3` held rows for exactly two
+    /// dates (08-15, 08-16) against 30+ days of source data, so every
+    /// 7d/14d/30d query was — correctly — refused with `not_built`. No amount
+    /// of maintenance throughput fixes that, because no task was ever queued.
+    ///
+    /// Bounded on purpose: newest-first, and at most `BACKFILL_PARTITIONS_PER_PASS`
+    /// partitions per pass. A whole horizon at once would add tens of thousands
+    /// of invalidations to a journal that is already ~18k deep, and the point is
+    /// to converge steadily without burying the live frontier.
+    pub async fn plan_rollup_backfill(&self) -> Result<usize> {
+        /// Newest-first per pass; the pass repeats on the same 60s cadence as
+        /// compaction-debt planning, so the horizon fills in over hours.
+        const BACKFILL_PARTITIONS_PER_PASS: usize = 8;
+
+        let horizon = i64::from(self.config.maintenance.timefusion_rollup_backfill_days);
+        if horizon == 0 || !self.config.maintenance.timefusion_rollup_enabled {
+            return Ok(0);
+        }
+        let today = crate::clock::today_utc();
+        let earliest = today - chrono::Duration::days(horizon);
+        let mut queued = 0usize;
+
+        for (storage_project, source, table_ref) in self.all_tables().await {
+            let Some(schema) = get_schema(&source) else { continue };
+            if schema.rollups.is_empty() {
+                continue;
+            }
+            // Metadata only — the Delta log already names every partition, so
+            // this never touches parquet.
+            let partitions_of = |table: &DeltaTable| -> Result<HashSet<(String, chrono::NaiveDate)>> {
+                Ok(table
+                    .snapshot()?
+                    .log_data()
+                    .iter()
+                    .filter_map(|file| {
+                        let path = file.path();
+                        let date =
+                            path.split('/').find_map(|segment| segment.strip_prefix("date=")).and_then(|value| value.parse::<chrono::NaiveDate>().ok())?;
+                        let project = path
+                            .split('/')
+                            .find_map(|segment| segment.strip_prefix("project_id="))
+                            .map(str::to_owned)
+                            .unwrap_or_else(|| if storage_project.is_empty() { "default".to_owned() } else { storage_project.clone() });
+                        Some((project, date))
+                    })
+                    .collect())
+            };
+
+            let mut want: Vec<(String, chrono::NaiveDate)> = {
+                let table = table_ref.read().await;
+                partitions_of(&table)?
+            }
+            .into_iter()
+            // Today is the live frontier's job; only sealed days are backfill.
+            .filter(|(_, date)| *date < today && *date >= earliest)
+            .collect();
+
+            // Covered by EVERY declared tier, not just one: a date present in
+            // the 1m tier but missing from the 1h tier still refuses a 30d
+            // panel, which reads the coarse tier.
+            for spec in &schema.rollups {
+                let target = spec.table_name(&source);
+                let Ok(target_ref) = self.resolve_table(&storage_project, &target).await else { continue };
+                let covered = {
+                    let table = target_ref.read().await;
+                    partitions_of(&table)?
+                };
+                want.retain(|key| !covered.contains(key));
+            }
+            // Skip any day that already has rollup work queued. `invalidate`
+            // takes `deadline.max(new_deadline)`, so re-invalidating a day that
+            // already has an eligible task pushes that task's deadline OUT by a
+            // full finalization delay. A planner running every 60s would then
+            // hold the live frontier permanently just out of reach — the suite
+            // caught exactly that: two rollup-parity tests went from correct
+            // totals to building nothing at all.
+            //
+            // "Nothing has touched it" is the actual precondition of a backfill,
+            // so make it literal.
+            {
+                let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let queued: HashSet<(String, chrono::NaiveDate)> = journal
+                    .tasks()
+                    .filter(|task| task.key.source == source && task.state != crate::maintenance_coordinator::TaskState::Complete)
+                    .filter_map(|task| {
+                        chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| (task.key.project_id.clone(), time.date_naive()))
+                    })
+                    .collect();
+                want.retain(|key| !queued.contains(key));
+            }
+            if want.is_empty() {
+                continue;
+            }
+            // Newest first: recent days are what dashboards actually read, and
+            // an oldest-first pass spends the whole horizon on data nobody has
+            // queried yet.
+            want.sort_by(|(pa, da), (pb, db)| db.cmp(da).then_with(|| pa.cmp(pb)));
+            let total = want.len();
+            want.truncate(BACKFILL_PARTITIONS_PER_PASS);
+            for (project_id, date) in &want {
+                self.enqueue_maintenance_hours(project_id, &source, &date.to_string(), crate::rollup::ALL_HOURS)?;
+                queued = queued.saturating_add(1);
+            }
+            // Never let a bounded pass read as "covered everything".
+            info!(source, queued = want.len(), remaining = total - want.len(), horizon_days = horizon, event = "rollup_backfill_planned");
+        }
+        Ok(queued)
+    }
+
     async fn run_coordinator_dedup_once(&self) -> Result<bool> {
         use crate::maintenance_coordinator::{MAX_DECODED_BYTES, Operation, Resources};
         use std::sync::atomic::Ordering::Relaxed;
@@ -9836,6 +9958,13 @@ impl Database {
             let planned = self.plan_compaction_debt().await?;
             if planned != 0 {
                 info!(planned, event = "maintenance_compaction_debt_planned");
+            }
+            // Same 60s cadence, same reason: this is historical debt nothing
+            // else will ever queue. Without it the rollup horizon never grows
+            // past the live frontier and long-window queries stay unroutable.
+            let backfilled = self.plan_rollup_backfill().await?;
+            if backfilled != 0 {
+                info!(backfilled, event = "maintenance_rollup_backfill_planned");
             }
         }
         // Interleave dependent publication with dedup instead of draining the

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -177,7 +177,8 @@ async fn query_delta_only_deduplicates_so_a_rollup_build_needs_no_certification(
 #[tokio::test]
 async fn a_rollup_built_over_an_uncertified_duplicated_partition_matches_the_deduped_answer() -> Result<()> {
     let mut cfg = (*TestConfigBuilder::new("rollup_no_cert").with_buffer_mode(BufferMode::Enabled).with_rollups().build()).clone();
-    // The backfill is off by default (0 = disabled); this test is about it.
+    // Pinned to 4 to keep this fixture's horizon small and explicit; the
+    // shipped default is 35 (it was 0/disabled until 2026-08-17).
     cfg.maintenance.timefusion_rollup_backfill_days = 4;
     let cfg = Arc::new(cfg);
     let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
@@ -221,6 +222,58 @@ async fn a_rollup_built_over_an_uncertified_duplicated_partition_matches_the_ded
         scalar(format!("SELECT COALESCE(SUM(request_count), 0)::BIGINT FROM otel_logs_and_spans_rollup_dashboard_1m_v3 WHERE project_id = '{project_id}'"))
             .await?;
     assert_eq!(rolled, deduped_raw, "the rollup must count the DEDUPLICATED rows; counting the physical 4 is the silent-wrong-number failure");
+    Ok(())
+}
+
+/// The rollup backfill must not disturb work that is already queued.
+///
+/// Backfill exists because nothing else queues an untouched sealed day:
+/// `reconcile_maintenance_task_cursors` enqueues only partitions named by
+/// commits after its durable cursor, and DML invalidation only covers what it
+/// touched. Prod 2026-08-17 had rollup rows for exactly two dates against 30+
+/// days of source data, so every 7d/14d/30d query was refused with `not_built`.
+///
+/// But the enqueue path it reuses, `invalidate`, takes
+/// `deadline.max(new_deadline)`. So re-invalidating a day that ALREADY has an
+/// eligible task pushes that task's deadline out by a full finalization delay,
+/// and a planner running every 60s holds the live frontier permanently just out
+/// of reach. That is not hypothetical: the first version of this planner did
+/// exactly that, and two rollup-parity tests went from correct totals to
+/// building nothing at all.
+///
+/// So the precondition of a backfill — "nothing has touched this day" — has to
+/// be literal. This pins it, and pins the horizon switch that turns the whole
+/// thing off.
+#[serial]
+#[tokio::test]
+async fn rollup_backfill_leaves_already_queued_days_alone() -> Result<()> {
+    let base = TestConfigBuilder::new("rollup_coordinator_backfill").with_buffer_mode(BufferMode::Enabled).with_rollups().build();
+    assert!(base.maintenance.timefusion_rollup_backfill_days >= 30, "the shipped default must cover a 30d query; 0 disables the backfill entirely");
+
+    let db = Arc::new(Database::with_config(Arc::clone(&base)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    // Writing the day queues rollup work for it through the normal path.
+    let day = chrono::Utc::now().date_naive() - chrono::Duration::days(3);
+    let ts = day.and_hms_opt(9, 0, 0).unwrap().and_utc().timestamp_micros();
+    for id in ["a", "b", "c"] {
+        db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![json_to_batch(vec![test_span_ts(id, "op", &project_id, ts)])?], true, None).await?;
+    }
+    if let Some(layer) = db.buffered_layer() {
+        layer.flush_all_now().await?;
+    }
+
+    assert_eq!(
+        db.plan_rollup_backfill().await?,
+        0,
+        "a day that already has queued rollup work must not be re-invalidated; doing so pushes its deadline out every pass and starves the live frontier"
+    );
+
+    // The horizon switch must still turn it off, or there is no way back.
+    let mut off = (*base).clone();
+    off.maintenance.timefusion_rollup_backfill_days = 0;
+    let db_off = Arc::new(Database::with_config(Arc::new(off)).await?);
+    assert_eq!(db_off.plan_rollup_backfill().await?, 0, "horizon 0 must disable the backfill entirely");
     Ok(())
 }
 


### PR DESCRIPTION
## The measurement

Prod 2026-08-17: `otel_logs_and_spans_rollup_dashboard_1m_v3` held rows for **exactly two dates**:

```
2026-08-16 | 885 rows
2026-08-15 | 400 rows
```

against 30+ days of source data. So every 7d/14d/30d query was refused with `not_built` — **correctly**. The rollups simply did not exist.

## Why nothing built them

Nothing queues an untouched day:

- `reconcile_maintenance_task_cursors` enqueues only partitions named by commits **after** its durable cursor
- DML invalidation only covers what it touched
- `rollup_backfill_tick` was written for exactly this case, and the coordinator redesign **retired its cron without replacing it** — it has been reachable only from tests ever since
- `timefusion_rollup_backfill_days` was `#[serde(default)]`, i.e. **0 = disabled**

The doc comment on that field already described the consequence precisely:

> *"Without a backfill the ONLY covered dates are today and the dedup lookback … so a 7d or 30d query, the only kind expensive enough to be worth accelerating, can never route no matter how long the process runs."*

It was written as a warning and then left true.

**No amount of maintenance throughput fixes this**, because no task ever existed — which is why #101 (1 → 6 jobs) and #106 (→ 12 jobs) moved plenty of bytes but not coverage.

## The change

`plan_rollup_backfill`, on the coordinator's existing 60s debt-planning cadence:

- **metadata-only** — the Delta log names every partition, no parquet is read
- **newest-first** — recent days are what dashboards read
- **bounded to 8 partitions/pass** — a 35-day horizon converges over hours instead of burying an already ~18k-deep journal
- default horizon **35**, matching `d_dedup_lookback_days`, so certification and rollup coverage cannot drift apart

## The trap the suite caught

`invalidate` takes `deadline.max(new_deadline)`. Re-invalidating a day that already has an eligible task pushes that task out by a full finalization delay — and a planner running every 60s would hold the **live frontier permanently just out of reach**.

The first version of this planner did exactly that: two rollup-parity tests went from correct totals to building **nothing at all**. Caught in CI, not in prod.

So the planner skips any day with a non-`Complete` task, making the precondition "nothing has touched it" literal. `rollup_backfill_leaves_already_queued_days_alone` pins that, and pins the horizon-0 kill switch.

## Verification

Full suite **949/949**, `cargo lint` clean, `cargo fmt --check` clean.

## Watch on deploy

`rollup_backfill_planned` events, rollup coverage day-count per project (a monitor is watching shipbubble), `tasks_pending` not exploding, and that the live frontier keeps up (`eligible_watermark_lag_seconds`).