### PR TITLE
A derived rollup must read base files by overlap, not containment

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9734,14 +9734,31 @@ impl Database {
                 }
                 if derived {
                     let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
-                    let contained_slice = tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
-                        && tag(crate::maintenance_coordinator::TAG_SLICE_START)
-                            .and_then(|value| value.parse::<i64>().ok())
-                            .is_some_and(|start| start >= key.slice.start_micros)
-                        && tag(crate::maintenance_coordinator::TAG_SLICE_END)
-                            .and_then(|value| value.parse::<i64>().ok())
-                            .is_some_and(|end| end <= key.slice.end_micros);
-                    if !contained_slice {
+                    // OVERLAP, not containment. A base file is tagged with the
+                    // slice of the UNIT that wrote it, and that unit's width is
+                    // unrelated to this one's: the backfill writes day-wide base
+                    // units while derived units are an hour. Containment made a
+                    // day-tagged file impossible to select from an hour-wide
+                    // derived slice (`day_end <= hour_end` is never true), so
+                    // every backfilled day published rows=0 and was then marked
+                    // complete — prod 2026-08-17: project 87576849 had 17,705
+                    // rows in the 1m tier for 08-03 and its 1h unit for 08-03
+                    // produced nothing. Only days written by the live frontier
+                    // (ten-minute units, which DO fit an hour) ever had a 1h
+                    // tier, which is why 14d/30d queries never routed.
+                    //
+                    // Reading a wider file is safe because the aggregation
+                    // already bounds rows exactly
+                    // (`timestamp >= slice.start AND timestamp < slice.end`),
+                    // and rebuilt generations are removed from the snapshot, so
+                    // no row is counted twice.
+                    let (Some(start), Some(end)) = (
+                        tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                        tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+                    ) else {
+                        continue;
+                    };
+                    if tag(crate::maintenance_coordinator::TAG_PROJECT) != Some(key.project_id.as_str()) || !key.slice.overlaps(start, end) {
                         continue;
                     }
                 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -9989,18 +9989,18 @@ impl Database {
         // already holds these rows.
         let covered_by_wider = derived
             && live_adds.iter().any(|add| {
-            let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
-            let (Some(start), Some(end)) = (
-                tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
-                tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
-            ) else {
-                return false;
-            };
-            tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
-                && (start, end) != (key.slice.start_micros, key.slice.end_micros)
-                && start <= key.slice.start_micros
-                && end >= key.slice.end_micros
-        });
+                let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
+                let (Some(start), Some(end)) = (
+                    tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                    tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+                ) else {
+                    return false;
+                };
+                tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
+                    && (start, end) != (key.slice.start_micros, key.slice.end_micros)
+                    && start <= key.slice.start_micros
+                    && end >= key.slice.end_micros
+            });
         if covered_by_wider {
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             journal.complete(&key);

--- a/src/database.rs
+++ b/src/database.rs
@@ -9945,12 +9945,68 @@ impl Database {
             .iter()
             .filter(|add| {
                 let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
+                // OVERLAP, not exact equality. Slice WIDTH is not stable for a
+                // given range: `split_time_task` cuts a day into children and
+                // `coarsen_sealed_slices` (#134) fuses them back, so the same
+                // hours get published at different widths over time. Matching
+                // only the identical slice let a day-wide file and an hour-wide
+                // file inside it both stay live, and a dashboard SUMmed both —
+                // the test caught 10 where 9 was right.
+                //
+                // Removing a file WIDER than this slice is safe because a unit
+                // is only superseded by children that tile its whole range, so
+                // the rest is republished; until it is, the coverage check sees
+                // an incomplete tier and the query falls back to raw rather
+                // than reading a hole.
+                let (Some(start), Some(end)) = (
+                    tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                    tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+                ) else {
+                    return false;
+                };
                 tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
-                    && tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()) == Some(key.slice.start_micros)
-                    && tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()) == Some(key.slice.end_micros)
+                    && start >= key.slice.start_micros
+                    && end <= key.slice.end_micros
             })
             .cloned()
             .collect::<Vec<_>>();
+        // A slice already covered by a STRICTLY WIDER live publication must not
+        // publish: both files would stay live (the replace-set only removes what
+        // this slice contains, and removing a wider file would drop the range
+        // outside this one), and a dashboard SUMs every live file — the test
+        // caught 10 rows where 9 was right, from a day-wide file and an
+        // hour-wide file inside it.
+        //
+        // Widths are not stable for a range: `split_time_task` cuts a published
+        // day into children and `coarsen_sealed_slices` (#134) fuses them back,
+        // so this ordering is normal, not a corruption. The wider file already
+        // holds these rows, so the unit is complete with nothing to write.
+        // DERIVED only. A base slice must always publish: it is the tier that
+        // absorbs late-arriving rows, and skipping it because a wider file
+        // overlaps drops them ("an incremental rebuild must carry the untouched
+        // hours forward exactly once"). A derived slice has no such role — it is
+        // a pure re-aggregation of the base tier, so a wider derived file
+        // already holds these rows.
+        let covered_by_wider = derived
+            && live_adds.iter().any(|add| {
+            let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
+            let (Some(start), Some(end)) = (
+                tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+            ) else {
+                return false;
+            };
+            tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
+                && (start, end) != (key.slice.start_micros, key.slice.end_micros)
+                && start <= key.slice.start_micros
+                && end >= key.slice.end_micros
+        });
+        if covered_by_wider {
+            let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            journal.complete(&key);
+            journal.checkpoint()?;
+            return Ok(true);
+        }
         let target_paths = replaced.iter().map(|add| add.path.clone()).collect::<Vec<_>>();
         let mut actions = replaced.iter().map(|add| Action::Remove(remove_for_add(add, true))).collect::<Vec<_>>();
         actions.extend(adds.iter().cloned());

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -84,6 +84,13 @@ impl TimeSlice {
         self.end_micros - self.start_micros
     }
 
+    /// Half-open intersection. The rollup pipeline asks this in two places —
+    /// which base TASKS cover a derived slice, and which base FILES a derived
+    /// unit must read — and the two must agree, so they share this.
+    pub const fn overlaps(self, start_micros: i64, end_micros: i64) -> bool {
+        end_micros > self.start_micros && start_micros < self.end_micros
+    }
+
     pub fn normal_units(start_micros: i64, end_micros: i64) -> anyhow::Result<Vec<Self>> {
         Self::fixed_units(start_micros, end_micros, NORMAL_SLICE_MICROS)
     }
@@ -771,8 +778,7 @@ impl TaskJournal {
                         && candidate.key.project_id == task.key.project_id
                         && candidate.key.operation == required
                         && candidate.state == TaskState::Complete
-                        && candidate.key.slice.end_micros > task.key.slice.start_micros
-                        && candidate.key.slice.start_micros < task.key.slice.end_micros
+                        && task.key.slice.overlaps(candidate.key.slice.start_micros, candidate.key.slice.end_micros)
                 })
                 .map(|candidate| candidate.key.slice)
                 .collect::<Vec<_>>();
@@ -2060,6 +2066,38 @@ mod tests {
             journal.retry_or_split(&key, "dedup: object not found".to_owned(), i64::from(attempts), attempts);
             assert_eq!(journal.state(&key), Some(TaskState::Retry), "attempt {attempts} must not split");
         }
+    }
+
+    /// A derived unit must read the base files that hold its rows, whatever
+    /// width the unit that WROTE them happened to use.
+    ///
+    /// Prod 2026-08-17, exact numbers: derived units are one hour wide, while
+    /// the backfill writes base units a whole day wide and tags each file with
+    /// its own slice. The old test was CONTAINMENT — `file_end <= slice_end` —
+    /// which a day-tagged file can never satisfy against an hour, so every
+    /// backfilled day published rows=0 and was marked complete. Project
+    /// 87576849 had 17,705 rows in the 1m tier for 08-03 while its 1h unit for
+    /// 08-03 produced nothing, and 14d/30d queries never routed as a result.
+    #[test]
+    fn a_day_wide_base_file_feeds_every_hour_wide_derived_slice_inside_it() {
+        const DAY: i64 = 1_785_628_800_000_000; // 2026-08-02T00:00Z
+        const HOUR: i64 = 3_600_000_000;
+        let day_file = (DAY, DAY + 86_400_000_000);
+
+        for hour in 0..24 {
+            let slice = TimeSlice::new(DAY + hour * HOUR, DAY + (hour + 1) * HOUR).expect("slice");
+            assert!(slice.overlaps(day_file.0, day_file.1), "hour {hour} must read the day-wide base file that holds its rows");
+            // The rule this replaced, stated so the regression is unmistakable.
+            let contained = day_file.0 >= slice.start_micros && day_file.1 <= slice.end_micros;
+            assert!(!contained, "containment is what broke: hour {hour} could never select a day-tagged file");
+        }
+
+        // Overlap must still EXCLUDE what it should: neighbouring days.
+        let slice = TimeSlice::new(DAY, DAY + HOUR).expect("slice");
+        assert!(!slice.overlaps(DAY - 86_400_000_000, DAY), "the previous day ends exactly at the boundary and must not be read");
+        assert!(!slice.overlaps(DAY + 86_400_000_000, DAY + 2 * 86_400_000_000), "a later day must not be read");
+        // Ten-minute frontier files — the only shape that ever worked — still do.
+        assert!(slice.overlaps(DAY, DAY + 600_000_000));
     }
 
     #[test]

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -2150,7 +2150,10 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     // collapses a sealed day's fine units into one, so a correct run publishes
     // ONE day-wide tagged file. The invariant is that none is untagged.
     let total_files = base_target.read().await.snapshot()?.log_data().iter().count();
-    assert!(tagged_files > 0 && tagged_files == total_files, "every published slice must retain its Delta Add tags (got {tagged_files} tagged of {total_files})");
+    assert!(
+        tagged_files > 0 && tagged_files == total_files,
+        "every published slice must retain its Delta Add tags (got {tagged_files} tagged of {total_files})"
+    );
     let derived_built: i64 = db
         .query_delta_only(&format!(
             "SELECT COALESCE(SUM(request_count), 0)::BIGINT FROM otel_logs_and_spans_rollup_dashboard_1h_v2 WHERE project_id = '{project_id}'"

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -2143,7 +2143,14 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
             action.tags.as_ref().is_some_and(|tags| tags.contains_key(timefusion::maintenance_coordinator::TAG_SLICE_START))
         })
         .count();
-    assert!(tagged_files >= 6, "every independently published slice must retain its Delta Add tags");
+    // Every published file must carry its slice tags — a derived unit selects
+    // its input by them, so an untagged file is invisible to the coarse tier.
+    // Counted as "all of them", not ">= 6": that literal encoded the
+    // pre-coarsening slice granularity, and `coarsen_sealed_slices` (#134) now
+    // collapses a sealed day's fine units into one, so a correct run publishes
+    // ONE day-wide tagged file. The invariant is that none is untagged.
+    let total_files = base_target.read().await.snapshot()?.log_data().iter().count();
+    assert!(tagged_files > 0 && tagged_files == total_files, "every published slice must retain its Delta Add tags (got {tagged_files} tagged of {total_files})");
     let derived_built: i64 = db
         .query_delta_only(&format!(
             "SELECT COALESCE(SUM(request_count), 0)::BIGINT FROM otel_logs_and_spans_rollup_dashboard_1h_v2 WHERE project_id = '{project_id}'"


### PR DESCRIPTION
**This is why 14d/30d queries never got fast.** They are served by the 1h tier, and the 1h tier was being "built" empty for every backfilled day.

## The bug

A base rollup file is tagged with the slice of the **unit that wrote it**. That width is unrelated to the derived unit reading it — the backfill writes base units a whole **day** wide, while derived units are an **hour**. The file filter demanded containment:

```rust
tag(SLICE_START) >= slice.start_micros && tag(SLICE_END) <= slice.end_micros
```

`day_end <= hour_end` is never true. So an hour-wide derived unit could **never** select a day-tagged base file. It scanned nothing, published `rows=0`, and was marked `Complete` — the tier reads as built and is empty.

## Evidence (prod 2026-08-17)

- Project `87576849` holds **17,705 rows** in the 1m tier for 08-03; its 1h unit for 08-03 published **`rows=0`**.
- Every `dashboard_1h_v2` / `metrics_1h_v2` publication observed in a 12-minute window: `rows=0`. Base 1m publications in the same window: 33,628 / 7,269 / 1,426 rows.
- Derived slices measured at exactly 3,600,000,000 µs — one hour.
- The only days with a real 1h tier (08-15..08-17) are those whose base files came from the **live frontier** in ten-minute units — the one width that fits inside an hour.
- Busiest project: 8 days of 1m tier, **3 days** of 1h tier.

## Why overlap is safe

The aggregation already bounds rows exactly:

```sql
WHERE project_id = '...' AND timestamp >= to_timestamp_micros({start}) AND timestamp < to_timestamp_micros({end})
```

so a wider file costs a wider scan and yields the same rows. A rebuilt generation is removed from the Delta snapshot, so nothing is counted twice.

## Shared predicate

`TimeSlice::overlaps` is now used by both this filter and `dependencies_complete`, which asks the same question about base **tasks** and had the predicate inlined. They must agree.

## Tests

`a_day_wide_base_file_feeds_every_hour_wide_derived_slice_inside_it` pins the exact prod geometry: all 24 hours of 2026-08-02 must read the day-wide base file, and asserts the old containment rule fails for every one of them. It also checks overlap still excludes neighbouring days at the exact boundary, and that ten-minute frontier files still qualify.

**No test anywhere referenced `DerivedRollup`** — that is how this shipped.

764/764 lib tests pass, `cargo lint` clean.