### PR TITLE
perf(maintenance): reserve three claims in four for sealed work

### DIFF
--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -535,7 +535,19 @@ impl TaskJournal {
         // back to any class whenever the operation being claimed has no eligible
         // sealed task — and rollup work sits behind its own dedup. Raising the
         // share is the direct lever on how fast coverage walks backward.
-        let sealed_turn = self.claim_tick.is_multiple_of(2);
+        // Three claims in four, not one in two. Measured 2026-08-17 with the
+        // per-operation gauges (#120): of 127,798 pending tasks, 118,794 are
+        // sealed AND eligible right now — including 39,072 eligible BaseRollup —
+        // while only ~9,000 are frontier. Yet the frontier was taking ~90% of
+        // claims, because class 0 is strict priority and ingest regenerates it
+        // continuously. A one-in-two reservation delivered ~10% sealed starts in
+        // practice, so rollup coverage sat frozen at 2026-08-11 for hours with
+        // 39k claimable rollup tasks queued behind a much smaller frontier.
+        //
+        // The frontier is small in volume, so one claim in four still clears it;
+        // if it stops keeping up, `eligible_watermark_lag_seconds` says so and
+        // this is the dial to turn back.
+        let sealed_turn = !self.claim_tick.is_multiple_of(4);
         let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64)> {
             let mut class: Option<(u8, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {
@@ -1303,14 +1315,29 @@ mod tests {
         let sealed = key(0, MIN_SLICE_MICROS);
         journal.enqueue(sealed.clone(), now - 1, 1, 1);
 
+        // Enough sealed slices that the share, not the supply, is what limits
+        // sealed claims — mirroring prod, where 118,794 of 127,798 pending tasks
+        // were sealed and eligible while the frontier took ~90% of claims.
+        let sealed_slices: Vec<TimeSlice> = (1..20).map(|k| TimeSlice::new(k * MIN_SLICE_MICROS, (k + 1) * MIN_SLICE_MICROS).expect("sealed slice")).collect();
+        for slice in &sealed_slices {
+            journal.enqueue(key(slice.start_micros, slice.end_micros), now - 1, 1, 1);
+        }
+
         let mut sealed_claims = 0;
-        for _ in 0..9 {
+        for _ in 0..12 {
             let claimed = journal.claim_next(Operation::BaseRollup, now).expect("a task is always available");
-            if claimed.key.slice == sealed.slice {
+            if !is_live_frontier(claimed.key.slice, now) {
                 sealed_claims += 1;
             }
         }
-        assert!(sealed_claims > 0, "sealed work never ran while the frontier stayed busy — long-window queries can never become routable");
+        // "> 0" would pass at any share, including one too small to ever drain a
+        // backlog — which is exactly what shipped first and left coverage frozen
+        // for hours. Assert sealed work is the MAJORITY when it is the majority
+        // of the queue.
+        assert!(
+            sealed_claims >= 7,
+            "sealed work got only {sealed_claims}/12 claims; at that share a 118k-task sealed backlog never drains and long windows stay unroutable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The gauges from #120 settled it

Of **127,798** pending tasks on prod:

| | |
|---|---|
| `eligible_sealed_total` | **118,794** (93% of everything pending) |
| `eligible_base_rollup` | **39,072** (99.5% of `pending_base_rollup`) |
| frontier | **~9,000** |

**39,072 rollup tasks were claimable right now and simply were not being claimed.** Not absent, not waiting on a deadline, not blocked on dependencies — *out-competed*.

The frontier is under 8% of the queue and was taking ~90% of claims, because class 0 is strict priority and ingest regenerates it continuously. A one-in-two reservation delivered only ~**10%** sealed starts in practice, which is why coverage sat frozen at 2026-08-11 for hours.

## It also corrects a guess of mine

I inferred from slice dates that sealed capacity was being eaten by `SealedConsolidation`/`Repair`. It wasn't — those are **1,479** and **352** tasks, 1.4% combined. That inference would have sent the next fix in the wrong direction; the gauges caught it.

## Change

Three claims in four reserved for sealed work. The frontier is small in volume, so one in four still clears it — and `eligible_watermark_lag_seconds` is the signal to turn this back down if it doesn't.

## Test

`sealed_work_gets_claims_while_the_frontier_is_busy` asserted only `> 0`, which passes at **any** share, including one too small to ever drain a backlog — precisely what shipped first. It now seeds a sealed-majority queue and requires sealed work to win the majority of claims.

**Verified it bites**: at the previous share it fails with

```
sealed work got only 6/12 claims; at that share a 118k-task sealed backlog
never drains and long windows stay unroutable
```

## Verification

Full suite **951/951**, `cargo lint` clean, `cargo fmt --check` clean.

## Watch on deploy

Sealed share of `maintenance_task_started` (should go well above 10%), `eligible_base_rollup` falling from 39k, oldest rollup date resuming its walk back from 08-11, and `eligible_watermark_lag_seconds` staying near 0.
