### PR TITLE
Claim wide sealed units first; stop heavy absorbing the coordinator share

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -286,6 +286,11 @@ const PER_SORT_BUDGET_BYTES: usize = 2 * GIB;
 /// and buy heavy little, since its concurrency is bounded by the rewrite
 /// permits rather than by bytes.
 const HEAVY_MIN_SHARE: f64 = 0.40;
+
+/// Pool slice per in-flight coordinator job. Kept equal to the admission
+/// ceiling so a job that is allowed to decode N bytes has N bytes of pool to
+/// hold them in before it must spill; see `coordinator_share_bytes`.
+const COORDINATOR_JOB_POOL_BYTES: usize = crate::maintenance_coordinator::MAX_DECODED_BYTES as usize;
 /// Floor so a tiny box never zeroes the maintenance pool.
 const MAINTENANCE_FLOOR_BYTES: usize = GIB;
 
@@ -421,6 +426,29 @@ impl DerivedBudget {
         self.maintenance_pool_bytes
     }
 
+    /// The durable coordinator's own pool, carved off before the heavy/light
+    /// split because the coordinator is now the primary maintenance path.
+    ///
+    /// Admission lets each job hold `MAX_DECODED_BYTES`, so the pool they share
+    /// must be that ceiling times the jobs that can be in flight. It used to be
+    /// `MAX_DECODED_BYTES` flat — the admission constant reused as a pool size,
+    /// correct only while `coordinator_jobs` was 1. At 16 jobs FairSpill sliced
+    /// 512 MB sixteen ways, below `ExternalSorterMerge`'s 32 MB floor, so units
+    /// FAILED instead of spilling: prod 2026-08-17 logged 72 `Failed to
+    /// allocate additional 32.0 MB ... pool_size: 512.0 MB` in 25 minutes.
+    pub fn coordinator_share_bytes(&self) -> usize {
+        match self.profile {
+            // The CLI drives engines directly; no coordinator runs.
+            BudgetProfile::MaintenanceCli => 0,
+            BudgetProfile::Server => (self.coordinator_jobs() * COORDINATOR_JOB_POOL_BYTES).min(self.maintenance_pool_bytes / 2),
+        }
+    }
+
+    /// What heavy and light divide, once the coordinator has taken its share.
+    fn maintenance_split_bytes(&self) -> usize {
+        self.maintenance_pool_bytes - self.coordinator_share_bytes()
+    }
+
     /// Heavy maintenance (dedup/optimize/recompress) share — at least
     /// `HEAVY_MIN_SHARE` of the maintenance pool.
     pub fn heavy_share_bytes(&self) -> usize {
@@ -429,7 +457,7 @@ impl DerivedBudget {
         // pool — only the active engine ever allocates.
         match self.profile {
             BudgetProfile::MaintenanceCli => ((self.maintenance_pool_bytes as f64) * 0.85) as usize,
-            BudgetProfile::Server => ((self.maintenance_pool_bytes as f64) * HEAVY_MIN_SHARE) as usize,
+            BudgetProfile::Server => ((self.maintenance_split_bytes() as f64) * HEAVY_MIN_SHARE) as usize,
         }
     }
 
@@ -437,7 +465,7 @@ impl DerivedBudget {
     pub fn light_share_bytes(&self) -> usize {
         match self.profile {
             BudgetProfile::MaintenanceCli => self.heavy_share_bytes(),
-            BudgetProfile::Server => self.maintenance_pool_bytes - self.heavy_share_bytes(),
+            BudgetProfile::Server => self.maintenance_split_bytes() - self.heavy_share_bytes(),
         }
     }
 
@@ -631,6 +659,7 @@ pub fn log_derived_budget(b: &DerivedBudget) {
         logical_count_memory_gb = b.logical_count_memory_bytes() / GIB,
         writer_reserve_gb = b.writer_reserve_bytes() / GIB,
         maintenance_pool_gb = b.maintenance_pool_bytes() / GIB,
+        coordinator_share_gb = b.coordinator_share_bytes() / GIB,
         heavy_share_gb = b.heavy_share_bytes() / GIB,
         light_share_gb = b.light_share_bytes() / GIB,
         rewrite_permits = b.rewrite_permits(),
@@ -2611,7 +2640,9 @@ mod tests {
             cli.heavy_share_bytes() / GIB
         );
         assert_eq!(server.maintenance_batch_size(), "2048");
-        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.heavy_share_bytes());
+        // Server: coordinator takes its slice first, then heavy/light divide the rest.
+        assert_eq!(server.light_share_bytes(), server.maintenance_pool_bytes - server.coordinator_share_bytes() - server.heavy_share_bytes());
+        assert_eq!(cli.coordinator_share_bytes(), 0, "the CLI drives engines directly; no coordinator competes for the pool");
     }
 
     #[test]
@@ -2798,6 +2829,35 @@ mod tests {
         let small = DerivedBudget::from_limits(16 * GIB, 4);
         assert!(small.coordinator_jobs() <= 2, "a 4-core box must not run maintenance wide, got {}", small.coordinator_jobs());
         assert!(small.coordinator_jobs() * 512 * 1024 * 1024 <= small.maintenance_pool_bytes(), "concurrent units must fit a small box's pool too");
+    }
+
+    /// The coordinator pool must scale with the jobs sharing it, and the three
+    /// maintenance shares must still sum to the pool.
+    ///
+    /// Prod 2026-08-17: the pool was pinned at one `MAX_DECODED_BYTES` while
+    /// jobs went to 16, so FairSpill handed each consumer ~32 MB — right at
+    /// `ExternalSorterMerge`'s allocation floor — and 72 units failed outright
+    /// in 25 minutes instead of spilling.
+    #[test]
+    fn coordinator_pool_scales_with_its_jobs_without_overcommitting() {
+        if std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").is_ok() {
+            return;
+        }
+        for (limit_gb, cores) in [(80, 48), (16, 4), (8, 4)] {
+            let b = DerivedBudget::from_limits(limit_gb * GIB, cores);
+            let per_job = b.coordinator_share_bytes() / b.coordinator_jobs();
+            assert!(
+                per_job >= 32 * 1024 * 1024,
+                "{limit_gb} GiB/{cores}-core: each of {} jobs gets {} MB, below the 32 MB sort floor",
+                b.coordinator_jobs(),
+                per_job / (1024 * 1024)
+            );
+            assert_eq!(
+                b.coordinator_share_bytes() + b.heavy_share_bytes() + b.light_share_bytes(),
+                b.maintenance_pool_bytes(),
+                "{limit_gb} GiB/{cores}-core: maintenance shares must partition the pool, not overcommit it"
+            );
+        }
     }
 
     // Small box (16 GiB / 4 cores): degrades to K=1, nothing underflows/zeroes.

--- a/src/database.rs
+++ b/src/database.rs
@@ -9306,13 +9306,20 @@ impl Database {
     /// of invalidations to a journal that is already ~18k deep, and the point is
     /// to converge steadily without burying the live frontier.
     pub async fn plan_rollup_backfill(&self) -> Result<usize> {
-        /// Newest-first per pass; the pass repeats on the same 60s cadence as
-        /// compaction-debt planning, so the horizon fills in over hours.
-        /// One partition expands to ~450 durable tasks (a day of slices x
-        /// Dedup/BaseRollup/HotPacking x each declared tier), so this is not
-        /// "8 tasks" — it is thousands. Shipped at 8 and the journal went from
-        /// 18.5k to 92k pending in ~25 minutes.
-        const BACKFILL_PARTITIONS_PER_PASS: usize = 2;
+        /// Newest-first per pass, repeating on the same 60s cadence as
+        /// compaction-debt planning.
+        ///
+        /// This was 2 because one partition used to expand to ~450 durable
+        /// tasks (a day of ten-minute slices x Dedup/BaseRollup/HotPacking x
+        /// each tier) — shipping it at 8 took the journal from 18.5k to 92k
+        /// pending in 25 minutes. Day-sized units retired that expansion: a
+        /// partition is now one Dedup plus one task per declared rollup tier,
+        /// about three. Holding the old number kept the enqueue rate ~150x
+        /// below what the queue can absorb, so the 30-day horizon would take
+        /// days to even be QUEUED. At 24 the whole horizon
+        /// (12 projects x 35 days) is queued in under 20 minutes, and
+        /// `BACKFILL_PENDING_CEILING` still bounds the journal.
+        const BACKFILL_PARTITIONS_PER_PASS: usize = 24;
         /// Stop queueing more history while the queue is already deep. Every
         /// `claim_next` scans the task set, so an over-full journal taxes the
         /// live frontier to buy work that cannot start for hours anyway. The
@@ -9383,7 +9390,7 @@ impl Database {
                 };
                 want.retain(|key| !covered.contains(key));
             }
-            // Skip any day that already has rollup work queued. `invalidate`
+            // Skip any day that already has ROLLUP work queued. `invalidate`
             // takes `deadline.max(new_deadline)`, so re-invalidating a day that
             // already has an eligible task pushes that task's deadline OUT by a
             // full finalization delay. A planner running every 60s would then
@@ -9391,13 +9398,22 @@ impl Database {
             // caught exactly that: two rollup-parity tests went from correct
             // totals to building nothing at all.
             //
-            // "Nothing has touched it" is the actual precondition of a backfill,
-            // so make it literal.
+            // Scoped to the operations this planner actually enqueues. It used
+            // to match ANY non-complete task on the source, which quietly made
+            // unrelated file debt veto rollup coverage: a day carrying a stuck
+            // `SealedConsolidation` or an outstanding `HotPacking` could never
+            // be backfilled. Prod 2026-08-17 — the whale's Aug 15
+            // `SealedConsolidation` sat on attempt 370, and after the
+            // coarse-backfill migration retired the fine-grained historical
+            // tasks there was nothing left to claim and nothing allowed to
+            // replace it: every task start for 30 minutes was today's, rollup
+            // coverage froze at three days, and 7d/14d queries fell back to a
+            // full raw scan (`rollup_miss_not_built`).
             {
                 let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 let queued: HashSet<(String, chrono::NaiveDate)> = journal
                     .tasks()
-                    .filter(|task| task.key.source == source && task.state != crate::maintenance_coordinator::TaskState::Complete)
+                    .filter(|task| task.key.source == source && crate::maintenance_coordinator::blocks_rollup_backfill(task))
                     .filter_map(|task| {
                         chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| (task.key.project_id.clone(), time.date_naive()))
                     })

--- a/src/database.rs
+++ b/src/database.rs
@@ -5816,9 +5816,7 @@ impl Database {
     }
 
     fn coordinator_runtime_env(&self) -> Arc<datafusion::execution::runtime_env::RuntimeEnv> {
-        self.coordinator_runtime_env
-            .get_or_init(|| self.build_spill_runtime_env(crate::maintenance_coordinator::MAX_DECODED_BYTES as usize, "coordinator_spill"))
-            .clone()
+        self.coordinator_runtime_env.get_or_init(|| self.build_spill_runtime_env(self.config.derived.coordinator_share_bytes(), "coordinator_spill")).clone()
     }
 
     /// Sort one flush group, picking the strategy by size.

--- a/src/database.rs
+++ b/src/database.rs
@@ -5795,10 +5795,16 @@ impl Database {
         self.light_optimize_pool_bytes() - self.pack_pool_bytes()
     }
 
-    /// Heavy maintenance (dedup, recompress, Z-order): the budget left after
-    /// the light-optimize slice.
+    /// Heavy maintenance (dedup, recompress, Z-order).
+    ///
+    /// Deferred to the budget tree rather than derived as "the pool minus
+    /// light". That residual form silently ABSORBED any share the tree carved
+    /// off for someone else: adding the coordinator's slice left heavy holding
+    /// it too, so coordinator + heavy + light came to 24 GiB of a 16 GiB pool.
+    /// A residual definition cannot stay correct across a change to the tree,
+    /// which is the same lesson `light_optimize_pool_bytes` already records.
     fn heavy_pool_bytes(&self) -> usize {
-        self.config.derived.maintenance_pool_bytes() - self.light_optimize_pool_bytes()
+        self.config.derived.heavy_share_bytes()
     }
 
     fn maintenance_runtime_env(&self) -> Arc<datafusion::execution::runtime_env::RuntimeEnv> {
@@ -22408,10 +22414,18 @@ mod tests {
         let db = Database::with_config(create_test_config("pool-split")).await?;
         assert_eq!(db.pack_pool_bytes() + db.repair_pool_bytes(), db.light_optimize_pool_bytes(), "the split must not grow the maintenance budget");
         assert!(db.pack_pool_bytes() > 0 && db.repair_pool_bytes() > 0, "neither pass may be sized to zero");
-        // The light and heavy pools must TILE the maintenance budget. They had
-        // independent definitions that agreed only while HEAVY_MIN_SHARE was
-        // 0.25, so moving that share silently desynced pools from `light_optimize_k`.
-        assert_eq!(db.light_optimize_pool_bytes() + db.heavy_pool_bytes(), db.config.derived.maintenance_pool_bytes(), "light + heavy must tile the pool");
+        // The coordinator, light and heavy pools must TILE the maintenance
+        // budget. They had independent definitions that agreed only while
+        // HEAVY_MIN_SHARE was 0.25, so moving that share silently desynced
+        // pools from `light_optimize_k`. Heavy was later still derived as "pool
+        // minus light", which ABSORBED the coordinator's new share instead of
+        // shrinking for it — 24 GiB of pools against a 16 GiB budget, the exact
+        // over-commit shape that OOM-killed prod on 2026-08-17.
+        assert_eq!(
+            db.config.derived.coordinator_share_bytes() + db.light_optimize_pool_bytes() + db.heavy_pool_bytes(),
+            db.config.derived.maintenance_pool_bytes(),
+            "coordinator + light + heavy must tile the pool, never over-commit it"
+        );
         assert_eq!(db.heavy_pool_bytes(), db.config.derived.heavy_share_bytes(), "the heavy pool must be the budget tree's heavy share, not a second opinion");
         assert!(!Arc::ptr_eq(&db.light_optimize_runtime_env(), &db.repair_runtime_env()), "sharing one RuntimeEnv is sharing one pool");
 

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -996,6 +996,18 @@ fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64) {
     }
 }
 
+/// Does this task mean a day's ROLLUP work is already queued?
+///
+/// The precondition of a backfill is "nothing has rolled this day up yet", and
+/// the planner enqueues exactly `Dedup` + the rollup tiers — so only those may
+/// veto it. Matching every non-complete task on the source instead let
+/// unrelated file debt disqualify a day forever: prod 2026-08-17 had the
+/// whale's Aug 15 `SealedConsolidation` on attempt 370, which alone kept that
+/// day out of every backfill pass.
+pub fn blocks_rollup_backfill(task: &MaintenanceTask) -> bool {
+    matches!(task.key.operation, Operation::Dedup | Operation::BaseRollup | Operation::DerivedRollup) && task.state != TaskState::Complete
+}
+
 fn is_live_frontier(slice: TimeSlice, now_micros: i64) -> bool {
     slice.end_micros >= now_micros.saturating_sub(LIVE_FRONTIER_WINDOW_MICROS) && slice.start_micros <= now_micros
 }
@@ -1166,6 +1178,31 @@ mod tests {
             created_unix_ms: 0,
             retry_reason: None,
             publication: None,
+        }
+    }
+
+    /// Only outstanding ROLLUP work may veto a rollup backfill.
+    ///
+    /// This predicate used to be "any non-complete task on the source", so a
+    /// day carrying unrelated file debt was disqualified forever. Prod
+    /// 2026-08-17: the whale's Aug 15 `SealedConsolidation` sat on attempt 370,
+    /// and once the coarse-backfill migration retired the fine-grained
+    /// historical tasks there was nothing left to claim and nothing allowed to
+    /// replace it — every task start for 30 minutes was today's, rollup
+    /// coverage froze at three days, and 7d/14d queries fell back to a full raw
+    /// scan (`rollup_miss_not_built`).
+    #[test]
+    fn only_outstanding_rollup_work_blocks_a_backfill() {
+        for operation in [Operation::SealedConsolidation, Operation::HotPacking, Operation::Repair] {
+            let debt = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(!blocks_rollup_backfill(&debt), "{operation:?} is file debt, not rollup coverage; it must not veto a backfill");
+        }
+        for operation in [Operation::Dedup, Operation::BaseRollup, Operation::DerivedRollup] {
+            let outstanding = task("whale", 0, NORMAL_SLICE_MICROS, operation);
+            assert!(blocks_rollup_backfill(&outstanding), "{operation:?} is the work a backfill would queue; re-queueing it pushes its deadline out");
+            let mut done = outstanding;
+            done.state = TaskState::Complete;
+            assert!(!blocks_rollup_backfill(&done), "a completed {operation:?} leaves the day open to backfill again");
         }
     }
 

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -223,9 +223,7 @@ impl Drop for TaskLease {
     fn drop(&mut self) {
         let mut journal = self.journal.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if journal.state(&self.key) == Some(TaskState::Running) {
-            let attempts = journal.task_indices.get(&self.key).and_then(|index| journal.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts).min(8);
-            let delay_micros = i64::try_from((1u64 << attempts).saturating_mul(1_000_000)).unwrap_or(i64::MAX);
-            journal.retry(&self.key, "worker_error".to_owned(), crate::clock::now_micros().saturating_add(delay_micros));
+            journal.abandon_running(&self.key, crate::clock::now_micros());
             if let Err(error) = journal.checkpoint() {
                 tracing::error!(error = %error, task = ?self.key, "failed to checkpoint maintenance task lease recovery");
             }
@@ -729,6 +727,32 @@ impl TaskJournal {
     /// parent remains as a completed audit record. Hash shards intentionally
     /// stay inside a one-minute task because `TaskKey` identifies logical
     /// slice work; the worker merges all shard states before publication.
+    /// A worker gave the task back without finishing it — an error, or a
+    /// deadline it could not meet.
+    ///
+    /// Once is a blip: back off and retry it whole. Twice says the slice itself
+    /// does not fit its deadline, and requeueing it unchanged is an infinite
+    /// loop that holds a worker for the full deadline every pass and never
+    /// produces anything — the failure this codebase has hit repeatedly, most
+    /// recently as five Dedup timeouts in twelve minutes permanently occupying
+    /// ~2 of 16 workers while the rollup horizon they starved sat days behind.
+    /// So bisect instead, and let the halves face the same test.
+    ///
+    /// Byte-based splitting does not cover this. It fires on decoded bytes,
+    /// while what overran was WALL TIME — a day-sized slice with modest bytes
+    /// still pays an object-store round trip per file.
+    pub fn abandon_running(&mut self, key: &TaskKey, now_micros: i64) {
+        let attempts = self.task_indices.get(key).and_then(|index| self.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts);
+        // `MAX_DECODED_BYTES + 1` is the smallest input that makes
+        // `byte_bounded_units` bisect: it asks for one split, not a full
+        // recursive shred down to the minimum slice.
+        if attempts >= 2 && self.split_time_task(key, MAX_DECODED_BYTES.saturating_add(1)) {
+            return;
+        }
+        let delay_micros = i64::try_from((1u64 << attempts.min(8)).saturating_mul(1_000_000)).unwrap_or(i64::MAX);
+        self.retry(key, "worker_error".to_owned(), now_micros.saturating_add(delay_micros));
+    }
+
     pub fn split_time_task(&mut self, key: &TaskKey, observed_bytes: u64) -> bool {
         let Some(index) = self.task_indices.get(key).copied() else { return false };
         let parent = self.snapshot.tasks[index].clone();
@@ -1746,6 +1770,39 @@ mod tests {
         assert_eq!(claimed.state, TaskState::Running);
         assert_eq!(claimed.attempts, 1);
         assert!(journal.claim_next(Operation::Dedup, 0).is_none());
+    }
+
+    /// A unit that cannot finish inside its deadline must get SMALLER, not be
+    /// requeued unchanged.
+    ///
+    /// The lease requeues whatever the worker abandoned, so a slice too big for
+    /// its deadline times out, requeues identical, times out again — forever,
+    /// holding a worker for the full deadline each time and never producing
+    /// anything. Prod 2026-08-17: five Dedup timeouts in twelve minutes at 300s
+    /// apiece, permanently occupying ~2 of 16 coordinator workers, while total
+    /// task starts fell to 2.2/min and the rollup horizon it was starving sat
+    /// days behind. Byte-based splitting cannot catch this — a day-sized slice
+    /// with modest bytes still pays one object-store round trip per file.
+    #[test]
+    fn a_unit_that_keeps_timing_out_bisects_instead_of_retrying_forever() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        const DAY_MICROS: i64 = 86_400_000_000;
+        let input = task("whale", 0, DAY_MICROS, Operation::Dedup);
+        let key = input.key.clone();
+        journal.enqueue(key.clone(), 0, 0, 0);
+
+        // Two abandoned runs: the first is an ordinary blip and must simply
+        // retry, the second says the slice itself does not fit.
+        for _ in 0..2 {
+            assert!(journal.mark_running(&key));
+            journal.abandon_running(&key, 0);
+        }
+
+        let widths: Vec<i64> = journal.tasks().filter(|t| t.state != TaskState::Superseded).map(|t| t.key.slice.width()).collect();
+        assert!(!widths.is_empty(), "bisection must leave claimable children behind");
+        assert!(widths.iter().all(|width| *width < DAY_MICROS), "a repeatedly-abandoned day must bisect; got widths {widths:?} still at the full day");
+        assert_eq!(journal.state(&key), Some(TaskState::Superseded), "the parent stays as an audit record");
     }
 
     #[test]

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -956,10 +956,14 @@ impl TaskJournal {
     }
 }
 
+/// `(class, operation priority, -width, -recency)` -> project -> that project's
+/// queue. Ordered so smaller tuples run first; see `scheduling_class`.
+type ReadyGroups<'a> = BTreeMap<(u8, u8, i64, i64), HashMap<&'a str, VecDeque<&'a MaintenanceTask>>>;
+
 /// Deadline ordering with round-robin selection among projects at the same
 /// operation priority. This prevents one whale from consuming an entire pass.
 pub fn fair_ready_tasks<'a>(tasks: impl IntoIterator<Item = &'a MaintenanceTask>, now_micros: i64) -> Vec<&'a MaintenanceTask> {
-    let mut groups: BTreeMap<(u8, u8, i64, i64), HashMap<&str, VecDeque<&MaintenanceTask>>> = BTreeMap::new();
+    let mut groups: ReadyGroups<'_> = BTreeMap::new();
     for task in tasks {
         if matches!(task.state, TaskState::Pending | TaskState::Retry) && task.deadline_micros <= now_micros {
             let (class, width_key, order_key) = scheduling_class(task, now_micros);

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -608,8 +608,8 @@ impl TaskJournal {
         // budget cut to pay for it (the documented 2026-07-04 pairing), not just
         // a bigger share.
         let sealed_turn = self.claim_tick.is_multiple_of(2);
-        let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64)> {
-            let mut class: Option<(u8, i64)> = None;
+        let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64, i64)> {
+            let mut class: Option<(u8, i64, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {
                 task.key.operation == operation
                     && matches!(task.state, TaskState::Pending | TaskState::Retry)
@@ -959,11 +959,11 @@ impl TaskJournal {
 /// Deadline ordering with round-robin selection among projects at the same
 /// operation priority. This prevents one whale from consuming an entire pass.
 pub fn fair_ready_tasks<'a>(tasks: impl IntoIterator<Item = &'a MaintenanceTask>, now_micros: i64) -> Vec<&'a MaintenanceTask> {
-    let mut groups: BTreeMap<(u8, u8, i64), HashMap<&str, VecDeque<&MaintenanceTask>>> = BTreeMap::new();
+    let mut groups: BTreeMap<(u8, u8, i64, i64), HashMap<&str, VecDeque<&MaintenanceTask>>> = BTreeMap::new();
     for task in tasks {
         if matches!(task.state, TaskState::Pending | TaskState::Retry) && task.deadline_micros <= now_micros {
-            let (class, order_key) = scheduling_class(task, now_micros);
-            groups.entry((class, task.key.operation.priority(), order_key)).or_default().entry(&task.key.project_id).or_default().push_back(task);
+            let (class, width_key, order_key) = scheduling_class(task, now_micros);
+            groups.entry((class, task.key.operation.priority(), width_key, order_key)).or_default().entry(&task.key.project_id).or_default().push_back(task);
         }
     }
     let mut ready = Vec::new();
@@ -995,11 +995,12 @@ pub fn fair_ready_tasks<'a>(tasks: impl IntoIterator<Item = &'a MaintenanceTask>
 /// This is intentionally based on event time, not mutation deadline. A late
 /// correction to old data is a bounded historical hole; treating its recent
 /// mutation as live-tail work would let backfill displace current coverage.
-fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64) {
+fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64, i64) {
     if is_live_frontier(task.key.slice, now_micros) {
         // Smaller tuples run first. Negating makes the newest minute the most
         // urgent while keeping all projects in that minute deadline-equivalent.
-        (0, -task.key.slice.end_micros.div_euclid(PRIORITY_BUCKET_MICROS))
+        // Width is not a frontier concern — these are all one slice wide.
+        (0, 0, -task.key.slice.end_micros.div_euclid(PRIORITY_BUCKET_MICROS))
     } else {
         // Newest slice first here too, for the same reason the dedup drain and
         // the rollup backfill are newest-first: recent days are what dashboards
@@ -1016,7 +1017,20 @@ fn scheduling_class(task: &MaintenanceTask, now_micros: i64) -> (u8, i64) {
         // Eligibility is still deadline-gated in `claim_next`
         // (`deadline_micros <= now`), so retry backoff is unaffected; this only
         // orders the tasks that are already runnable.
-        (1, -task.key.slice.end_micros.div_euclid(PRIORITY_BUCKET_MICROS))
+        //
+        // WIDTH outranks recency, though. A day-sized unit comes from the
+        // backfill planner and is the only kind that advances the horizon; a
+        // ten-minute unit is what the live path mints, and a day that has just
+        // sealed carries ~144 of them per project per tier. Newest-first alone
+        // therefore spends every sealed claim on yesterday's leftovers before
+        // reaching the day before it — and midnight mints another day's worth,
+        // so the horizon never moves. Prod 2026-08-17, 65 rollup starts in 25
+        // minutes: 46 on today, 18 on yesterday, ZERO older, while 7d/14d
+        // queries were refused for want of exactly those older days.
+        //
+        // Newest-first still breaks ties, so among backfill units recent
+        // history is still built first.
+        (1, -task.key.slice.width(), -task.key.slice.end_micros.div_euclid(PRIORITY_BUCKET_MICROS))
     }
 }
 
@@ -1770,6 +1784,47 @@ mod tests {
         assert_eq!(claimed.state, TaskState::Running);
         assert_eq!(claimed.attempts, 1);
         assert!(journal.claim_next(Operation::Dedup, 0).is_none());
+    }
+
+    /// Among sealed work, a day-sized unit outranks yesterday's ten-minute
+    /// leftovers even though those are newer.
+    ///
+    /// Day-sized units come from the backfill planner and are the only kind
+    /// that advances the rollup horizon. Ten-minute units are what the live
+    /// path mints, and a day that has just sealed carries ~144 of them per
+    /// project per tier. Ordering sealed work newest-first alone therefore
+    /// grinds all of yesterday before reaching the day before — and midnight
+    /// mints a fresh day's worth, so the horizon can never move.
+    ///
+    /// Prod 2026-08-17, 65 rollup starts in 25 minutes: 46 on today, 18 on
+    /// yesterday, ZERO on any older day, while 7d/14d queries were refused for
+    /// want of exactly those older days.
+    #[test]
+    fn sealed_backfill_units_outrank_yesterdays_fine_slices() {
+        const DAY_MICROS: i64 = 86_400_000_000;
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        // "Now" well past both, so everything is sealed rather than frontier.
+        let now = 10 * DAY_MICROS;
+
+        // Yesterday's fine-grained leftovers: newer, and far more numerous.
+        for slot in 0..12 {
+            let start = 8 * DAY_MICROS + slot * NORMAL_SLICE_MICROS;
+            let fine = task("p", start, start + NORMAL_SLICE_MICROS, Operation::BaseRollup);
+            journal.enqueue(fine.key.clone(), 0, 0, 0);
+        }
+        // An older day, queued whole by the backfill planner.
+        let coarse = task("p", 3 * DAY_MICROS, 4 * DAY_MICROS, Operation::BaseRollup);
+        journal.enqueue(coarse.key.clone(), 0, 0, 0);
+
+        let claimed = journal.claim_next(Operation::BaseRollup, now).expect("a sealed task is claimable");
+        assert_eq!(
+            claimed.key.slice.width(),
+            DAY_MICROS,
+            "the horizon-advancing day unit must be claimed before yesterday's ten-minute slices; got a {}s slice starting {}",
+            claimed.key.slice.width() / 1_000_000,
+            claimed.key.slice.start_micros / DAY_MICROS
+        );
     }
 
     /// A unit that cannot finish inside its deadline must get SMALLER, not be


### PR DESCRIPTION
Two fixes the goal measurement turned up.

## 1. The rollup horizon could never advance

Sealed work was ordered newest-slice-first. A day that has just sealed still carries the ~144 ten-minute units **per project per tier** that the live path minted while it *was* the frontier — so every sealed claim goes to yesterday, and midnight mints another day's worth.

Prod 2026-08-17, 65 rollup starts in 25 minutes:

```
46  08-17 (today)
18  08-16 (yesterday)
 0  08-15 or earlier      <- exactly the days 7d/14d queries were refused for
 1  DerivedRollup         <- the 1h tier those queries actually read
```

Width now outranks recency within sealed work. Day-sized units come from the backfill planner and are the only kind that advances the horizon. Newest-first still breaks ties, so recent history is still built before old.

Test `sealed_backfill_units_outrank_yesterdays_fine_slices` — verified it fails without the fix:
```
got a 600s slice starting 8
```

## 2. Heavy absorbed the coordinator's share (over-commit)

`heavy_pool_bytes` was `maintenance_pool - light`. A residual cannot survive a change to the budget tree: carving out the coordinator share in #125 left heavy holding it too.

```
coordinator 8 GiB + heavy 10.8 GiB + light 5.2 GiB = 24 GiB   of a 16 GiB pool
```

That is the over-commit shape that OOM-killed prod earlier the same day. Heavy now defers to the tree, and the pool test asserts all **three** shares tile the budget instead of two — the assertion that would have caught this.