### PR TITLE
Count base files a derived rollup cannot read for want of tags

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9865,6 +9865,7 @@ impl Database {
         }
         let projected_numerator = u64::try_from(required_columns.len()).unwrap_or(u64::MAX);
         let projected_denominator = u64::try_from(source_schema.fields.len().max(1)).unwrap_or(u64::MAX);
+        let mut untagged_inputs = 0u64;
         let (snapshot, log_store, selected, estimated_bytes) = {
             let table = from_table.read().await;
             let snapshot = Arc::new(table.snapshot()?.snapshot().clone());
@@ -9909,10 +9910,18 @@ impl Database {
                     // (`timestamp >= slice.start AND timestamp < slice.end`),
                     // and rebuilt generations are removed from the snapshot, so
                     // no row is counted twice.
+                    // A base file with no readable slice tags is invisible to
+                    // the coarse tier FOREVER — the unit publishes rows=0 and is
+                    // marked complete, which reads exactly like "this slice is
+                    // genuinely empty". Counted separately so the two are
+                    // distinguishable: #139 fixed day-tagged files being
+                    // unselectable, and if any tier still comes back empty this
+                    // is the number that says whether tags are the reason.
                     let (Some(start), Some(end)) = (
                         tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
                         tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
                     ) else {
+                        untagged_inputs = untagged_inputs.saturating_add(1);
                         continue;
                     };
                     if tag(crate::maintenance_coordinator::TAG_PROJECT) != Some(key.project_id.as_str()) || !key.slice.overlaps(start, end) {
@@ -9925,6 +9934,17 @@ impl Database {
             }
             (snapshot, table.log_store(), selected, estimated)
         };
+        if untagged_inputs > 0 {
+            crate::metrics::maintenance_stats().rollup_untagged_inputs.fetch_add(untagged_inputs, std::sync::atomic::Ordering::Relaxed);
+            warn!(
+                table = %key.physical_table,
+                project_id = %key.project_id,
+                slice_start = key.slice.start_micros,
+                untagged_inputs,
+                event = "maintenance_rollup_untagged_input",
+                "base files carry no slice tags; their rows can never reach this tier"
+            );
+        }
         if estimated_bytes > MAX_DECODED_BYTES && key.slice.width() > crate::maintenance_coordinator::MIN_SLICE_MICROS {
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             if journal.split_time_task(&key, estimated_bytes) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -722,6 +722,11 @@ atomic_stats! {
     /// file already covered them. Expected to be rare; if it is not, a late row
     /// inside an already-published day may be going stale in the coarse tier.
     rollup_skipped_covered_by_wider,
+    /// Base rollup files a derived unit could not read because they carry no
+    /// parseable slice tags. Such a file is invisible to the coarse tier
+    /// forever, and the unit publishes rows=0 and completes — indistinguishable
+    /// from a genuinely empty slice unless this is counted.
+    rollup_untagged_inputs,
     /// Contiguous sealed days of rollup coverage, counting back from yesterday,
     /// minimised over every (project, declared tier).
     ///

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -327,6 +327,7 @@ impl StatsTableProvider {
             "rollup_rebuilds_full_total" => m.rollup_rebuilds_full,
             "rollup_dirty_partitions" => m.rollup_dirty_partitions,
             "rollup_skipped_covered_by_wider" => m.rollup_skipped_covered_by_wider,
+            "rollup_untagged_inputs" => m.rollup_untagged_inputs,
             "rollup_min_contiguous_days" => m.rollup_min_contiguous_days,
             "rollup_oldest_invalidation_age_seconds" => m.rollup_oldest_invalidation_age_secs,
             "rollup_scan_cohorts_total" => m.rollup_scan_cohorts,


### PR DESCRIPTION
A base rollup file with no parseable slice tags is invisible to the coarse tier **forever**: the derived unit selects nothing, publishes `rows=0`, and is marked `Complete` — which reads exactly like *"this slice is genuinely empty"*.

That ambiguity is what made #139 take hours to find. `rows=0` was consistent with three different causes:

1. no source data for that (project, date) — genuinely empty
2. base files tagged at a width the predicate could not select — the actual bug
3. base files with no tags at all

Only a per-project cross-check against the base tier separated them (project `87576849` had 17,705 rows in the 1m tier for 08-03 while its 1h unit published `rows=0`). #139 fixed case 2; this makes case 3 announce itself, via `rollup_untagged_inputs` plus a warn naming the table, project and slice.

## Deliberately a counter, not a fix

If it ever moves, the right response depends on *why* the tags are missing — a legacy writer, or a rewrite that dropped them — and guessing now would be inventing a problem. It is expected to stay **0**, because the coordinator's publish path sets the tags unconditionally; a non-zero value means something else is writing into a rollup table.

769/769 lib tests pass, `cargo lint` clean, `cargo fmt --check` clean.
