### PR TITLE
Charge the dedup run buffer for its own rows, not the block it borrows

### DIFF
--- a/docs/plans/2026-08-17-dedup-charges-inherited-scan-blocks.md
+++ b/docs/plans/2026-08-17-dedup-charges-inherited-scan-blocks.md
@@ -1,0 +1,100 @@
+# DedupExec charges the parquet reader's column chunks, not its own rows
+
+Status: **root-caused from prod logs, fix scoped below.**
+
+## Symptom the user reported
+
+"With each spill or any random thing queries get slow cos maintenance lags."
+
+## What prod actually shows
+
+monoscope's enrichment UPDATE, 2026-08-17 15:42:37, ran **16.9 s and then
+failed**:
+
+```
+duration_us=16861662 success=false
+Error: Failed to allocate additional 15.2 GB for DedupExec[keep-greatest]
+  with 0.0 B already allocated for this reservation
+  - 14.2 GB remain available for the total memory pool:
+    greedy(used: 1866.2 MB, pool_size: 16.0 GB)
+```
+
+Three facts make the 15.2 GB a lie, not a measurement:
+
+1. The pool had **1.8 GB used of 16 GB**. The process was not holding 15.2 GB;
+   RSS would have shown it and the cgroup would have killed us.
+2. The scans feeding this plan read `active_add_files_bytes=847116` (847 KB)
+   and `5243336` (5 MB). Megabytes in, 15.2 GB claimed.
+3. `0.0 B already allocated for this reservation` — this is the **first**
+   `try_grow` on a fresh reservation, i.e. **one batch** allegedly weighing
+   15.2 GB.
+
+Observed sizes over 45 minutes: 15.2 GB, 13.9 GB, 5.8 GB, 5.5 GB, 4.8 GB —
+three occurrences each, i.e. ~5 distinct statements each retried 3x.
+
+## Root cause
+
+`read_dedup.rs` sizes the keep-greatest run buffer with
+`batch.get_array_memory_size()`, which sums buffer **capacities**. Batches
+arriving from the DML UPDATE path are view arrays that reference the parquet
+reader's full column-chunk blocks, so each batch is charged the whole block
+rather than the rows it owns.
+
+This codebase already diagnosed this exact mechanism, for a different consumer.
+`mem_buffer.rs:531`:
+
+> Inherited scan blocks: rows read back by the DML UPDATE path arrive as view
+> arrays referencing the parquet reader's full column-chunk data blocks
+> (`capacity == len`, so slack detection can't see it) — ~250-row UPDATE
+> batches charged ~135MB each (29.9GB for 54k rows).
+
+MemBuffer fixed it by compacting; `DedupExec` never got the same treatment.
+
+**It is not only an accounting error.** The keep-greatest run buffer *retains*
+the batches it holds, so an inherited block stays alive for as long as the run
+does. Compacting makes the charge honest *and* actually releases the block.
+
+## Why this is the user's "maintenance lags → queries slow"
+
+The chain is real and now fully instrumented:
+
+```
+maintenance lags  →  partitions never certified  →  DedupExec stays in every plan
+                  →  DedupExec charges inherited scan blocks
+                  →  query fails ResourcesExhausted (or crawls) after ~17 s
+```
+
+`DedupExec` is only in the plan because certification hasn't happened. So
+maintenance lag doesn't merely make queries scan more data — it inserts an
+operator whose memory accounting is wrong by three orders of magnitude.
+
+## Fix
+
+Reuse `mem_buffer::compact_batch` (already `pub(crate)`, already the "full
+charge-honesty pass": view `gc()` for block slack/inheritance, then
+`privatize_sliced` for IPC-style shared buffers) on the buffering path in
+`Dedup`, before `try_grow`.
+
+It is free when there is nothing to compact — `compact_batch` returns the same
+`RecordBatch` when every column pointer is unchanged.
+
+Scope: the unbounded/keep-greatest run buffer only. Do not touch the bounded
+path's emit logic, the survivor rule, or `UNBOUNDED_GREATEST_MAX_BYTES`.
+
+## Verification
+
+1. Failing test first: a batch whose columns are slices of a large parent, run
+   through unbounded keep-greatest under a pool sized between the real bytes and
+   the inherited-capacity charge. Must fail before the fix, pass after.
+2. Full lib suite.
+3. Prod: `Failed to allocate additional <GB> for DedupExec[keep-greatest]`
+   should stop appearing, and the enrichment UPDATE should stop returning
+   `success=false`.
+
+## Explicitly NOT in scope
+
+The heavy-share sizing question (`HEAVY_REWRITE_PERMITS` 4→10 against a
+4.98 GiB heavy pool, with `PER_SORT_BUDGET_BYTES` halved to pay for it) is a
+separate, real concern — 10 x 2 GiB of declared per-sort budget against a
+4.98 GiB pool. It is tracked separately; this document is only the query-path
+failure.

--- a/docs/plans/2026-08-17-maintenance-unit-economics-at-10x.md
+++ b/docs/plans/2026-08-17-maintenance-unit-economics-at-10x.md
@@ -1,0 +1,118 @@
+# Maintenance unit economics, and why the queue diverges at 10x projects
+
+Status: **#134 fixes the immediate arithmetic. The deeper questions below are
+open and are the next exploration.**
+
+The roadmap target is "10x current number of projects on the same server". This
+document is about the one property that decides whether that is possible: the
+number of durable maintenance UNITS the system creates per day, versus the
+number it can retire per day. Everything else — pool sizes, concurrency,
+per-unit speed — is a constant factor on top of it.
+
+## The arithmetic
+
+The live path mints one unit per **ten-minute slice** (`NORMAL_SLICE_MICROS`),
+per project, per operation, per declared tier. The codebase already states the
+per-partition figure, in `plan_rollup_backfill`:
+
+> ~144 slices x Dedup/BaseRollup/HotPacking x each tier, about **450 durable
+> tasks per (project, date)**
+
+So, per day:
+
+```
+   450 units per (project, source)
+ x  13 projects
+ x   2 rollup-declared sources   (otel_logs_and_spans, otel_metrics)
+ = ~11,700 units/day created
+```
+
+Measured drain, 2026-08-17 (16 coordinator jobs, after the day's fixes):
+~500 units/hour = **~12,000 units/day retired**.
+
+That is break-even, and it is break-even by coincidence rather than design. The
+observed queue confirms it — flat-to-rising all day:
+
+```
+16:14Z   tasks_pending 17,993   tasks_complete 7,970   tasks_running 14
+         dedup 4,997 · base_rollup 4,857 · hot_packing 4,955
+         derived_rollup 1,207 · sealed_consolidation 1,659 · repair 381
+         oldest_task_age 106,836s (29.7h)   backlog 18.1 TB
+```
+
+**Creation scales linearly with projects; drain does not scale at all** — it is
+bounded by cores and object-store round trips on one box. At 130 projects the
+creation rate is ~117,000 units/day against the same ~12,000 retired. The queue
+does not lag, it diverges, and every `claim_next` scans the task set, so the
+scheduler gets slower exactly as the backlog grows.
+
+## Why the units are so numerous
+
+Ten minutes is the right granularity for the **live frontier**: it bounds how
+much work a crash loses and how quickly a just-written slice becomes queryable.
+It is the wrong granularity for a **sealed day**, where the same 144 units each
+pay the same fixed cost — Delta log scan, admission, lease, checkpoint — for a
+144th of the data.
+
+The fixed cost per unit dominates: measured earlier in the day, units cost
+50-80s of object-store work "regardless of how little data it covers".
+
+## What #134 does
+
+Collapses each sealed day's leftover sub-day units into one day-sized unit, on
+the existing 60s planner tick. `migrate_fine_grained_backfill` did this once for
+the historical backlog; #134 is the recurring form, because every midnight
+creates another day of it.
+
+Expected effect: creation drops from ~450 to ~3-6 units per (project, date)
+**after the day seals**, i.e. from ~11,700/day to roughly 11,700 transient +
+~150 durable. The frontier still mints its ten-minute units during the day;
+they simply stop outliving their purpose.
+
+The anti-loop guard is the load-bearing half: `split_time_task` leaves an
+oversized parent `Superseded`, so a day whose day-unit exists in ANY state is
+skipped. Without it, a whale's day splits into children, coarsens back into a
+day, and splits again forever.
+
+## Open questions — the actual next exploration
+
+1. **Does the frontier need durable per-slice units at all?**
+   They exist so a crash cannot lose a slice. But the WAL already provides that
+   guarantee for the DATA. If the frontier's units were derived from a cursor
+   rather than enumerated, creation would stop scaling with projects entirely.
+   This is the single biggest lever and the least explored.
+
+2. **`claim_next` is O(n) over the whole task set, per claim, per worker.**
+   Already rewritten once today from O(n log n) plus two allocations. At 16
+   workers and a six-operation cycle it is ~100 scans/second over `n`. It needs
+   an index keyed by `(class, operation)` before `n` grows another order of
+   magnitude.
+
+3. **HotPacking is ~28% of the queue (4,955) and produces no coverage.**
+   It is file hygiene. Its units should probably be planned by DEBT (bytes of
+   unpacked files) rather than by time slice, so their count tracks fragmentation
+   instead of tracking the calendar.
+
+4. **Per-unit fixed cost of 50-80s is mostly Delta metadata.**
+   ~6 metadata scans per task at 47-90ms was measured, which is only ~0.3s — so
+   the rest is object-store latency on the data path. Worth attributing properly
+   before assuming compaction fixes it.
+
+5. **Dedup is not a dependency of BaseRollup** (`dependencies_complete` returns
+   `None` for it), yet it holds a third of the queue and, before #127, was the
+   largest single consumer of worker time. Its scheduling share should be
+   justified against what actually blocks coverage.
+
+6. **The unit count is a function of `NORMAL_SLICE_MICROS`.**
+   Nothing has re-derived that 10-minute constant against the current write
+   rates; it predates the coordinator. A larger frontier slice would cut
+   creation proportionally, at the cost of coarser crash granularity.
+
+## How to tell whether this is fixed
+
+Not by `tasks_pending` alone — it moves for many reasons. The test is:
+
+- `tasks_pending` **falls** across a midnight boundary rather than stepping up
+- `maintenance_sealed_slices_coarsened` reports a large collapse each day
+- `oldest_task_age_seconds` stops climbing (it was 29.7h)
+- creation-per-project-day, derived from the above, is O(tiers) not O(144 x tiers)

--- a/src/read_dedup.rs
+++ b/src/read_dedup.rs
@@ -1009,12 +1009,23 @@ impl Dedup {
                 None => {
                     // Pool BEFORE buffering: on ResourcesExhausted the query
                     // fails here instead of the cgroup killing the server.
-                    let size = batch.get_array_memory_size();
+                    //
+                    // Compact first, because the run buffer RETAINS what it
+                    // holds. Batches read back by the DML UPDATE path are view
+                    // arrays over the parquet reader's whole column-chunk
+                    // blocks, so buffering one both charges the pool that block
+                    // and keeps it alive — prod 2026-08-17: the enrichment
+                    // UPDATE failed after 16.9s asking for 15.2 GB on a pool
+                    // 1.8 GB into 16 GB, fed by 847 KB and 5 MB of files.
+                    // `compact_batch` returns the batch untouched when there is
+                    // nothing to compact.
+                    let owned = crate::mem_buffer::compact_batch(batch.clone());
+                    let size = owned.get_array_memory_size();
                     if self.bound.is_none() {
                         check_unbounded_growth(g.bytes, size)?;
                     }
                     g.reservation.try_grow(size)?;
-                    g.batches.push(batch.clone());
+                    g.batches.push(owned);
                     g.masks.push(vec![false; batch.num_rows()]);
                     g.bytes += size;
                     let bi = g.batches.len() as u32 - 1;
@@ -1387,6 +1398,54 @@ mod tests {
         }
         let err = err.expect("a 512-byte pool must refuse the run buffer");
         assert!(format!("{err}").contains("Resources exhausted"), "must fail with the pool's error, got: {err}");
+    }
+
+    /// A batch whose columns are slices of a much larger parent must be charged
+    /// for the rows it owns, not for the allocation it borrows from.
+    ///
+    /// Prod 2026-08-17: monoscope's enrichment UPDATE failed after 16.9s with
+    /// `Failed to allocate additional 15.2 GB for DedupExec[keep-greatest]` on
+    /// a pool that was 1.8 GB used of 16 GB, fed by scans reading 847 KB and
+    /// 5 MB of files. Batches from the DML UPDATE path are view arrays over the
+    /// parquet reader's full column-chunk blocks, and `get_array_memory_size`
+    /// charges the whole block — the mechanism `mem_buffer::compact_batch`
+    /// already exists to neutralize.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_batch_slicing_a_big_parent_is_charged_for_its_own_rows() {
+        use datafusion::execution::{memory_pool::GreedyMemoryPool, runtime_env::RuntimeEnvBuilder};
+        // One 64k-row parent per column; each batch keeps two rows of it.
+        let ids: Vec<String> = (0..65536).map(|i| format!("k{i}")).collect();
+        let parent_id = StringArray::from(ids.iter().map(String::as_str).collect::<Vec<_>>());
+        let parent_ts = Int64Array::from((0..65536i64).collect::<Vec<_>>());
+        let parent_tb = Int64Array::from((0..65536i64).map(Some).collect::<Vec<_>>());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("ts", DataType::Int64, false),
+            Field::new("tb", DataType::Int64, true),
+        ]));
+        let sliced = |off: usize| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(parent_id.slice(off, 2)), Arc::new(parent_ts.slice(off, 2)), Arc::new(parent_tb.slice(off, 2))],
+            )
+            .unwrap()
+        };
+        let batches: Vec<RecordBatch> = (0..8).map(|i| sliced(i * 2)).collect();
+        let owned: usize = batches.iter().map(|b| b.num_rows()).sum();
+        let inherited = batches[0].get_array_memory_size();
+        assert!(inherited > 64 * 1024, "a slice of a 64k-row parent must report the parent's buffers, else this test proves nothing");
+
+        // Comfortably above the 16 rows actually retained, far below 8 x the
+        // inherited charge. Only honest accounting fits here.
+        let plan = unbounded_greatest_plan(batches);
+        let runtime = RuntimeEnvBuilder::new().with_memory_pool(Arc::new(GreedyMemoryPool::new(inherited))).build_arc().unwrap();
+        let ctx = Arc::new(TaskContext::default().with_runtime(runtime));
+        let mut stream = plan.execute(0, ctx).unwrap();
+        let mut rows = 0;
+        while let Some(r) = futures::StreamExt::next(&mut stream).await {
+            rows += r.expect("16 sliced rows must not be charged the whole parent").num_rows();
+        }
+        assert_eq!(rows, owned, "every distinct key must survive");
     }
 
     #[test]

--- a/src/read_dedup.rs
+++ b/src/read_dedup.rs
@@ -1424,11 +1424,8 @@ mod tests {
             Field::new("tb", DataType::Int64, true),
         ]));
         let sliced = |off: usize| {
-            RecordBatch::try_new(
-                schema.clone(),
-                vec![Arc::new(parent_id.slice(off, 2)), Arc::new(parent_ts.slice(off, 2)), Arc::new(parent_tb.slice(off, 2))],
-            )
-            .unwrap()
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(parent_id.slice(off, 2)), Arc::new(parent_ts.slice(off, 2)), Arc::new(parent_tb.slice(off, 2))])
+                .unwrap()
         };
         let batches: Vec<RecordBatch> = (0..8).map(|i| sliced(i * 2)).collect();
         let owned: usize = batches.iter().map(|b| b.num_rows()).sum();


### PR DESCRIPTION
## What prod shows

monoscope's enrichment UPDATE, 2026-08-17 15:42:37 — **ran 16.9 s, then failed**:

```
duration_us=16861662 success=false
Failed to allocate additional 15.2 GB for DedupExec[keep-greatest]
  with 0.0 B already allocated for this reservation
  - 14.2 GB remain available: greedy(used: 1866.2 MB, pool_size: 16.0 GB)
```

Three facts make 15.2 GB a lie rather than a measurement:

1. The pool was **1.8 GB used of 16 GB**. Nothing was holding 15.2 GB.
2. The scans feeding the plan read `active_add_files_bytes=847116` (847 KB) and 5 MB. Megabytes in, 15.2 GB claimed.
3. `0.0 B already allocated` — first `try_grow` on a fresh reservation, so **one batch** allegedly weighed 15.2 GB.

Over 45 minutes: 15.2, 13.9, 5.8, 5.5, 4.8 GB — three attempts each, ~5 distinct statements failing deterministically.

## Root cause

`get_array_memory_size()` sums buffer **capacities**. Batches from the DML UPDATE path are view arrays over the parquet reader's full column-chunk blocks, so each was charged the whole block.

The codebase already diagnosed this mechanism for a different consumer — `mem_buffer.rs:531` names the same path:

> Inherited scan blocks: rows read back by the **DML UPDATE path** arrive as view arrays referencing the parquet reader's full column-chunk data blocks (`capacity == len`, so slack detection can't see it) — ~250-row UPDATE batches charged ~135MB each (29.9GB for 54k rows).

MemBuffer fixed it by compacting. `DedupExec` never got the same treatment.

**It is not only accounting.** The run buffer *retains* its batches, so an inherited block stays alive for the life of the run. Compacting makes the charge honest *and* frees the block.

## Fix

Reuse `mem_buffer::compact_batch` before `try_grow`. Free when there is nothing to compact (returns the same `RecordBatch` when no column pointer changed).

## Why this is "maintenance lag makes queries slow"

`DedupExec` is only in these plans because the partition is **uncertified**. So maintenance lag doesn't merely make queries scan more — it inserts an operator whose memory accounting is wrong by three orders of magnitude, and the customer's statement fails.

## Tests

Failing-test-first. `a_batch_slicing_a_big_parent_is_charged_for_its_own_rows` builds batches slicing a 64k-row parent and runs unbounded keep-greatest under a pool sized between the real rows and the inherited charge.

Before: `ResourcesExhausted ... 1792.4 KB` for 16 rows — the prod symptom in miniature.
After: passes.

764/764 lib tests pass, `cargo lint` clean.

Plan: `docs/plans/2026-08-17-dedup-charges-inherited-scan-blocks.md`.

## Not in scope

Heavy-share sizing (`HEAVY_REWRITE_PERMITS` 4→10 against a 4.98 GiB heavy pool, with `PER_SORT_BUDGET_BYTES` halved to pay for it — 10 × 2 GiB declared against 4.98 GiB actual). Real, separate, tracked.