### PR TITLE
perf(maintenance): 24 jobs, and half the claims reserved for sealed work

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -489,8 +489,15 @@ impl DerivedBudget {
             // decode against 85.9 GiB, still far below the 48-way exposure that
             // starved health checks on 2026-08-16, and the dedicated maintenance
             // runtime is what protects liveness either way.
-            let cpu_bound = self.cores / 4;
-            mem_bound.min(cpu_bound).clamp(1, 12)
+            // Raised again 2026-08-17 after measuring the actual constraint.
+            // At 12 jobs prod completed ~4,400 tasks/hour (~1.2/s) against ~148k
+            // tasks of genuine backfill work (30 days x 11 projects x ~450 tasks
+            // per partition) — ~34 hours, with RSS at 8% of the cgroup, OCC
+            // conflicts at 0, and 12 of 48 cores in use. Throughput, not the
+            // split between frontier and sealed work, is what bounds rollup
+            // coverage. 24 jobs is ~12 GiB of tracked decode against 85.9 GiB.
+            let cpu_bound = self.cores / 2;
+            mem_bound.min(cpu_bound).clamp(1, 24)
         })
     }
 
@@ -2716,8 +2723,14 @@ mod tests {
         // Every admitted unit reserves at most MAX_DECODED_BYTES, so the
         // concurrent decode reservation must still fit the maintenance pool.
         assert!(prod.coordinator_jobs() * 512 * 1024 * 1024 <= prod.maintenance_pool_bytes(), "concurrent 512 MiB units must fit the maintenance pool");
-        // Small boxes degrade to serial rather than thrashing.
-        assert_eq!(DerivedBudget::from_limits(16 * GIB, 4).coordinator_jobs(), 1);
+        // Small boxes stay modest rather than thrashing. This pinned exactly 1
+        // while the divisor was cores/8; at cores/2 a 4-core box gets 2, which
+        // is still only 1 GiB of concurrent decode. The invariant worth holding
+        // is "does not thrash a small box and still fits its pool", not a
+        // specific number that has to be edited every time the divisor moves.
+        let small = DerivedBudget::from_limits(16 * GIB, 4);
+        assert!(small.coordinator_jobs() <= 2, "a 4-core box must not run maintenance wide, got {}", small.coordinator_jobs());
+        assert!(small.coordinator_jobs() * 512 * 1024 * 1024 <= small.maintenance_pool_bytes(), "concurrent units must fit a small box's pool too");
     }
 
     // Small box (16 GiB / 4 cores): degrades to K=1, nothing underflows/zeroes.

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -529,7 +529,13 @@ impl TaskJournal {
         // exactly the sealed days that never ran. Falls back to any class when
         // there is no sealed work, so quiet history never idles a worker.
         self.claim_tick = self.claim_tick.wrapping_add(1);
-        let sealed_turn = self.claim_tick.is_multiple_of(3);
+        // Every OTHER claim, not every third. Measured after the reservation
+        // shipped: sealed work went from 0 of 278 task starts to 8 of 131
+        // (6.1%), far short of the intended third, because a sealed turn falls
+        // back to any class whenever the operation being claimed has no eligible
+        // sealed task — and rollup work sits behind its own dedup. Raising the
+        // share is the direct lever on how fast coverage walks backward.
+        let sealed_turn = self.claim_tick.is_multiple_of(2);
         let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64)> {
             let mut class: Option<(u8, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {


### PR DESCRIPTION
Two measurements after #111 landed.

## 1. The reservation works, but the share is too small

| | before #111 | after #111 |
|---|---|---|
| sealed task starts | **0 of 278** | **8 of 131 (6.1%)** |
| dates reached | none | 08-15, then 08-14 |

It walks backward correctly. But 6.1% is far short of the intended third: a sealed turn falls back to any class whenever the operation being claimed has no eligible sealed task, and sealed rollup work sits behind its own sealed dedup. **Reserve every other claim instead.**

## 2. Throughput, not the split, is the binding constraint

At 12 jobs prod completes ~4,400 tasks/hour (**~1.2/s**) against ~**148k** tasks of genuine backfill work (30 days × 11 projects × ~450 tasks/partition). That is ~**34 hours** even if every claim went to sealed work.

Meanwhile:

| | |
|---|---|
| RSS | **8%** of cgroup |
| `occ_conflicts_total` | **0** |
| cores in use | **12 of 48** |

`cores/2` capped at 24 is ~12 GiB of tracked decode against 85.9 GiB.

## Test change

`coordinator_jobs_scale_with_the_box` pinned "small box == exactly 1", which was a statement about the divisor rather than about safety. A 4-core box now gets 2 — 1 GiB of concurrent decode. It now asserts what matters: doesn't run wide on a small box, and still fits that box's pool.

## Reversible

`TIMEFUSION_COORDINATOR_JOB_WORKERS` pins concurrency; the sealed share is a single constant.

## Verification

Full suite **950/950**, `cargo lint` clean, `cargo fmt --check` clean.

## Watch on deploy

Sealed share of task starts, tasks/hour, and whether RSS/OCC stay flat at 24 jobs. Kill switch ready if the frontier lags.