### PR TITLE
Revert sealed share to one in two after an OOM kill

### DIFF
--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -547,7 +547,22 @@ impl TaskJournal {
         // The frontier is small in volume, so one claim in four still clears it;
         // if it stops keeping up, `eligible_watermark_lag_seconds` says so and
         // this is the dial to turn back.
-        let sealed_turn = !self.claim_tick.is_multiple_of(4);
+        // Back to one in two after an OOM. Prod 2026-08-17 09:39:02:
+        //
+        //   maintenance-wor invoked oom-killer
+        //   Killed process (timefusion) anon-rss: 124,921,780 kB  (124.9 GB)
+        //
+        // RSS was 11.9 GB two minutes earlier, so this was a fan-in spike, not
+        // drift. Three-in-four routes far more SEALED partitions through the
+        // heavy path at once, and historical partitions are much larger than
+        // frontier slices — so the same permit count admits far more bytes.
+        // permits=10 + jobs=16 had run 1.5h clean before this landed; the share
+        // is the variable that changed immediately before the kill.
+        //
+        // One in two ran ~6h without an OOM. Raising it again needs the per-sort
+        // budget cut to pay for it (the documented 2026-07-04 pairing), not just
+        // a bigger share.
+        let sealed_turn = self.claim_tick.is_multiple_of(2);
         let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64)> {
             let mut class: Option<(u8, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {
@@ -1334,9 +1349,14 @@ mod tests {
         // backlog — which is exactly what shipped first and left coverage frozen
         // for hours. Assert sealed work is the MAJORITY when it is the majority
         // of the queue.
+        // Was `>= 7` (three in four). Lowered to the one-in-two floor after the
+        // 2026-08-17 OOM: sealed work must still get a real share — "> 0" is the
+        // bug that let an ineffective share ship — but the higher share cost
+        // 124.9 GB of anon RSS and a kill, so the invariant is "a third or
+        // better", not "the majority".
         assert!(
-            sealed_claims >= 7,
-            "sealed work got only {sealed_claims}/12 claims; at that share a 118k-task sealed backlog never drains and long windows stay unroutable"
+            sealed_claims >= 4,
+            "sealed work got only {sealed_claims}/12 claims; below a third, a 118k-task sealed backlog never drains and long windows stay unroutable"
         );
     }
 


### PR DESCRIPTION
## The kill

Prod 2026-08-17 09:39:02:

```
maintenance-wor invoked oom-killer
Killed process (timefusion)  anon-rss: 124,921,780 kB   (124.9 GB)
```

RSS was **11.9 GB two minutes earlier**, so this was a fan-in spike, not drift — and the kernel names the **maintenance worker** as the caller.

## Attribution

| change | live | outcome |
|---|---|---|
| permits 4→10 (#118) | ~1.5 h | clean |
| jobs 12→16 (#119) | ~1.5 h | clean |
| sealed share → 3-in-4 (#121) | ~35 min | **OOM** |

Three-in-four routes far more **sealed** partitions through the heavy path at once, and historical partitions are much larger than frontier slices — so the same permit count admits far more bytes. One-in-two had run ~6 h without an OOM.

**Reverting exactly that one variable**, not the whole stack. Permits and jobs stay; neither is implicated by the timeline.

This is the failure mode the `HEAVY_REWRITE_PERMITS` comment documents (the 2026-07-04 fan-in OOM), reached from the other direction: not by raising permits alone, but by feeding the same permits much larger units. Raising the share again needs the per-sort budget cut to pay for it, not just a bigger share.

## Test

Asserted `>= 7/12`, which only holds at three-in-four. Lowered to `>= 4/12`: sealed work must still get a real share — `> 0` is the bug that let an ineffective share ship in the first place — but the invariant is now "a third or better", not "the majority".

## Verification

Full suite **951/951**, `cargo lint` clean, `cargo fmt --check` clean.

Prod is currently up and healthy (one OOM, one restart — not crashlooping).
