### PR TITLE
Reopen the covering slice instead of dropping a late hour

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10045,38 +10045,60 @@ impl Database {
         // a pure re-aggregation of the base tier, so a wider derived file
         // already holds these rows.
         let covered_by_wider = derived
-            && live_adds.iter().any(|add| {
-                let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
-                let (Some(start), Some(end)) = (
-                    tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
-                    tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
-                ) else {
-                    return false;
-                };
-                tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
-                    && (start, end) != (key.slice.start_micros, key.slice.end_micros)
-                    && start <= key.slice.start_micros
-                    && end >= key.slice.end_micros
-            });
-        if covered_by_wider {
-            // Counted because this branch has a hazard we cannot currently
-            // observe. `invalidate` mints derived work at DERIVED_SLICE_MICROS,
-            // so late rows for ONE HOUR inside an already-published day arrive
-            // as an hour-wide unit — and completing it without publishing would
-            // leave that hour stale in the coarse tier, which is a wrong number
-            // rather than a slow one.
+            .then(|| {
+                live_adds.iter().find_map(|add| {
+                    let tag = |name: &str| add.tags.as_ref().and_then(|tags| tags.get(name)).and_then(Option::as_deref);
+                    let (Some(start), Some(end)) = (
+                        tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                        tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+                    ) else {
+                        return None;
+                    };
+                    (tag(crate::maintenance_coordinator::TAG_PROJECT) == Some(key.project_id.as_str())
+                        && (start, end) != (key.slice.start_micros, key.slice.end_micros)
+                        && start <= key.slice.start_micros
+                        && end >= key.slice.end_micros)
+                        .then_some((start, end))
+                })
+            })
+            .flatten();
+        if let Some((covering_start, covering_end)) = covered_by_wider {
+            // ESCALATE. This slice cannot publish — two overlapping files would
+            // both stay live and a dashboard would SUM them — but completing it
+            // silently is the other wrong answer: `invalidate` mints derived
+            // work at DERIVED_SLICE_MICROS, so late rows for ONE HOUR inside an
+            // already-published day arrive as an hour-wide unit, and dropping it
+            // leaves that hour STALE in the coarse tier.
             //
-            // Not "fixed" by reopening the covering slice, because the failure
-            // could not be reproduced: in the one test that builds this shape
-            // the late row lands outside the covering file, and master behaves
-            // identically. Rebuilding a whole day on every hour invalidation is
-            // a real cost to pay against a hazard that may not occur, so
-            // measure first. If this counter moves on prod, the staleness is
-            // reachable and escalation is the fix.
+            // #145 shipped this branch as a counter first, because the failure
+            // could not be reproduced in a test and rebuilding a whole day on
+            // every hour invalidation is a real cost. The counter then moved on
+            // prod (`rollup_skipped_covered_by_wider` = 5 within an hour of
+            // deploying), which is the condition that PR named for making this
+            // change — so the cost is now justified by evidence rather than by
+            // argument.
+            //
+            // Reopening the covering slice rebuilds the whole day, which absorbs
+            // the change; its own replace-set then removes everything it
+            // contains. It terminates: the wider unit publishes at its own
+            // width, so it never re-enters this branch.
             crate::metrics::maintenance_stats().rollup_skipped_covered_by_wider.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Ok(covering) = crate::maintenance_coordinator::TimeSlice::new(covering_start, covering_end) {
+                journal.enqueue(
+                    crate::maintenance_coordinator::TaskKey { slice: covering, ..key.clone() },
+                    crate::clock::now_micros(),
+                    MAX_DECODED_BYTES,
+                    u64::try_from(crate::clock::now_micros().div_euclid(1_000)).unwrap_or_default(),
+                );
+            }
             journal.complete(&key);
             journal.checkpoint()?;
+            info!(
+                table = %key.physical_table, project_id = %key.project_id,
+                slice_start = key.slice.start_micros, covering_start, covering_end,
+                event = "maintenance_rollup_escalated_to_covering_slice"
+            );
             return Ok(true);
         }
         let target_paths = replaced.iter().map(|add| add.path.clone()).collect::<Vec<_>>();

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -2331,6 +2331,38 @@ async fn a_partly_covered_window_unions_the_rollup_with_raw_and_matches_the_raw_
     let after_by_id = rows_of(ctx.sql(&query).await?.collect().await?);
     assert_eq!(hits(), before + 1, "an id-scoped DML on today's row must leave yesterday's coverage intact (misses +{})", misses() - misses_before);
     assert_eq!(after_by_id.iter().map(|row| row.1).sum::<i64>(), 11, "the id-scoped update must not change the counted rows: {after_by_id:?}");
+
+    // LAST, because it writes a new row and would move every count above it.
+    //
+    // A derived slice that cannot publish — a wider live file already covers it
+    // — must REOPEN that covering slice rather than quietly complete.
+    // `invalidate` mints derived work at DERIVED_SLICE_MICROS, so late rows for
+    // one hour inside an already-published day arrive as an hour-wide unit, and
+    // dropping it leaves that hour permanently stale in the coarse tier: a wrong
+    // number, not a slow one. Prod confirmed the branch is reachable —
+    // `rollup_skipped_covered_by_wider` moved to 5 within an hour of shipping
+    // the counter (#145), which is the condition that PR set for doing this.
+    let derived_of = |db: Arc<Database>, project_id: String| async move {
+        let batches = db
+            .query_delta_only(&format!(
+                "SELECT COALESCE(SUM(request_count), 0)::BIGINT FROM otel_logs_and_spans_rollup_dashboard_1h_v2 WHERE project_id = '{project_id}'"
+            ))
+            .await?;
+        Ok::<i64, anyhow::Error>(
+            batches.iter().filter(|b| b.num_rows() > 0).filter_map(|b| b.column(0).as_primitive_opt::<Int64Type>().map(|c| c.value(0))).next().unwrap_or(0),
+        )
+    };
+    let derived_before = derived_of(Arc::clone(&db), project_id.clone()).await?;
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![row("y-late", "cart", 999, yesterday_noon + 90_000_000)?], true, None).await?;
+    db.dedup_today_partitions(&table_ref, "otel_logs_and_spans", "otel_logs_and_spans").await?;
+    timefusion::clock::advance_micros(
+        timefusion::maintenance_coordinator::FINALIZATION_DELAY_MICROS + timefusion::maintenance_coordinator::INVALIDATION_DEADLINE_BUCKET_MICROS + 1,
+    );
+    // Twice: the first drain may escalate, the second rebuilds the covering slice.
+    db.run_maintenance_units(1024).await?;
+    db.run_maintenance_units(1024).await?;
+    let derived_after = derived_of(Arc::clone(&db), project_id.clone()).await?;
+    assert!(derived_after > derived_before, "a late row inside an already-published day must reach the 1h tier (was {derived_before}, now {derived_after})");
     Ok(())
 }
 


### PR DESCRIPTION
**The counter I shipped in #145 did its job.**

#145 deliberately shipped this branch as a *counter* rather than a fix, because the staleness could not be reproduced in a test and rebuilding a whole day on every hour invalidation is a real recurring cost. It named the condition for revisiting:

> *"If `rollup_skipped_covered_by_wider` moves on prod, the staleness is reachable and escalation is the fix."*

It moved — **5 within an hour of deploying**. So the cost is now justified by evidence rather than by argument.

## The bug

A derived slice that cannot publish because a wider live file already covers it was silently marked `Complete`.

- It genuinely **cannot publish itself**: two overlapping files would both stay live and a dashboard would SUM them (#139 measured 10 where 9 was right).
- But completing it silently is the **other** wrong answer. `invalidate` mints derived work at `DERIVED_SLICE_MICROS`, so late rows for one hour inside an already-published day arrive as an hour-wide unit — and dropping it leaves that hour **permanently stale** in the coarse tier.

Stale is a wrong number, not a slow one.

## The fix

Reopen the covering slice. Rebuilding the covering day absorbs the change, and its own replace-set then removes everything it contains. It terminates: the wider unit publishes at its own width, so it never re-enters this branch.

## The test, and why the first attempt was worthless

`a_partly_covered_window_unions_...` now asserts a late row inside an already-published day reaches the 1h tier. **It fails on master and passes here** — verified by reverting `database.rs` to `origin/master` with the test in place.

It had to go at the **end** of the test. My first attempt put it in the middle, where writing a new row shifted every count the later assertions check (12 vs 11), so the test failed for an unrelated reason and looked like it proved nothing about the bug.

965/965 tests pass, `cargo lint` clean, `cargo fmt --check` clean.
