### PR TITLE
Bisect a maintenance unit that keeps missing its deadline

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -286,6 +286,11 @@ const PER_SORT_BUDGET_BYTES: usize = 2 * GIB;
 /// and buy heavy little, since its concurrency is bounded by the rewrite
 /// permits rather than by bytes.
 const HEAVY_MIN_SHARE: f64 = 0.40;
+
+/// Pool slice per in-flight coordinator job. Kept equal to the admission
+/// ceiling so a job that is allowed to decode N bytes has N bytes of pool to
+/// hold them in before it must spill; see `coordinator_share_bytes`.
+const COORDINATOR_JOB_POOL_BYTES: usize = crate::maintenance_coordinator::MAX_DECODED_BYTES as usize;
 /// Floor so a tiny box never zeroes the maintenance pool.
 const MAINTENANCE_FLOOR_BYTES: usize = GIB;
 
@@ -421,6 +426,29 @@ impl DerivedBudget {
         self.maintenance_pool_bytes
     }
 
+    /// The durable coordinator's own pool, carved off before the heavy/light
+    /// split because the coordinator is now the primary maintenance path.
+    ///
+    /// Admission lets each job hold `MAX_DECODED_BYTES`, so the pool they share
+    /// must be that ceiling times the jobs that can be in flight. It used to be
+    /// `MAX_DECODED_BYTES` flat — the admission constant reused as a pool size,
+    /// correct only while `coordinator_jobs` was 1. At 16 jobs FairSpill sliced
+    /// 512 MB sixteen ways, below `ExternalSorterMerge`'s 32 MB floor, so units
+    /// FAILED instead of spilling: prod 2026-08-17 logged 72 `Failed to
+    /// allocate additional 32.0 MB ... pool_size: 512.0 MB` in 25 minutes.
+    pub fn coordinator_share_bytes(&self) -> usize {
+        match self.profile {
+            // The CLI drives engines directly; no coordinator runs.
+            BudgetProfile::MaintenanceCli => 0,
+            BudgetProfile::Server => (self.coordinator_jobs() * COORDINATOR_JOB_POOL_BYTES).min(self.maintenance_pool_bytes / 2),
+        }
+    }
+
+    /// What heavy and light divide, once the coordinator has taken its share.
+    fn maintenance_split_bytes(&self) -> usize {
+        self.maintenance_pool_bytes - self.coordinator_share_bytes()
+    }
+
     /// Heavy maintenance (dedup/optimize/recompress) share — at least
     /// `HEAVY_MIN_SHARE` of the maintenance pool.
     pub fn heavy_share_bytes(&self) -> usize {
@@ -429,7 +457,7 @@ impl DerivedBudget {
         // pool — only the active engine ever allocates.
         match self.profile {
             BudgetProfile::MaintenanceCli => ((self.maintenance_pool_bytes as f64) * 0.85) as usize,
-            BudgetProfile::Server => ((self.maintenance_pool_bytes as f64) * HEAVY_MIN_SHARE) as usize,
+            BudgetProfile::Server => ((self.maintenance_split_bytes() as f64) * HEAVY_MIN_SHARE) as usize,
         }
     }
 
@@ -437,7 +465,7 @@ impl DerivedBudget {
     pub fn light_share_bytes(&self) -> usize {
         match self.profile {
             BudgetProfile::MaintenanceCli => self.heavy_share_bytes(),
-            BudgetProfile::Server => self.maintenance_pool_bytes - self.heavy_share_bytes(),
+            BudgetProfile::Server => self.maintenance_split_bytes() - self.heavy_share_bytes(),
         }
     }
 
@@ -631,6 +659,7 @@ pub fn log_derived_budget(b: &DerivedBudget) {
         logical_count_memory_gb = b.logical_count_memory_bytes() / GIB,
         writer_reserve_gb = b.writer_reserve_bytes() / GIB,
         maintenance_pool_gb = b.maintenance_pool_bytes() / GIB,
+        coordinator_share_gb = b.coordinator_share_bytes() / GIB,
         heavy_share_gb = b.heavy_share_bytes() / GIB,
         light_share_gb = b.light_share_bytes() / GIB,
         rewrite_permits = b.rewrite_permits(),
@@ -2611,7 +2640,9 @@ mod tests {
             cli.heavy_share_bytes() / GIB
         );
         assert_eq!(server.maintenance_batch_size(), "2048");
-        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.heavy_share_bytes());
+        // Server: coordinator takes its slice first, then heavy/light divide the rest.
+        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.coordinator_share_bytes() - server.heavy_share_bytes());
+        assert_eq!(cli.coordinator_share_bytes(), 0, "the CLI drives engines directly; no coordinator competes for the pool");
     }
 
     #[test]
@@ -2798,6 +2829,35 @@ mod tests {
         let small = DerivedBudget::from_limits(16 * GIB, 4);
         assert!(small.coordinator_jobs() <= 2, "a 4-core box must not run maintenance wide, got {}", small.coordinator_jobs());
         assert!(small.coordinator_jobs() * 512 * 1024 * 1024 <= small.maintenance_pool_bytes(), "concurrent units must fit a small box's pool too");
+    }
+
+    /// The coordinator pool must scale with the jobs sharing it, and the three
+    /// maintenance shares must still sum to the pool.
+    ///
+    /// Prod 2026-08-17: the pool was pinned at one `MAX_DECODED_BYTES` while
+    /// jobs went to 16, so FairSpill handed each consumer ~32 MB — right at
+    /// `ExternalSorterMerge`'s allocation floor — and 72 units failed outright
+    /// in 25 minutes instead of spilling.
+    #[test]
+    fn coordinator_pool_scales_with_its_jobs_without_overcommitting() {
+        if std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").is_ok() {
+            return;
+        }
+        for (limit_gb, cores) in [(80, 48), (16, 4), (8, 4)] {
+            let b = DerivedBudget::from_limits(limit_gb * GIB, cores);
+            let per_job = b.coordinator_share_bytes() / b.coordinator_jobs();
+            assert!(
+                per_job >= 32 * 1024 * 1024,
+                "{limit_gb} GiB/{cores}-core: each of {} jobs gets {} MB, below the 32 MB sort floor",
+                b.coordinator_jobs(),
+                per_job / (1024 * 1024)
+            );
+            assert_eq!(
+                b.coordinator_share_bytes() + b.heavy_share_bytes() + b.light_share_bytes(),
+                b.maintenance_pool_bytes(),
+                "{limit_gb} GiB/{cores}-core: maintenance shares must partition the pool, not overcommit it"
+            );
+        }
     }
 
     // Small box (16 GiB / 4 cores): degrades to K=1, nothing underflows/zeroes.

--- a/src/database.rs
+++ b/src/database.rs
@@ -9306,13 +9306,20 @@ impl Database {
     /// of invalidations to a journal that is already ~18k deep, and the point is
     /// to converge steadily without burying the live frontier.
     pub async fn plan_rollup_backfill(&self) -> Result<usize> {
-        /// Newest-first per pass; the pass repeats on the same 60s cadence as
-        /// compaction-debt planning, so the horizon fills in over hours.
-        /// One partition expands to ~450 durable tasks (a day of slices x
-        /// Dedup/BaseRollup/HotPacking x each declared tier), so this is not
-        /// "8 tasks" — it is thousands. Shipped at 8 and the journal went from
-        /// 18.5k to 92k pending in ~25 minutes.
-        const BACKFILL_PARTITIONS_PER_PASS: usize = 2;
+        /// Newest-first per pass, repeating on the same 60s cadence as
+        /// compaction-debt planning.
+        ///
+        /// This was 2 because one partition used to expand to ~450 durable
+        /// tasks (a day of ten-minute slices x Dedup/BaseRollup/HotPacking x
+        /// each tier) — shipping it at 8 took the journal from 18.5k to 92k
+        /// pending in 25 minutes. Day-sized units retired that expansion: a
+        /// partition is now one Dedup plus one task per declared rollup tier,
+        /// about three. Holding the old number kept the enqueue rate ~150x
+        /// below what the queue can absorb, so the 30-day horizon would take
+        /// days to even be QUEUED. At 24 the whole horizon
+        /// (12 projects x 35 days) is queued in under 20 minutes, and
+        /// `BACKFILL_PENDING_CEILING` still bounds the journal.
+        const BACKFILL_PARTITIONS_PER_PASS: usize = 24;
         /// Stop queueing more history while the queue is already deep. Every
         /// `claim_next` scans the task set, so an over-full journal taxes the
         /// live frontier to buy work that cannot start for hours anyway. The
@@ -9383,7 +9390,7 @@ impl Database {
                 };
                 want.retain(|key| !covered.contains(key));
             }
-            // Skip any day that already has rollup work queued. `invalidate`
+            // Skip any day that already has ROLLUP work queued. `invalidate`
             // takes `deadline.max(new_deadline)`, so re-invalidating a day that
             // already has an eligible task pushes that task's deadline OUT by a
             // full finalization delay. A planner running every 60s would then
@@ -9391,13 +9398,22 @@ impl Database {
             // caught exactly that: two rollup-parity tests went from correct
             // totals to building nothing at all.
             //
-            // "Nothing has touched it" is the actual precondition of a backfill,
-            // so make it literal.
+            // Scoped to the operations this planner actually enqueues. It used
+            // to match ANY non-complete task on the source, which quietly made
+            // unrelated file debt veto rollup coverage: a day carrying a stuck
+            // `SealedConsolidation` or an outstanding `HotPacking` could never
+            // be backfilled. Prod 2026-08-17 — the whale's Aug 15
+            // `SealedConsolidation` sat on attempt 370, and after the
+            // coarse-backfill migration retired the fine-grained historical
+            // tasks there was nothing left to claim and nothing allowed to
+            // replace it: every task start for 30 minutes was today's, rollup
+            // coverage froze at three days, and 7d/14d queries fell back to a
+            // full raw scan (`rollup_miss_not_built`).
             {
                 let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 let queued: HashSet<(String, chrono::NaiveDate)> = journal
                     .tasks()
-                    .filter(|task| task.key.source == source && task.state != crate::maintenance_coordinator::TaskState::Complete)
+                    .filter(|task| task.key.source == source && crate::maintenance_coordinator::blocks_rollup_backfill(task))
                     .filter_map(|task| {
                         chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| (task.key.project_id.clone(), time.date_naive()))
                     })

--- a/src/database.rs
+++ b/src/database.rs
@@ -5816,9 +5816,7 @@ impl Database {
     }
 
     fn coordinator_runtime_env(&self) -> Arc<datafusion::execution::runtime_env::RuntimeEnv> {
-        self.coordinator_runtime_env
-            .get_or_init(|| self.build_spill_runtime_env(crate::maintenance_coordinator::MAX_DECODED_BYTES as usize, "coordinator_spill"))
-            .clone()
+        self.coordinator_runtime_env.get_or_init(|| self.build_spill_runtime_env(self.config.derived.coordinator_share_bytes(), "coordinator_spill")).clone()
     }
 
     /// Sort one flush group, picking the strategy by size.

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -996,6 +996,18 @@ fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64) {
     }
 }
 
+/// Does this task mean a day's ROLLUP work is already queued?
+///
+/// The precondition of a backfill is "nothing has rolled this day up yet", and
+/// the planner enqueues exactly `Dedup` + the rollup tiers — so only those may
+/// veto it. Matching every non-complete task on the source instead let
+/// unrelated file debt disqualify a day forever: prod 2026-08-17 had the
+/// whale's Aug 15 `SealedConsolidation` on attempt 370, which alone kept that
+/// day out of every backfill pass.
+pub fn blocks_rollup_backfill(task: &MaintenanceTask) -> bool {
+    matches!(task.key.operation, Operation::Dedup | Operation::BaseRollup | Operation::DerivedRollup) && task.state != TaskState::Complete
+}
+
 fn is_live_frontier(slice: TimeSlice, now_micros: i64) -> bool {
     slice.end_micros >= now_micros.saturating_sub(LIVE_FRONTIER_WINDOW_MICROS) && slice.start_micros <= now_micros
 }
@@ -1166,6 +1178,31 @@ mod tests {
             created_unix_ms: 0,
             retry_reason: None,
             publication: None,
+        }
+    }
+
+    /// Only outstanding ROLLUP work may veto a rollup backfill.
+    ///
+    /// This predicate used to be "any non-complete task on the source", so a
+    /// day carrying unrelated file debt was disqualified forever. Prod
+    /// 2026-08-17: the whale's Aug 15 `SealedConsolidation` sat on attempt 370,
+    /// and once the coarse-backfill migration retired the fine-grained
+    /// historical tasks there was nothing left to claim and nothing allowed to
+    /// replace it — every task start for 30 minutes was today's, rollup
+    /// coverage froze at three days, and 7d/14d queries fell back to a full raw
+    /// scan (`rollup_miss_not_built`).
+    #[test]
+    fn only_outstanding_rollup_work_blocks_a_backfill() {
+        for operation in [Operation::SealedConsolidation, Operation::HotPacking, Operation::Repair] {
+            let debt = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(!blocks_rollup_backfill(&debt), "{operation:?} is file debt, not rollup coverage; it must not veto a backfill");
+        }
+        for operation in [Operation::Dedup, Operation::BaseRollup, Operation::DerivedRollup] {
+            let outstanding = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(blocks_rollup_backfill(&outstanding), "{operation:?} is the work a backfill would queue; re-queueing it pushes its deadline out");
+            let mut done = outstanding;
+            done.state = TaskState::Complete;
+            assert!(!blocks_rollup_backfill(&done), "a completed {operation:?} leaves the day open to backfill again");
         }
     }
 

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -223,9 +223,7 @@ impl Drop for TaskLease {
     fn drop(&mut self) {
         let mut journal = self.journal.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if journal.state(&self.key) == Some(TaskState::Running) {
-            let attempts = journal.task_indices.get(&self.key).and_then(|index| journal.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts).min(8);
-            let delay_micros = i64::try_from((1u64 << attempts).saturating_mul(1_000_000)).unwrap_or(i64::MAX);
-            journal.retry(&self.key, "worker_error".to_owned(), crate::clock::now_micros().saturating_add(delay_micros));
+            journal.abandon_running(&self.key, crate::clock::now_micros());
             if let Err(error) = journal.checkpoint() {
                 tracing::error!(error = %error, task = ?self.key, "failed to checkpoint maintenance task lease recovery");
             }
@@ -729,6 +727,32 @@ impl TaskJournal {
     /// parent remains as a completed audit record. Hash shards intentionally
     /// stay inside a one-minute task because `TaskKey` identifies logical
     /// slice work; the worker merges all shard states before publication.
+    /// A worker gave the task back without finishing it — an error, or a
+    /// deadline it could not meet.
+    ///
+    /// Once is a blip: back off and retry it whole. Twice says the slice itself
+    /// does not fit its deadline, and requeueing it unchanged is an infinite
+    /// loop that holds a worker for the full deadline every pass and never
+    /// produces anything — the failure this codebase has hit repeatedly, most
+    /// recently as five Dedup timeouts in twelve minutes permanently occupying
+    /// ~2 of 16 workers while the rollup horizon they starved sat days behind.
+    /// So bisect instead, and let the halves face the same test.
+    ///
+    /// Byte-based splitting does not cover this. It fires on decoded bytes,
+    /// while what overran was WALL TIME — a day-sized slice with modest bytes
+    /// still pays an object-store round trip per file.
+    pub fn abandon_running(&mut self, key: &TaskKey, now_micros: i64) {
+        let attempts = self.task_indices.get(key).and_then(|index| self.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts);
+        // `MAX_DECODED_BYTES + 1` is the smallest input that makes
+        // `byte_bounded_units` bisect: it asks for one split, not a full
+        // recursive shred down to the minimum slice.
+        if attempts >= 2 && self.split_time_task(key, MAX_DECODED_BYTES.saturating_add(1)) {
+            return;
+        }
+        let delay_micros = i64::try_from((1u64 << attempts.min(8)).saturating_mul(1_000_000)).unwrap_or(i64::MAX);
+        self.retry(key, "worker_error".to_owned(), now_micros.saturating_add(delay_micros));
+    }
+
     pub fn split_time_task(&mut self, key: &TaskKey, observed_bytes: u64) -> bool {
         let Some(index) = self.task_indices.get(key).copied() else { return false };
         let parent = self.snapshot.tasks[index].clone();
@@ -1746,6 +1770,39 @@ mod tests {
         assert_eq!(claimed.state, TaskState::Running);
         assert_eq!(claimed.attempts, 1);
         assert!(journal.claim_next(Operation::Dedup, 0).is_none());
+    }
+
+    /// A unit that cannot finish inside its deadline must get SMALLER, not be
+    /// requeued unchanged.
+    ///
+    /// The lease requeues whatever the worker abandoned, so a slice too big for
+    /// its deadline times out, requeues identical, times out again — forever,
+    /// holding a worker for the full deadline each time and never producing
+    /// anything. Prod 2026-08-17: five Dedup timeouts in twelve minutes at 300s
+    /// apiece, permanently occupying ~2 of 16 coordinator workers, while total
+    /// task starts fell to 2.2/min and the rollup horizon it was starving sat
+    /// days behind. Byte-based splitting cannot catch this — a day-sized slice
+    /// with modest bytes still pays one object-store round trip per file.
+    #[test]
+    fn a_unit_that_keeps_timing_out_bisects_instead_of_retrying_forever() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        const DAY_MICROS: i64 = 86_400_000_000;
+        let input = task("whale", 0, DAY_MICROS, Operation::Dedup);
+        let key = input.key.clone();
+        journal.enqueue(key.clone(), 0, 0, 0);
+
+        // Two abandoned runs: the first is an ordinary blip and must simply
+        // retry, the second says the slice itself does not fit.
+        for _ in 0..2 {
+            assert!(journal.mark_running(&key));
+            journal.abandon_running(&key, 0);
+        }
+
+        let widths: Vec<i64> = journal.tasks().filter(|t| t.state != TaskState::Superseded).map(|t| t.key.slice.width()).collect();
+        assert!(!widths.is_empty(), "bisection must leave claimable children behind");
+        assert!(widths.iter().all(|width| *width < DAY_MICROS), "a repeatedly-abandoned day must bisect; got widths {widths:?} still at the full day");
+        assert_eq!(journal.state(&key), Some(TaskState::Superseded), "the parent stays as an audit record");
     }
 
     #[test]


### PR DESCRIPTION
## The loop

`TaskLease`'s `Drop` requeues whatever a worker abandoned, **unchanged**. A slice too big for its deadline times out, requeues identical, times out again — forever — holding a worker for the full deadline each pass and producing nothing.

Prod 2026-08-17, twelve minutes of logs:

```
5  event="maintenance_coordinator_unit_timed_out"   operation=Dedup, 300s each
26 event="maintenance_task_started"                 (2.2/min, down from ~5/min)
8  BaseRollup starts, all 08-16 -> 8 publications   (1:1 — rollup work is fine)
```

Five 300s timeouts in a 720s window is ~2 of 16 workers permanently occupied. And `dependencies_complete` returns `None` for `BaseRollup`, so Dedup blocks nothing the rollup horizon needs — it was purely starving the work that advances coverage.

The existing byte-based split can't catch this: it fires on **decoded bytes**, and what overran was **wall time**. A day-sized slice with modest bytes still pays one object-store round trip per file.

## Change

`abandon_running` — the lease's requeue policy, now named and testable:
- **1st abandonment** — a blip. Exponential back-off, retry whole (unchanged behaviour).
- **2nd** — the slice does not fit. Bisect, and let the halves face the same test.

`byte_bounded_units` already floors at `MIN_SLICE_MICROS`, so the recursion terminates.

## Test

`a_unit_that_keeps_timing_out_bisects_instead_of_retrying_forever` — verified it **fails** without the fix:

```
a repeatedly-abandoned day must bisect; got widths [86400000000] still at the full day
```