### PR TITLE
Stop the coordinator ceiling starving the share that sorts; log rollup publications

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -436,11 +436,28 @@ impl DerivedBudget {
     /// 512 MB sixteen ways, below `ExternalSorterMerge`'s 32 MB floor, so units
     /// FAILED instead of spilling: prod 2026-08-17 logged 72 `Failed to
     /// allocate additional 32.0 MB ... pool_size: 512.0 MB` in 25 minutes.
+    /// Capped at a QUARTER of the maintenance pool, not a half.
+    ///
+    /// `jobs x MAX_DECODED_BYTES` is the ceiling a fully-rollup-loaded
+    /// coordinator could want, but it is not what the coordinator typically
+    /// runs: only its rollup units draw on this pool
+    /// (`bounded_rollup_maintenance_context`), while its DEDUP units sort on
+    /// the heavy share. Letting the ceiling take half the pool starved the
+    /// share doing the sorting — prod 2026-08-17, immediately after the
+    /// over-commit fix sized heavy honestly at 3.4 GiB:
+    ///
+    ///   dedup: Not enough memory to continue external sort ... Failed to
+    ///   allocate additional 637.9 MB ... pool_size: 3.4 GB
+    ///
+    /// A quarter still leaves each of 16 jobs ~260 MB — far above
+    /// `ExternalSorterMerge`'s 32 MB floor, which is the failure that sizing
+    /// this pool by job count was introduced to prevent — and hands the
+    /// difference back to the tiers that were measurably short.
     pub fn coordinator_share_bytes(&self) -> usize {
         match self.profile {
             // The CLI drives engines directly; no coordinator runs.
             BudgetProfile::MaintenanceCli => 0,
-            BudgetProfile::Server => (self.coordinator_jobs() * COORDINATOR_JOB_POOL_BYTES).min(self.maintenance_pool_bytes / 2),
+            BudgetProfile::Server => (self.coordinator_jobs() * COORDINATOR_JOB_POOL_BYTES).min(self.maintenance_pool_bytes / 4),
         }
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -9964,6 +9964,24 @@ impl Database {
             );
             journal.publish(&key, crate::maintenance_coordinator::Publication { source_fingerprint: source_fp, generation: generation.clone(), rows });
             journal.checkpoint()?;
+            // Per-unit outcome, because the counters are process-wide totals and
+            // cannot answer "why has THIS project's coverage not moved". Prod
+            // 2026-08-17: the whale started day-sized BaseRollup units for
+            // 08-08..08-13 at attempt 1 and published nothing for any of them,
+            // while 120k raw rows/hour sat in those partitions — and there was
+            // no way to tell a zero-row publication from a unit that never got
+            // that far.
+            info!(
+                operation = ?key.operation,
+                table = %key.physical_table,
+                project_id = %key.project_id,
+                slice_start = key.slice.start_micros,
+                slice_end = key.slice.end_micros,
+                rows,
+                output_files,
+                estimated_decoded_bytes = estimated_bytes,
+                event = "maintenance_rollup_published"
+            );
             let stats = crate::metrics::maintenance_stats();
             stats.maintenance_processed_bytes.fetch_add(estimated_bytes, Relaxed);
             stats.rollup_output_rows.fetch_add(rows, Relaxed);


### PR DESCRIPTION
## The starvation

The coordinator pool was `jobs x MAX_DECODED_BYTES` capped at **half** the maintenance pool — 8 GiB of 16. That ceiling is what a fully rollup-loaded coordinator *could* want, but only its **rollup** units draw on that pool (`bounded_rollup_maintenance_context`); its **dedup** units sort on the heavy share. So half the budget went to the tier that was not sorting, and once #128 sized heavy honestly at 3.4 GiB the sorts started failing:

```
dedup: Not enough memory to continue external sort ...
Failed to allocate additional 637.9 MB for ExternalSorter[0] -
199.0 MB remain available for the total memory pool: fair(pool_size: 3.4 GB)
```

Capped at a **quarter**. Each of 16 jobs still gets ~260 MB — far above the 32 MB `ExternalSorterMerge` floor that sizing this pool by job count was introduced to prevent (#125) — and the difference returns to the tiers that were measurably short:

| | before | after |
|---|---|---|
| coordinator | 8.0 | 4.1 |
| heavy | 3.4 | 5.0 |
| light | 5.2 | 7.4 |

Still tiles the pool; the three-way assertion from #128 covers it.

## The visibility gap

The whale started day-sized `BaseRollup` units for 08-08..08-13, **all at attempt 1**, and published nothing for any of them — while 120k raw rows/hour sat in those partitions (confirmed against the raw table). Splits are already logged (`maintenance_dedup_task_split`) and there were only 2 in 20 minutes, so the unit is reaching neither a split nor a publication, and nothing recorded which.

`rollup_output_rows_total` and friends are process-wide totals and cannot answer "why has THIS project's coverage not moved". Now one line per publication carries project, slice, rows and output files.