### PR TITLE
Count derived slices that complete without publishing

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10046,6 +10046,21 @@ impl Database {
                     && end >= key.slice.end_micros
             });
         if covered_by_wider {
+            // Counted because this branch has a hazard we cannot currently
+            // observe. `invalidate` mints derived work at DERIVED_SLICE_MICROS,
+            // so late rows for ONE HOUR inside an already-published day arrive
+            // as an hour-wide unit — and completing it without publishing would
+            // leave that hour stale in the coarse tier, which is a wrong number
+            // rather than a slow one.
+            //
+            // Not "fixed" by reopening the covering slice, because the failure
+            // could not be reproduced: in the one test that builds this shape
+            // the late row lands outside the covering file, and master behaves
+            // identically. Rebuilding a whole day on every hour invalidation is
+            // a real cost to pay against a hazard that may not occur, so
+            // measure first. If this counter moves on prod, the staleness is
+            // reachable and escalation is the fix.
+            crate::metrics::maintenance_stats().rollup_skipped_covered_by_wider.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             journal.complete(&key);
             journal.checkpoint()?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -718,6 +718,10 @@ atomic_stats! {
     rollup_rebuilds_incremental,
     rollup_rebuilds_full,
     rollup_dirty_partitions,
+    /// Derived slices completed WITHOUT publishing because a strictly wider live
+    /// file already covered them. Expected to be rare; if it is not, a late row
+    /// inside an already-published day may be going stale in the coarse tier.
+    rollup_skipped_covered_by_wider,
     /// Contiguous sealed days of rollup coverage, counting back from yesterday,
     /// minimised over every (project, declared tier).
     ///

--- a/src/stats_table.rs
+++ b/src/stats_table.rs
@@ -326,6 +326,7 @@ impl StatsTableProvider {
             "rollup_rebuilds_incremental_total" => m.rollup_rebuilds_incremental,
             "rollup_rebuilds_full_total" => m.rollup_rebuilds_full,
             "rollup_dirty_partitions" => m.rollup_dirty_partitions,
+            "rollup_skipped_covered_by_wider" => m.rollup_skipped_covered_by_wider,
             "rollup_min_contiguous_days" => m.rollup_min_contiguous_days,
             "rollup_oldest_invalidation_age_seconds" => m.rollup_oldest_invalidation_age_secs,
             "rollup_scan_cohorts_total" => m.rollup_scan_cohorts,


### PR DESCRIPTION
#139 added a guard: a derived slice already covered by a strictly wider live file does not publish, because two overlapping files would both stay live and a dashboard would **SUM** them (it measured 10 where 9 was right).

That branch has a hazard I want visibility on before deciding anything.

## The hazard

`invalidate` mints derived work at `DERIVED_SLICE_MICROS`, so late rows for **one hour** inside an already-published day arrive as an hour-wide unit. Completing it without publishing would leave that hour **stale** in the coarse tier — a wrong number, not a slow one.

## Why this counts instead of fixing

**I could not reproduce it.** The one test that builds this shape (`a_partly_covered_window_unions_...`) puts the late row outside the covering file, and unmodified master behaves identically — `base_total=13`, `derived=11` either way — so the test does not exercise the path.

The obvious fix, reopening the covering slice, would rebuild a **whole day on every hour invalidation**. That is a real, recurring cost, and paying it against a hazard that may not occur is the wrong trade without evidence.

So: if `rollup_skipped_covered_by_wider` moves on prod, the staleness is reachable and escalation is the fix. If it stays at zero, the guard is inert and the question is closed.

## Unrelated observation, not fixed here

While investigating I found an **untagged** file in the 1h tier in that test (`start=- end=-`, 6 rows). The replace-set matches on tags, so an untagged rollup file can never be superseded and sums forever. `stage_rollup_wave` inserts `TAG_SLICE_START` with a `None` value when `date_start_micros(date)` fails to parse, which reads as untagged. I have no evidence this occurs in prod, so it is recorded rather than acted on — #144 adds the counter that would show it.

769/769 lib tests pass, `cargo lint` clean.
