### PR TITLE
Stop unrelated file debt from vetoing rollup backfill

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -286,6 +286,11 @@ const PER_SORT_BUDGET_BYTES: usize = 2 * GIB;
 /// and buy heavy little, since its concurrency is bounded by the rewrite
 /// permits rather than by bytes.
 const HEAVY_MIN_SHARE: f64 = 0.40;
+
+/// Pool slice per in-flight coordinator job. Kept equal to the admission
+/// ceiling so a job that is allowed to decode N bytes has N bytes of pool to
+/// hold them in before it must spill; see `coordinator_share_bytes`.
+const COORDINATOR_JOB_POOL_BYTES: usize = crate::maintenance_coordinator::MAX_DECODED_BYTES as usize;
 /// Floor so a tiny box never zeroes the maintenance pool.
 const MAINTENANCE_FLOOR_BYTES: usize = GIB;
 
@@ -421,6 +426,29 @@ impl DerivedBudget {
         self.maintenance_pool_bytes
     }
 
+    /// The durable coordinator's own pool, carved off before the heavy/light
+    /// split because the coordinator is now the primary maintenance path.
+    ///
+    /// Admission lets each job hold `MAX_DECODED_BYTES`, so the pool they share
+    /// must be that ceiling times the jobs that can be in flight. It used to be
+    /// `MAX_DECODED_BYTES` flat — the admission constant reused as a pool size,
+    /// correct only while `coordinator_jobs` was 1. At 16 jobs FairSpill sliced
+    /// 512 MB sixteen ways, below `ExternalSorterMerge`'s 32 MB floor, so units
+    /// FAILED instead of spilling: prod 2026-08-17 logged 72 `Failed to
+    /// allocate additional 32.0 MB ... pool_size: 512.0 MB` in 25 minutes.
+    pub fn coordinator_share_bytes(&self) -> usize {
+        match self.profile {
+            // The CLI drives engines directly; no coordinator runs.
+            BudgetProfile::MaintenanceCli => 0,
+            BudgetProfile::Server => (self.coordinator_jobs() * COORDINATOR_JOB_POOL_BYTES).min(self.maintenance_pool_bytes / 2),
+        }
+    }
+
+    /// What heavy and light divide, once the coordinator has taken its share.
+    fn maintenance_split_bytes(&self) -> usize {
+        self.maintenance_pool_bytes - self.coordinator_share_bytes()
+    }
+
     /// Heavy maintenance (dedup/optimize/recompress) share — at least
     /// `HEAVY_MIN_SHARE` of the maintenance pool.
     pub fn heavy_share_bytes(&self) -> usize {
@@ -429,7 +457,7 @@ impl DerivedBudget {
         // pool — only the active engine ever allocates.
         match self.profile {
             BudgetProfile::MaintenanceCli => ((self.maintenance_pool_bytes as f64) * 0.85) as usize,
-            BudgetProfile::Server => ((self.maintenance_pool_bytes as f64) * HEAVY_MIN_SHARE) as usize,
+            BudgetProfile::Server => ((self.maintenance_split_bytes() as f64) * HEAVY_MIN_SHARE) as usize,
         }
     }
 
@@ -437,7 +465,7 @@ impl DerivedBudget {
     pub fn light_share_bytes(&self) -> usize {
         match self.profile {
             BudgetProfile::MaintenanceCli => self.heavy_share_bytes(),
-            BudgetProfile::Server => self.maintenance_pool_bytes - self.heavy_share_bytes(),
+            BudgetProfile::Server => self.maintenance_split_bytes() - self.heavy_share_bytes(),
         }
     }
 
@@ -631,6 +659,7 @@ pub fn log_derived_budget(b: &DerivedBudget) {
         logical_count_memory_gb = b.logical_count_memory_bytes() / GIB,
         writer_reserve_gb = b.writer_reserve_bytes() / GIB,
         maintenance_pool_gb = b.maintenance_pool_bytes() / GIB,
+        coordinator_share_gb = b.coordinator_share_bytes() / GIB,
         heavy_share_gb = b.heavy_share_bytes() / GIB,
         light_share_gb = b.light_share_bytes() / GIB,
         rewrite_permits = b.rewrite_permits(),
@@ -2611,7 +2640,9 @@ mod tests {
             cli.heavy_share_bytes() / GIB
         );
         assert_eq!(server.maintenance_batch_size(), "2048");
-        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.heavy_share_bytes());
+        // Server: coordinator takes its slice first, then heavy/light divide the rest.
+        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.coordinator_share_bytes() - server.heavy_share_bytes());
+        assert_eq!(cli.coordinator_share_bytes(), 0, "the CLI drives engines directly; no coordinator competes for the pool");
     }
 
     #[test]
@@ -2798,6 +2829,35 @@ mod tests {
         let small = DerivedBudget::from_limits(16 * GIB, 4);
         assert!(small.coordinator_jobs() <= 2, "a 4-core box must not run maintenance wide, got {}", small.coordinator_jobs());
         assert!(small.coordinator_jobs() * 512 * 1024 * 1024 <= small.maintenance_pool_bytes(), "concurrent units must fit a small box's pool too");
+    }
+
+    /// The coordinator pool must scale with the jobs sharing it, and the three
+    /// maintenance shares must still sum to the pool.
+    ///
+    /// Prod 2026-08-17: the pool was pinned at one `MAX_DECODED_BYTES` while
+    /// jobs went to 16, so FairSpill handed each consumer ~32 MB — right at
+    /// `ExternalSorterMerge`'s allocation floor — and 72 units failed outright
+    /// in 25 minutes instead of spilling.
+    #[test]
+    fn coordinator_pool_scales_with_its_jobs_without_overcommitting() {
+        if std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").is_ok() {
+            return;
+        }
+        for (limit_gb, cores) in [(80, 48), (16, 4), (8, 4)] {
+            let b = DerivedBudget::from_limits(limit_gb * GIB, cores);
+            let per_job = b.coordinator_share_bytes() / b.coordinator_jobs();
+            assert!(
+                per_job >= 32 * 1024 * 1024,
+                "{limit_gb} GiB/{cores}-core: each of {} jobs gets {} MB, below the 32 MB sort floor",
+                b.coordinator_jobs(),
+                per_job / (1024 * 1024)
+            );
+            assert_eq!(
+                b.coordinator_share_bytes() + b.heavy_share_bytes() + b.light_share_bytes(),
+                b.maintenance_pool_bytes(),
+                "{limit_gb} GiB/{cores}-core: maintenance shares must partition the pool, not overcommit it"
+            );
+        }
     }
 
     // Small box (16 GiB / 4 cores): degrades to K=1, nothing underflows/zeroes.

--- a/src/database.rs
+++ b/src/database.rs
@@ -9306,13 +9306,20 @@ impl Database {
     /// of invalidations to a journal that is already ~18k deep, and the point is
     /// to converge steadily without burying the live frontier.
     pub async fn plan_rollup_backfill(&self) -> Result<usize> {
-        /// Newest-first per pass; the pass repeats on the same 60s cadence as
-        /// compaction-debt planning, so the horizon fills in over hours.
-        /// One partition expands to ~450 durable tasks (a day of slices x
-        /// Dedup/BaseRollup/HotPacking x each declared tier), so this is not
-        /// "8 tasks" — it is thousands. Shipped at 8 and the journal went from
-        /// 18.5k to 92k pending in ~25 minutes.
-        const BACKFILL_PARTITIONS_PER_PASS: usize = 2;
+        /// Newest-first per pass, repeating on the same 60s cadence as
+        /// compaction-debt planning.
+        ///
+        /// This was 2 because one partition used to expand to ~450 durable
+        /// tasks (a day of ten-minute slices x Dedup/BaseRollup/HotPacking x
+        /// each tier) — shipping it at 8 took the journal from 18.5k to 92k
+        /// pending in 25 minutes. Day-sized units retired that expansion: a
+        /// partition is now one Dedup plus one task per declared rollup tier,
+        /// about three. Holding the old number kept the enqueue rate ~150x
+        /// below what the queue can absorb, so the 30-day horizon would take
+        /// days to even be QUEUED. At 24 the whole horizon
+        /// (12 projects x 35 days) is queued in under 20 minutes, and
+        /// `BACKFILL_PENDING_CEILING` still bounds the journal.
+        const BACKFILL_PARTITIONS_PER_PASS: usize = 24;
         /// Stop queueing more history while the queue is already deep. Every
         /// `claim_next` scans the task set, so an over-full journal taxes the
         /// live frontier to buy work that cannot start for hours anyway. The
@@ -9383,7 +9390,7 @@ impl Database {
                 };
                 want.retain(|key| !covered.contains(key));
             }
-            // Skip any day that already has rollup work queued. `invalidate`
+            // Skip any day that already has ROLLUP work queued. `invalidate`
             // takes `deadline.max(new_deadline)`, so re-invalidating a day that
             // already has an eligible task pushes that task's deadline OUT by a
             // full finalization delay. A planner running every 60s would then
@@ -9391,13 +9398,22 @@ impl Database {
             // caught exactly that: two rollup-parity tests went from correct
             // totals to building nothing at all.
             //
-            // "Nothing has touched it" is the actual precondition of a backfill,
-            // so make it literal.
+            // Scoped to the operations this planner actually enqueues. It used
+            // to match ANY non-complete task on the source, which quietly made
+            // unrelated file debt veto rollup coverage: a day carrying a stuck
+            // `SealedConsolidation` or an outstanding `HotPacking` could never
+            // be backfilled. Prod 2026-08-17 — the whale's Aug 15
+            // `SealedConsolidation` sat on attempt 370, and after the
+            // coarse-backfill migration retired the fine-grained historical
+            // tasks there was nothing left to claim and nothing allowed to
+            // replace it: every task start for 30 minutes was today's, rollup
+            // coverage froze at three days, and 7d/14d queries fell back to a
+            // full raw scan (`rollup_miss_not_built`).
             {
                 let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 let queued: HashSet<(String, chrono::NaiveDate)> = journal
                     .tasks()
-                    .filter(|task| task.key.source == source && task.state != crate::maintenance_coordinator::TaskState::Complete)
+                    .filter(|task| task.key.source == source && crate::maintenance_coordinator::blocks_rollup_backfill(task))
                     .filter_map(|task| {
                         chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| (task.key.project_id.clone(), time.date_naive()))
                     })

--- a/src/database.rs
+++ b/src/database.rs
@@ -5816,9 +5816,7 @@ impl Database {
     }
 
     fn coordinator_runtime_env(&self) -> Arc<datafusion::execution::runtime_env::RuntimeEnv> {
-        self.coordinator_runtime_env
-            .get_or_init(|| self.build_spill_runtime_env(crate::maintenance_coordinator::MAX_DECODED_BYTES as usize, "coordinator_spill"))
-            .clone()
+        self.coordinator_runtime_env.get_or_init(|| self.build_spill_runtime_env(self.config.derived.coordinator_share_bytes(), "coordinator_spill")).clone()
     }
 
     /// Sort one flush group, picking the strategy by size.

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -996,6 +996,18 @@ fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64) {
     }
 }
 
+/// Does this task mean a day's ROLLUP work is already queued?
+///
+/// The precondition of a backfill is "nothing has rolled this day up yet", and
+/// the planner enqueues exactly `Dedup` + the rollup tiers — so only those may
+/// veto it. Matching every non-complete task on the source instead let
+/// unrelated file debt disqualify a day forever: prod 2026-08-17 had the
+/// whale's Aug 15 `SealedConsolidation` on attempt 370, which alone kept that
+/// day out of every backfill pass.
+pub fn blocks_rollup_backfill(task: &MaintenanceTask) -> bool {
+    matches!(task.key.operation, Operation::Dedup | Operation::BaseRollup | Operation::DerivedRollup) && task.state != TaskState::Complete
+}
+
 fn is_live_frontier(slice: TimeSlice, now_micros: i64) -> bool {
     slice.end_micros >= now_micros.saturating_sub(LIVE_FRONTIER_WINDOW_MICROS) && slice.start_micros <= now_micros
 }
@@ -1166,6 +1178,31 @@ mod tests {
             created_unix_ms: 0,
             retry_reason: None,
             publication: None,
+        }
+    }
+
+    /// Only outstanding ROLLUP work may veto a rollup backfill.
+    ///
+    /// This predicate used to be "any non-complete task on the source", so a
+    /// day carrying unrelated file debt was disqualified forever. Prod
+    /// 2026-08-17: the whale's Aug 15 `SealedConsolidation` sat on attempt 370,
+    /// and once the coarse-backfill migration retired the fine-grained
+    /// historical tasks there was nothing left to claim and nothing allowed to
+    /// replace it — every task start for 30 minutes was today's, rollup
+    /// coverage froze at three days, and 7d/14d queries fell back to a full raw
+    /// scan (`rollup_miss_not_built`).
+    #[test]
+    fn only_outstanding_rollup_work_blocks_a_backfill() {
+        for operation in [Operation::SealedConsolidation, Operation::HotPacking, Operation::Repair] {
+            let debt = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(!blocks_rollup_backfill(&debt), "{operation:?} is file debt, not rollup coverage; it must not veto a backfill");
+        }
+        for operation in [Operation::Dedup, Operation::BaseRollup, Operation::DerivedRollup] {
+            let outstanding = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(blocks_rollup_backfill(&outstanding), "{operation:?} is the work a backfill would queue; re-queueing it pushes its deadline out");
+            let mut done = outstanding;
+            done.state = TaskState::Complete;
+            assert!(!blocks_rollup_backfill(&done), "a completed {operation:?} leaves the day open to backfill again");
         }
     }
 


### PR DESCRIPTION
## Why 7d/14d queries time out

Measured on prod today, against the "14d/30d in ~1s" goal:

| window | result |
|---|---|
| 1d (has coverage) | routes hybrid, **6.7s warm** |
| 7d / 14d | `rollup_miss_not_built` -> full raw scan -> **60s timeout** |

Coverage existed only for Aug 15-17. `not_built` is all-or-nothing, so three days of coverage buys a 7d query nothing.

## Why coverage was frozen

`plan_rollup_backfill` skips days that already have rollup work queued — correct, because re-invalidating pushes the existing task's deadline out by a finalization delay. But the predicate matched **any** non-complete task on the source, including operations this planner never enqueues:

```rust
.filter(|task| task.key.source == source && task.state != TaskState::Complete)
```

So one stuck file-compaction task disqualified its day from rollup backfill permanently. The whale's Aug 15 `SealedConsolidation` was on **attempt 370**. Once the coarse-backfill migration retired the fine-grained historical tasks, there was nothing left to claim and nothing allowed to replace it:

```
BaseRollup starts, 30 min:  35 x 2026-08-17,  0 historical
Dedup starts,      30 min:  54 x 2026-08-17,  0 historical
eligible_base_rollup = 3970    coverage: unchanged for 18+ min
```

## Change

- Predicate extracted to `blocks_rollup_backfill` — only `Dedup` / `BaseRollup` / `DerivedRollup` may veto, which is exactly what the planner enqueues. Named and unit-tested rather than inline.
- `BACKFILL_PARTITIONS_PER_PASS` 2 -> 24. The 2 was calibrated when a partition expanded to ~450 tasks; day-sized units cut that to ~3, leaving the enqueue rate ~150x below what the queue absorbs. `BACKFILL_PENDING_CEILING` still bounds the journal.

## Test

`only_outstanding_rollup_work_blocks_a_backfill` — verified it **fails** against the old predicate and passes with the fix.