### PR TITLE
feat(tantivy): census remaining reindex work every 15 minutes

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -2420,6 +2420,9 @@ pub struct Database {
     maintenance_tasks: Arc<std::sync::Mutex<crate::maintenance_coordinator::TaskJournal>>,
     maintenance_admission: crate::maintenance_coordinator::AdmissionController,
     maintenance_debt_planned_at: Arc<std::sync::atomic::AtomicI64>,
+    /// Last Tantivy coverage census. Metadata-only, so it is throttled by time
+    /// rather than by admission.
+    tantivy_census_at: Arc<std::sync::atomic::AtomicI64>,
     maintenance_schedule_cursor: Arc<std::sync::atomic::AtomicUsize>,
     /// Bounded exponential retry state for failed source-partition rollup builds.
     rollup_backoff: Arc<dashmap::DashMap<RollupCoverageKey, (u32, std::time::Instant)>>,
@@ -3108,6 +3111,7 @@ impl Database {
             maintenance_tasks: Arc::new(std::sync::Mutex::new(maintenance_tasks)),
             maintenance_admission,
             maintenance_debt_planned_at: Arc::new(std::sync::atomic::AtomicI64::new(i64::MIN)),
+            tantivy_census_at: Arc::new(std::sync::atomic::AtomicI64::new(i64::MIN)),
             maintenance_schedule_cursor: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             rollup_backoff: Arc::new(dashmap::DashMap::new()),
             logical_count_cache,
@@ -3339,6 +3343,65 @@ impl Database {
         }
         let built = self.backfill_table_indexes(&svc, table_name).await?;
         Ok((built, removed, blobs))
+    }
+
+    /// Count live parquet the Tantivy manifest does not cover, without building
+    /// anything.
+    ///
+    /// `backfill_table_indexes` already publishes these gauges, but it only runs
+    /// from the daily reconcile cron — so after a deploy the reindex has no
+    /// reported remaining-work figure for up to 24 hours, which is exactly the
+    /// blind spot that had the reindex being chased by hand from sibling
+    /// containers. This is the same diff, metadata-only: the Delta log names the
+    /// live files and the manifest names the covered ones. No parquet is read
+    /// and no index is built, so it is safe to run far more often than a pass.
+    pub async fn tantivy_coverage_census(&self) -> anyhow::Result<(u64, u64)> {
+        use crate::tantivy_index::{manifest, service::project_id_of_uri};
+        let Some(svc) = self.tantivy_indexer().cloned() else { return Ok((0, 0)) };
+        let (mut uncovered, mut oversized) = (0u64, 0u64);
+        for table_name in svc.config.indexed_tables() {
+            if !svc.config.is_table_indexed(&table_name) {
+                continue;
+            }
+            let mut roots: Vec<String> = vec!["default".into()];
+            roots.extend(self.custom_project_tables.read().await.keys().filter(|(_, t)| *t == table_name).map(|(p, _)| p.clone()));
+            for root in roots {
+                let Ok(table_ref) = self.resolve_table(&root, &table_name).await else { continue };
+                let (uris, sizes) = {
+                    let t = table_ref.read().await;
+                    let sizes: HashMap<String, u64> = match t.snapshot() {
+                        Ok(snapshot) => snapshot.log_data().iter().map(|f| (f.path().into_owned(), f.size() as u64)).collect(),
+                        Err(_) => HashMap::new(),
+                    };
+                    (t.get_file_uris()?.collect::<Vec<String>>(), sizes)
+                };
+                let mut by_pid: HashMap<String, Vec<String>> = HashMap::new();
+                for uri in uris.into_iter().filter(|uri| uri.ends_with(".parquet")) {
+                    if let Some(pid) = project_id_of_uri(&uri) {
+                        by_pid.entry(pid.to_string()).or_default().push(uri);
+                    }
+                }
+                let max_bytes = self.config.tantivy.timefusion_tantivy_backfill_max_file_mb * 1024 * 1024;
+                for (pid, mut uris) in by_pid {
+                    let manifest = manifest::load(svc.object_store.as_ref(), &table_name, &pid).await?;
+                    let covered: std::collections::HashSet<&String> =
+                        manifest.entries.values().filter(|e| e.index.is_some() && e.error.is_none()).flat_map(|e| e.covered_files.iter()).collect();
+                    uris.retain(|uri| !covered.contains(uri));
+                    if max_bytes > 0 {
+                        let before = uris.len();
+                        uris.retain(|uri| {
+                            crate::tantivy_index::service::parquet_rel_of_uri(uri).and_then(|rel| sizes.get(rel)).is_none_or(|size| *size <= max_bytes)
+                        });
+                        oversized = oversized.saturating_add((before - uris.len()) as u64);
+                    }
+                    uncovered = uncovered.saturating_add(uris.len() as u64);
+                }
+            }
+        }
+        let stats = crate::metrics::maintenance_stats();
+        stats.tantivy_uncovered_files.store(uncovered, std::sync::atomic::Ordering::Relaxed);
+        stats.tantivy_oversized_skipped.store(oversized, std::sync::atomic::Ordering::Relaxed);
+        Ok((uncovered, oversized))
     }
 
     async fn backfill_table_indexes(&self, svc: &Arc<crate::tantivy_index::service::TantivyIndexService>, table_name: &str) -> anyhow::Result<usize> {
@@ -9995,6 +10058,20 @@ impl Database {
             let backfilled = self.plan_rollup_backfill().await?;
             if backfilled != 0 {
                 info!(backfilled, event = "maintenance_rollup_backfill_planned");
+            }
+        }
+        // Tantivy coverage census: metadata-only, so it is throttled by wall
+        // clock rather than admission. Every 15 minutes keeps
+        // `tantivy_uncovered_files` meaningful between daily reconcile passes —
+        // without it the reindex reports nothing for up to 24h after a deploy.
+        const TANTIVY_CENSUS_INTERVAL_MICROS: i64 = 15 * 60 * 1_000_000;
+        let census_last = self.tantivy_census_at.load(std::sync::atomic::Ordering::Relaxed);
+        if now.saturating_sub(census_last) >= TANTIVY_CENSUS_INTERVAL_MICROS
+            && self.tantivy_census_at.compare_exchange(census_last, now, std::sync::atomic::Ordering::AcqRel, std::sync::atomic::Ordering::Relaxed).is_ok()
+        {
+            match self.tantivy_coverage_census().await {
+                Ok((uncovered, oversized)) => info!(uncovered, oversized, event = "tantivy_coverage_census"),
+                Err(error) => warn!(%error, event = "tantivy_coverage_census_failed"),
             }
         }
         // Interleave dependent publication with dedup instead of draining the

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -1617,6 +1617,14 @@ async fn tantivy_reconcile_backfills_new_files_and_gcs_orphans() -> Result<()> {
     let ordering = std::sync::atomic::Ordering::Relaxed;
     tantivy_stats.tantivy_uncovered_files.store(999, ordering);
 
+    // The census must see the uncovered files BEFORE anything is built. The
+    // gauge is otherwise only written by a reconcile pass, i.e. once a day, so a
+    // freshly deployed process reports "0 remaining" for up to 24h whether or
+    // not the reindex is actually finished — the exact blind spot that had this
+    // work being chased by hand from sibling containers.
+    let (uncovered_before, _) = db.tantivy_coverage_census().await?;
+    assert!(uncovered_before >= 2, "census must count uncovered live files before any build, got {uncovered_before}");
+
     let (built, removed, _) = db.tantivy_reconcile_table(TABLE).await?;
     assert!(built >= 2, "expected both uncovered live files indexed, built={built}");
     assert_eq!(removed, 0, "nothing to GC before compaction");
@@ -1625,6 +1633,8 @@ async fn tantivy_reconcile_backfills_new_files_and_gcs_orphans() -> Result<()> {
         0,
         "the pass must publish remaining work (sentinel not overwritten); 'uncovered -> 0' is the definition of a finished reindex"
     );
+    let (uncovered_after, _) = db.tantivy_coverage_census().await?;
+    assert_eq!(uncovered_after, 0, "after indexing every uncovered file the census must independently agree the reindex is done");
     let m = manifest::load(tantivy_store.as_ref(), TABLE, &project_id).await?;
     assert_eq!(m.entries.len(), 2, "per-uuid manifest covers both files");
 


### PR DESCRIPTION
Follow-on to #114.

## Why #114 wasn't enough

#114 published `tantivy_uncovered_files`, but only `backfill_table_indexes` writes it — and that runs from the **daily** reconcile cron. So a freshly deployed process reports **"0 remaining" for up to 24 hours**, whether or not the reindex is actually finished.

Confirmed on prod right after #114 deployed: `maintenance.tantivy_uncovered_files = 0`, purely because no pass had run yet.

That is the same blind spot that had the reindex being chased by hand from sibling containers (three OOM-killed on 2026-08-16). **A metric that reads 0 because it hasn't been computed** is the exact failure mode this line of work keeps hitting — it's now happened with the cohort-only rollup counters, with `cert_granted_total`, and here.

## The change

`tantivy_coverage_census` does the same diff **without building anything**: the Delta log names the live parquet, the manifest names what's covered. No parquet is read, no index is built, so it can run far more often than a pass.

Wired into the coordinator's existing planning tick, throttled to **15 minutes** by wall clock rather than by admission — it costs one manifest GET per project.

## Test

Now asserts the census counts uncovered files **before** any build (`>= 2`), and independently agrees on **0** after the reconcile. So it cannot pass by never running.

## Verification

Full suite **950/950**, `cargo lint` clean, `cargo fmt --check` clean.