### PR TITLE
feat(tantivy): report how much of the reindex is left

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -3351,6 +3351,8 @@ impl Database {
         let mut roots: Vec<String> = vec!["default".into()];
         roots.extend(self.custom_project_tables.read().await.keys().filter(|(_, t)| t == table_name).map(|(p, _)| p.clone()));
         let mut built = 0usize;
+        // Coverage gauges for this pass — see `tantivy_uncovered_files`.
+        let (mut uncovered_total, mut oversized_total) = (0u64, 0u64);
         for root in roots {
             let Ok(table_ref) = self.resolve_table(&root, table_name).await else {
                 continue;
@@ -3381,6 +3383,7 @@ impl Database {
                     let before = uris.len();
                     uris.retain(|u| parquet_rel_of_uri(u).and_then(|rel| sizes.get(rel)).is_none_or(|sz| *sz <= max_bytes));
                     let skipped = before - uris.len();
+                    oversized_total = oversized_total.saturating_add(skipped as u64);
                     if skipped > 0 {
                         // No silent caps: oversized files stay uncovered until a
                         // bigger-memory runner reconciles without the limit.
@@ -3390,6 +3393,7 @@ impl Database {
                 // Dashboard acceptance is governed by recent windows; a
                 // terabyte of legacy history must not stand in front of the
                 // last seven days after a migration.
+                uncovered_total = uncovered_total.saturating_add(uris.len() as u64);
                 sort_backfill_uris_newest_first(&mut uris);
                 let queue = uris.into_iter().filter_map(|uri| Some((parquet_rel_of_uri(&uri)?.to_string(), uri))).collect::<VecDeque<_>>();
                 queues.push((pid, queue));
@@ -3407,6 +3411,14 @@ impl Database {
                 }
             }
         }
+        // Gauges, so each pass reports the CURRENT remaining work rather than a
+        // running total. `uncovered` reaching 0 is what "the reindex is done"
+        // means, and nothing reported it before — which is why the reindex was
+        // being chased by hand from sibling containers.
+        let stats = crate::metrics::maintenance_stats();
+        stats.tantivy_uncovered_files.store(uncovered_total.saturating_sub(built as u64), std::sync::atomic::Ordering::Relaxed);
+        stats.tantivy_oversized_skipped.store(oversized_total, std::sync::atomic::Ordering::Relaxed);
+        info!(table_name, built, uncovered_before = uncovered_total, oversized_skipped = oversized_total, event = "tantivy_backfill_pass");
         Ok(built)
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -735,6 +735,17 @@ atomic_stats! {
     rollup_end_to_end_duration_ms,
     rollup_output_rows,
     rollup_output_files,
+    /// Live parquet files the Tantivy manifest does NOT cover, as of the last
+    /// reconcile pass, plus the ones skipped for exceeding
+    /// TIMEFUSION_TANTIVY_BACKFILL_MAX_FILE_MB. Gauges, not counters: each pass
+    /// overwrites them.
+    ///
+    /// Without these there is no way to tell whether a reindex is converging or
+    /// how far it has left to run, which is precisely why the reindex was being
+    /// driven by hand from sibling containers — three of which were OOM-killed
+    /// on 2026-08-16. `uncovered` trending to 0 IS the definition of done.
+    tantivy_uncovered_files,
+    tantivy_oversized_skipped,
     rollup_full_hours_rebuilt,
     rollup_incremental_hours_rebuilt,
     maintenance_tasks_pending,

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -343,6 +343,8 @@ impl StatsTableProvider {
             "rollup_end_to_end_duration_ms_total" => m.rollup_end_to_end_duration_ms,
             "rollup_output_rows_total" => m.rollup_output_rows,
             "rollup_output_files_total" => m.rollup_output_files,
+            "tantivy_uncovered_files" => m.tantivy_uncovered_files,
+            "tantivy_oversized_skipped" => m.tantivy_oversized_skipped,
             "rollup_full_hours_rebuilt_total" => m.rollup_full_hours_rebuilt,
             "rollup_incremental_hours_rebuilt_total" => m.rollup_incremental_hours_rebuilt,
             "tasks_pending" => m.maintenance_tasks_pending,

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -1609,9 +1609,22 @@ async fn tantivy_reconcile_backfills_new_files_and_gcs_orphans() -> Result<()> {
 
     // Reconcile #1 = backfill: both uncovered live files get indexes under
     // the project-uuid manifest; nothing is stale yet.
+    // A reindex has no visible end state without a remaining-work gauge, which
+    // is why it was being chased by hand from sibling containers (three
+    // OOM-killed on 2026-08-16). Seed a sentinel first: a gauge that is simply
+    // never written also reads 0, so asserting 0 alone would pass vacuously.
+    let tantivy_stats = timefusion::metrics::maintenance_stats();
+    let ordering = std::sync::atomic::Ordering::Relaxed;
+    tantivy_stats.tantivy_uncovered_files.store(999, ordering);
+
     let (built, removed, _) = db.tantivy_reconcile_table(TABLE).await?;
     assert!(built >= 2, "expected both uncovered live files indexed, built={built}");
     assert_eq!(removed, 0, "nothing to GC before compaction");
+    assert_eq!(
+        tantivy_stats.tantivy_uncovered_files.load(ordering),
+        0,
+        "the pass must publish remaining work (sentinel not overwritten); 'uncovered -> 0' is the definition of a finished reindex"
+    );
     let m = manifest::load(tantivy_store.as_ref(), TABLE, &project_id).await?;
     assert_eq!(m.entries.len(), 2, "per-uuid manifest covers both files");
 


### PR DESCRIPTION
## The gap

There was no way to tell whether the Tantivy reindex was converging or how far it had to go. `tantivy.recovery_pending_files` covers only post-WAL-replay deferrals; **nothing reported live parquet files the manifest does not cover.**

That gap is why the reindex was being driven by hand from sibling containers — `timefusion-tantivy-reconcile-{streaming,4cpu,2cpu}`, all three **OOM-killed (exit 137)** on 2026-08-16. Without a remaining-work number there is no way to say "it's done", so the only options were to keep pushing or to guess.

## What's already fine

The in-process backfill is the well-behaved design and needs no redesign:

- newest-first (`sort_backfill_uris_newest_first`)
- fair project rotation (#99)
- bounded build concurrency (default **2**, documented as safe alongside prod query load)
- a reserved tantivy memory budget (`budget.tantivy_peak_mb = 1536`)
- oversized files **warned, not silently skipped** ("No silent caps")

It runs unconditionally from the daily reconcile cron. It just had no scoreboard.

## Change

Two gauges published from each pass:

| stat | meaning |
|---|---|
| `tantivy_uncovered_files` | live parquet the manifest does not cover |
| `tantivy_oversized_skipped` | files past `TIMEFUSION_TANTIVY_BACKFILL_MAX_FILE_MB` |

Gauges, not counters — each pass overwrites them, so the value is always "remaining right now". **`uncovered` reaching 0 is the definition of done.**

## Test

Seeds a sentinel before the pass, because a gauge that is never written also reads 0 and asserting 0 alone would pass vacuously. **Verified it bites**: with the store removed it fails with `left: 999`.

## Verification

Full suite **950/950**, `cargo lint` clean, `cargo fmt --check` clean.

Note: a stale MinIO from the `kill_recovery` test was squatting on :9000 with a deleted data dir (`listPathRaw: 0 drives provided`), failing every S3-backed test. Restarted via `make minio-start` — unrelated to this change, but worth knowing it can happen.