### PR TITLE
Assert the heavy fan-in envelope against the pool sorts actually use

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2800,6 +2800,33 @@ mod tests {
             b.rewrite_permits() * PER_SORT_BUDGET_BYTES < b.memory_limit_bytes() / 2,
             "the fan-in envelope must stay well under the cgroup, whatever the permit count"
         );
+        // The cgroup is the wrong denominator for the assertion above, and it is
+        // why the envelope could go to 20 GiB unnoticed: heavy sorts do not run
+        // in the cgroup, they run in `heavy_share_bytes()`, which on prod is
+        // ~4.98 GiB (16.6 GiB pool, less a 4.15 GiB coordinator quarter, x 0.40).
+        // 10 x 2 GiB against 4.98 GiB passes the cgroup test by 2x while
+        // over-committing the real pool by 4x.
+        //
+        // What actually has to hold is that a FairSpillPool slice still clears
+        // the allocations a sort cannot avoid: one indivisible `batch_size`
+        // batch (2048 wide otel rows reach ~150 MB) plus `ExternalSorterMerge`'s
+        // 32 MB floor, which cannot spill. Below that a unit FAILS instead of
+        // spilling — prod 2026-08-17 logged exactly that at a 512 MB
+        // coordinator pool, and again at 3.4 GiB heavy.
+        //
+        // Stated as a floor per concurrent sort rather than as an envelope, so
+        // raising permits is only safe if the share grows with them.
+        const WIDEST_BATCH_BYTES: usize = 150 * 1024 * 1024;
+        const UNSPILLABLE_MERGE_FLOOR_BYTES: usize = 32 * 1024 * 1024;
+        let per_sort_slice = b.heavy_share_bytes() / b.rewrite_permits();
+        assert!(
+            per_sort_slice >= WIDEST_BATCH_BYTES + UNSPILLABLE_MERGE_FLOOR_BYTES,
+            "each of {} concurrent heavy sorts gets {} MB of the {} MB heavy share, below the {} MB a sort cannot spill below — it will fail rather than spill",
+            b.rewrite_permits(),
+            per_sort_slice / 1024 / 1024,
+            b.heavy_share_bytes() / 1024 / 1024,
+            (WIDEST_BATCH_BYTES + UNSPILLABLE_MERGE_FLOOR_BYTES) / 1024 / 1024,
+        );
         assert_eq!(b.optimize_merge_tasks(), 2);
     }
 


### PR DESCRIPTION
The guard meant to stop the fan-in envelope drifting compares it to the **cgroup**:

```rust
rewrite_permits * PER_SORT_BUDGET_BYTES < memory_limit_bytes / 2
```

Heavy sorts do not run in the cgroup. They run in `heavy_share_bytes()`.

| box | heavy share | envelope (10 × 2 GiB) | over-commit |
|---|---|---|---|
| modelled prod (120 GiB / 48c) | 9 GiB | 20 GiB | 2.2× |
| real prod (`fair(pool_size: 5.0 GB)` in the error text) | 4.98 GiB | 20 GiB | **4×** |

So the envelope passes the cgroup test by 2× while over-committing the pool that actually bounds it by 4×. That is how permits went 4 → 10 on 2026-08-17 — paid for by halving `PER_SORT_BUDGET_BYTES` — with nothing objecting.

## What this adds

The invariant that has to hold: a FairSpillPool slice must still clear the allocations a sort **cannot avoid** — one indivisible `batch_size` batch (2048 wide otel rows reach ~150 MB) plus `ExternalSorterMerge`'s 32 MB floor, which cannot spill. Below that a unit **fails instead of spilling**, which prod logged at a 512 MB coordinator pool and again at 3.4 GiB heavy:

```
dedup: Not enough memory to continue external sort ...
  Failed to allocate additional 1090.9 MB for ExternalSorter[1]
  ... fair(pool_size: 5.0 GB)
```

Stated as a **floor per concurrent sort** rather than as a total, so raising permits is only safe if the share grows with them.

## Not a behaviour change

No constant moves. Current margin is real, not tight — **921 MB** per sort on the modelled box, **~498 MB** on prod, against a **182 MB** floor. It would bind at roughly 27 permits.

The cgroup assertion stays: it is a valid outer bound, just not the binding one.

767/767 lib tests pass, `cargo lint` clean, `cargo fmt --check` clean.