### PR TITLE
perf(maintenance): coordinator jobs 12 to 16 now that permits are 10

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -526,8 +526,17 @@ impl DerivedBudget {
             // permit — permit_wait_ms reached 271,692 (4.5 min), 10 units timed
             // out, and completions collapsed from ~0.6/s to 0.035/s. Wider than
             // the inner pool only converts coordinator slots into queueing.
-            let cpu_bound = self.cores / 4;
-            mem_bound.min(cpu_bound).clamp(1, 12)
+            // cores/3 (cap 16) since 2026-08-17, once HEAVY_REWRITE_PERMITS went
+            // 4 -> 10. Jobs are only useful up to the inner permit pool: at
+            // 12 jobs / 4 permits the ratio was 3:1 and `permit_wait_ms` p50 was
+            // 2 minutes, which is why 24 jobs had to be reverted. 16 jobs
+            // against 10 permits is 1.6:1 — headroom for the operations that do
+            // not take a rewrite permit at all, without rebuilding the queue.
+            //
+            // Memory term stays exact: 16 x MAX_DECODED_BYTES = 8 GiB against a
+            // ~16.6 GiB maintenance pool, asserted below.
+            let cpu_bound = self.cores / 3;
+            mem_bound.min(cpu_bound).clamp(1, 16)
         })
     }
 


### PR DESCRIPTION
Follow-on to #118.

## Jobs are only useful up to the inner permit pool

At 12 jobs against 4 permits the ratio was 3:1 and `permit_wait_ms` p50 was **2 minutes** — which is exactly why 24 jobs had to be reverted in #113: it queued deeper on the same semaphore rather than doing more work.

With `HEAVY_REWRITE_PERMITS` now 10, **16 jobs is 1.6:1**, leaving headroom for the operations that never take a rewrite permit without rebuilding that queue.

Memory term stays exact and asserted: `16 × MAX_DECODED_BYTES = 8 GiB` against a ~16.6 GiB maintenance pool.

## Deliberately NOT raising `HEAVY_MIN_SHARE` — correcting my own earlier suggestion

It is a **zero-sum split** of the maintenance pool. `0.40 → 0.60` leaves light with 6.6 GiB, which divided by `PER_SORT_BUDGET_BYTES` drops hot-tail packing to **K=1**. That tier is the one that has been consistently productive all night (`light_optimize_bins_committed` 63 → 84). Raising heavy's share would starve what works to feed what #118 already unblocked.

## Growing the maintenance pool is not available either

| | |
|---|---|
| `committed_mb` | 61,440 of an 80 GiB limit |
| reserve | exactly the documented **25%** untracked floor |
| `slack_mb` | **0** |

The apparent headroom in `mem_buffer` (2.5 of 21.5 GiB) and `query_pool` (27 MB of 16.4 GiB) is **burst ceiling** for precisely the bulk-INSERT and wide-scan paths the earlier OOM series came through — not spare capacity.

If heavy sorts do thrash on spill after #118, the honest next lever is a bigger maintenance pool funded by an explicit decision about which burst ceiling to shrink, not a quiet re-split.

## Verification

Full suite **950/950**, `cargo lint` clean, `cargo fmt --check` clean.
