### PR TITLE
Revert to 12 coordinator jobs: 24 queues on the inner permit pool

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -496,8 +496,15 @@ impl DerivedBudget {
             // conflicts at 0, and 12 of 48 cores in use. Throughput, not the
             // split between frontier and sealed work, is what bounds rollup
             // coverage. 24 jobs is ~12 GiB of tracked decode against 85.9 GiB.
-            let cpu_bound = self.cores / 2;
-            mem_bound.min(cpu_bound).clamp(1, 24)
+            // Back to cores/4 (cap 12) after measuring 24 on prod. Coordinator
+            // jobs are NOT the innermost limit: an admitted unit still waits on
+            // the much smaller rewrite/sort permit pools (HEAVY_REWRITE_PERMITS
+            // is 4). At 24 jobs those slots filled with units blocked on a
+            // permit — permit_wait_ms reached 271,692 (4.5 min), 10 units timed
+            // out, and completions collapsed from ~0.6/s to 0.035/s. Wider than
+            // the inner pool only converts coordinator slots into queueing.
+            let cpu_bound = self.cores / 4;
+            mem_bound.min(cpu_bound).clamp(1, 12)
         })
     }
 


### PR DESCRIPTION
## What #112 got wrong

I raised coordinator jobs to `cores/2` (24) because RSS was 8%, OCC 0, and only 12 of 48 cores were in use. That read the wrong constraint.

**Coordinator jobs are not the innermost limit.** An admitted unit still has to take a rewrite/sort permit, and `HEAVY_REWRITE_PERMITS` is **4**. At 24 jobs the extra slots filled with units *blocked on a permit* rather than doing work:

| metric | 12 jobs | 24 jobs |
|---|---|---|
| `permit_wait_ms` p50 / max | — | **4,195 / 271,692** (4.5 min) |
| maintenance unit timeouts | — | **10** |
| completions | ~0.6/s | **0.035/s** |

RSS (10.4 GB, 12%), `occ_conflicts_total` (0) and `eligible_watermark_lag_seconds` (0) all stayed healthy — which is exactly why this needed measuring rather than eyeballing. **Every safety metric said there was room; the throughput metric said the opposite.**

## Change

Back to `cores/4` (cap 12).

Raising `HEAVY_REWRITE_PERMITS` is the other end of this trade, but that constant carries a documented fan-in OOM history (2026-07-04) and explicitly says not to raise it without shrinking the per-shard budget first. Not a change to make blind at 4am.

## Kept from #112

The sealed-claim share (every other claim) stays — it moved sealed work from **6.1% → 11.2%** of task starts and reached 08-13, and it is independent of job count.

## Verification

Full suite green apart from `optimize_preserves_all_partition_values`, which flaked once under parallel load and passed 2/2 in isolation; this change is a one-line constant that cannot affect partition values. `cargo lint` and `cargo fmt --check` clean.