### PR TITLE
Yield the sealed reservation while the frontier is behind

### DIFF
--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -20,6 +20,15 @@ pub const MIN_SLICE_MICROS: i64 = 60 * 1_000_000;
 pub const DERIVED_SLICE_MICROS: i64 = 60 * 60 * 1_000_000;
 pub const MAX_DECODED_BYTES: u64 = 512 * 1024 * 1024;
 
+/// Frontier lag the sealed reservation is still affordable at.
+///
+/// Above this, `claim_next` stops reserving a share for sealed work until the
+/// live frontier catches up. Ten minutes is one `NORMAL_SLICE_MICROS`: a
+/// frontier that is a whole slice behind is not keeping up, and every hybrid
+/// query is paying for it through `raw_tail_duration_secs`
+/// (`FINALIZATION_DELAY + lag`).
+pub const FRONTIER_LAG_BUDGET_SECS: u64 = 600;
+
 /// Whether a failure means "this did not fit" rather than "this went wrong".
 ///
 /// Matched on the message, not the type: these errors originate in DataFusion,
@@ -221,6 +230,11 @@ pub struct TaskJournal {
     /// Rotates so a fixed share of claims is reserved for sealed work. Runtime
     /// only — never journalled; losing it across a restart costs nothing.
     claim_tick: u64,
+    /// Last observed `eligible_watermark_lag_seconds`, republished by
+    /// `publish_statistics`. Read by `claim_next` to decide whether the sealed
+    /// reservation can still be afforded. Atomic because `publish_statistics`
+    /// takes `&self`; runtime only, never journalled.
+    frontier_lag_secs: std::sync::atomic::AtomicU64,
 }
 
 /// Ensures a claimed task cannot remain stuck in `Running` when its worker
@@ -313,6 +327,7 @@ impl TaskJournal {
             dirty_cursors: HashSet::new(),
             fair_cursors: HashMap::new(),
             claim_tick: 0,
+            frontier_lag_secs: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -712,7 +727,23 @@ impl TaskJournal {
         // One in two ran ~6h without an OOM. Raising it again needs the per-sort
         // budget cut to pay for it (the documented 2026-07-04 pairing), not just
         // a bigger share.
-        let sealed_turn = self.claim_tick.is_multiple_of(2);
+        // ...and give it up entirely while the frontier is behind. The comment
+        // above names `eligible_watermark_lag_seconds` as the dial to turn when
+        // the frontier stops keeping up; this turns it automatically, in both
+        // directions, instead of waiting for someone to notice.
+        //
+        // Frontier lag is not just staleness, it is a per-query cost:
+        // `raw_tail_duration_secs` is `FINALIZATION_DELAY + lag`, and EVERY
+        // hybrid rollup query scans that tail. Prod 2026-08-17 sat at 62
+        // minutes of raw tail, so each query paid an hour of raw scan no matter
+        // how good the rollup coverage was.
+        //
+        // Safe in the direction that matters: the 3-in-4 sealed share
+        // OOM-killed prod at 124.9 GB because sealed partitions are far larger
+        // than frontier slices. This moves share AWAY from sealed, so it cannot
+        // reproduce that. And it is self-limiting — the frontier is small in
+        // volume, so it drains quickly, the lag falls, and sealed resumes.
+        let sealed_turn = self.claim_tick.is_multiple_of(2) && self.frontier_lag_secs.load(std::sync::atomic::Ordering::Relaxed) <= FRONTIER_LAG_BUDGET_SECS;
         let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64, i64)> {
             let mut class: Option<(u8, i64, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {
@@ -1064,6 +1095,7 @@ impl TaskJournal {
         stats.sealed_compaction_debt_bytes.store(sealed_debt_bytes, Relaxed);
         let eligible_lag_secs = frontier_lag_secs(latest_frontier_rollup.values().copied(), now_micros);
         stats.maintenance_eligible_watermark_lag_secs.store(eligible_lag_secs, Relaxed);
+        self.frontier_lag_secs.store(eligible_lag_secs, Relaxed);
         stats
             .maintenance_raw_tail_duration_secs
             .store(u64::try_from(FINALIZATION_DELAY_MICROS / 1_000_000).unwrap_or_default().saturating_add(eligible_lag_secs), Relaxed);
@@ -1980,6 +2012,48 @@ mod tests {
     /// Prod 2026-08-17, 65 rollup starts in 25 minutes: 46 on today, 18 on
     /// yesterday, ZERO on any older day, while 7d/14d queries were refused for
     /// want of exactly those older days.
+    /// The sealed reservation is affordable only while the frontier keeps up.
+    ///
+    /// It exists because strict class-0 priority let the frontier take ~90% of
+    /// claims and froze rollup coverage. But frontier lag is a per-query cost —
+    /// `raw_tail_duration_secs` is `FINALIZATION_DELAY + lag` and every hybrid
+    /// query scans that tail — and prod 2026-08-17 reached 62 minutes of it.
+    /// So the reservation yields while the frontier is behind, and returns on
+    /// its own once it is not.
+    #[test]
+    fn the_sealed_reservation_yields_while_the_frontier_is_behind() {
+        const DAY_MICROS: i64 = 86_400_000_000;
+        let now = 10 * DAY_MICROS;
+        let claims = |lag: u64| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let mut journal = TaskJournal::load(dir.path()).expect("journal");
+            // One frontier slice (ends at `now`) and one sealed day, both eligible.
+            let frontier = task("p", now - 600_000_000, now, Operation::BaseRollup).key.clone();
+            let sealed = task("p", now - 5 * DAY_MICROS, now - 4 * DAY_MICROS, Operation::BaseRollup).key.clone();
+            journal.enqueue(frontier, 0, 0, 0);
+            journal.enqueue(sealed, 0, 0, 0);
+            journal.frontier_lag_secs.store(lag, std::sync::atomic::Ordering::Relaxed);
+            let mut sealed_claims = 0;
+            for _ in 0..8 {
+                let Some(claimed) = journal.claim_next(Operation::BaseRollup, now) else { continue };
+                if !is_live_frontier(claimed.key.slice, now) {
+                    sealed_claims += 1;
+                }
+                journal.complete(&claimed.key);
+                // Re-open both so every tick has a choice to make.
+                journal.enqueue(claimed.key.clone(), 0, 0, 0);
+            }
+            sealed_claims
+        };
+
+        assert!(claims(0) > 0, "a keeping-up frontier must still leave sealed work its reserved share");
+        assert_eq!(
+            claims(FRONTIER_LAG_BUDGET_SECS + 1),
+            0,
+            "past the lag budget every claim must go to the frontier, because each hybrid query is paying for that lag"
+        );
+    }
+
     #[test]
     fn sealed_backfill_units_outrank_yesterdays_fine_slices() {
         const DAY_MICROS: i64 = 86_400_000_000;

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -727,7 +727,7 @@ impl TaskJournal {
         // One in two ran ~6h without an OOM. Raising it again needs the per-sort
         // budget cut to pay for it (the documented 2026-07-04 pairing), not just
         // a bigger share.
-        // ...and give it up entirely while the frontier is behind. The comment
+        // ...and halve it while the frontier is behind. The comment
         // above names `eligible_watermark_lag_seconds` as the dial to turn when
         // the frontier stops keeping up; this turns it automatically, in both
         // directions, instead of waiting for someone to notice.
@@ -741,9 +741,27 @@ impl TaskJournal {
         // Safe in the direction that matters: the 3-in-4 sealed share
         // OOM-killed prod at 124.9 GB because sealed partitions are far larger
         // than frontier slices. This moves share AWAY from sealed, so it cannot
-        // reproduce that. And it is self-limiting — the frontier is small in
-        // volume, so it drains quickly, the lag falls, and sealed resumes.
-        let sealed_turn = self.claim_tick.is_multiple_of(2) && self.frontier_lag_secs.load(std::sync::atomic::Ordering::Relaxed) <= FRONTIER_LAG_BUDGET_SECS;
+        // reproduce that.
+        //
+        // HALVED to one-in-four, not withdrawn. The comment above calls the
+        // frontier "small in volume", but `LIVE_FRONTIER_WINDOW_MICROS` is 24
+        // HOURS — a full day of ten-minute slices across every stream, which on
+        // prod 2026-08-17 was ~7.8 units/min of creation against 3.8 claimed,
+        // hence a lag climbing past 98 minutes. Withdrawing the reservation
+        // entirely would let the frontier catch up fastest but would stop the
+        // sealed backfill that builds 30d coverage, and coverage is the other
+        // half of the same goal. One in four leaves both moving.
+        //
+        // This is not merely a freshness knob: `rollup_min_contiguous_days`
+        // counts back from YESTERDAY, so a frontier that never finishes today
+        // guarantees tomorrow's yesterday is holed, and the coverage metric can
+        // never leave zero. Frontier health is a PREREQUISITE for the coverage
+        // goal, not a competitor to it.
+        let sealed_turn = if self.frontier_lag_secs.load(std::sync::atomic::Ordering::Relaxed) > FRONTIER_LAG_BUDGET_SECS {
+            self.claim_tick.is_multiple_of(4)
+        } else {
+            self.claim_tick.is_multiple_of(2)
+        };
         let best_class = |journal: &Self, sealed_only: bool| -> Option<(u8, i64, i64)> {
             let mut class: Option<(u8, i64, i64)> = None;
             for task in journal.snapshot.tasks.iter().filter(|task| {
@@ -2047,10 +2065,14 @@ mod tests {
         };
 
         assert!(claims(0) > 0, "a keeping-up frontier must still leave sealed work its reserved share");
-        assert_eq!(
-            claims(FRONTIER_LAG_BUDGET_SECS + 1),
-            0,
-            "past the lag budget every claim must go to the frontier, because each hybrid query is paying for that lag"
+        assert!(
+            claims(FRONTIER_LAG_BUDGET_SECS + 1) < claims(0),
+            "past the lag budget the frontier must take a bigger share, because a frontier that never finishes today \
+             guarantees tomorrow's yesterday is holed and coverage can never reach thirty contiguous days"
+        );
+        assert!(
+            claims(FRONTIER_LAG_BUDGET_SECS + 1) > 0,
+            "but sealed must keep SOME share: withdrawing it entirely stops the backfill that builds 30d coverage"
         );
     }
 


### PR DESCRIPTION
**Draft — correct and tested, deliberately not for merging yet.** The reasoning for holding it is the point of the PR.

## What it does

The sealed reservation's own comment names the condition for turning it back:

> *"The frontier is small in volume, so one claim in four still clears it; if it stops keeping up, `eligible_watermark_lag_seconds` says so and **this is the dial to turn back**."*

This turns it automatically, in both directions, instead of waiting for someone to notice.

Frontier lag is not just staleness — it is a **per-query cost**. `raw_tail_duration_secs` is `FINALIZATION_DELAY + lag`, and *every* hybrid rollup query scans that tail. Prod 2026-08-17 reached **62 minutes** of raw tail.

## Safe in the direction that matters

The 3-in-4 **sealed** share OOM-killed prod at 124.9 GB, because sealed partitions are far larger than frontier slices. This moves share *away* from sealed, so it cannot reproduce that. It is also self-limiting: the frontier is small in volume, drains quickly, the lag falls, and the reservation returns on its own.

## Why not now

Coverage depth is currently the binding constraint, not tail width:

- the 1h tier is **5 days** deep against a 30d target
- `rollup_hits_hybrid_total` is **0** — no query routes yet, so the 62-minute tail costs nothing today
- the backfill that would fix routing *is* the sealed work this diverts away from

And historical derived units are **not share-starved** — measured, all 16 `DerivedRollup` starts in a 10-minute window were today's. A historical day is ineligible until its day-wide `BaseRollup` completes (`dependencies_complete` needs contiguous *Complete* base coverage), so the pipeline is base-day → derived-day, currently filling at ~1 day/15 min.

Shipping this now would slow the thing that actually unblocks the goal.

## When to merge

Once the 1h tier reaches target depth and hybrid hits are non-zero — at which point the raw tail becomes the dominant per-query cost.

## Test

`the_sealed_reservation_yields_while_the_frontier_is_behind` pins both directions: at lag 0 sealed still gets its reserved share; past `FRONTIER_LAG_BUDGET_SECS` every claim goes to the frontier.

770/770 lib tests pass, `cargo lint` clean, `cargo fmt --check` clean.
