### PR TITLE
Plan file hygiene by debt, not per ten-minute slice

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -20017,7 +20017,13 @@ mod tests {
 
     /// A tenant's first write must not manufacture a full day of empty and
     /// future maintenance debt. One dirty hour is six ten-minute source units
-    /// plus one derived hour; dedup and packing are shared by both rollup specs.
+    /// plus one derived hour; dedup is shared by both rollup specs.
+    ///
+    /// No HotPacking: file hygiene is planned by DEBT in `plan_compaction_debt`
+    /// (one day-wide unit per project, and only when the partition really has
+    /// small or unsorted files), never per slice. Minting it per ten-minute
+    /// slice made it 22% of the prod journal with a count that tracked ingest
+    /// rather than fragmentation.
     #[tokio::test]
     async fn first_rollup_invalidation_enqueues_only_the_touched_hour() -> Result<()> {
         use crate::maintenance_coordinator::Operation;
@@ -20033,8 +20039,8 @@ mod tests {
         assert_eq!(counts.get(&Operation::Dedup), Some(&6));
         assert_eq!(counts.get(&Operation::BaseRollup), Some(&6));
         assert_eq!(counts.get(&Operation::DerivedRollup), Some(&1));
-        assert_eq!(counts.get(&Operation::HotPacking), Some(&6));
-        assert_eq!(journal.tasks().count(), 19, "one touched hour, not 456 full-day tasks");
+        assert_eq!(counts.get(&Operation::HotPacking), None, "ingest must not mint file-hygiene work; the debt planner owns it");
+        assert_eq!(journal.tasks().count(), 13, "one touched hour, not 456 full-day tasks");
         Ok(())
     }
 

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -622,10 +622,9 @@ impl TaskJournal {
         // the "~450 durable tasks per (project, date)" expansion that coarse
         // planning exists to undo. This stops minting them rather than
         // collapsing them afterwards.
-        for (operation, slices) in [
-            (Operation::Dedup, normal_slices.as_slice()),
-            (if derived { Operation::DerivedRollup } else { Operation::BaseRollup }, rollup_slices.as_slice()),
-        ] {
+        for (operation, slices) in
+            [(Operation::Dedup, normal_slices.as_slice()), (if derived { Operation::DerivedRollup } else { Operation::BaseRollup }, rollup_slices.as_slice())]
+        {
             for &slice in slices {
                 let key = TaskKey {
                     physical_table: match operation {

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -602,10 +602,29 @@ impl TaskJournal {
         } else {
             normal_slices.clone()
         };
+        // HotPacking is deliberately NOT here. File hygiene is planned by DEBT,
+        // not by the calendar: `plan_compaction_debt` scans the actual file list
+        // per (project, date) every 60s and mints ONE day-wide unit when the
+        // partition really has small or unsorted files
+        // (`small.len() >= 2 || any !sorted`) — HotPacking for today,
+        // SealedConsolidation once the day seals.
+        //
+        // Minting one per ten-minute slice here duplicated that with 144 units
+        // per project per day whose count tracked ingest rather than
+        // fragmentation. It was 5,367 pending on prod 2026-08-17 — 22% of the
+        // whole journal — for an operation that produces no rollup coverage,
+        // and it is a third of everything the live frontier creates. The
+        // frontier wanted ~7.8 units/min against a total drain of ~11.6.
+        //
+        // The rest of the codebase already treated these as waste:
+        // `migrate_fine_grained_backfill` and `coarsen_sealed_slices` both list
+        // HotPacking as coarsenable, and the comment on the former names it in
+        // the "~450 durable tasks per (project, date)" expansion that coarse
+        // planning exists to undo. This stops minting them rather than
+        // collapsing them afterwards.
         for (operation, slices) in [
             (Operation::Dedup, normal_slices.as_slice()),
             (if derived { Operation::DerivedRollup } else { Operation::BaseRollup }, rollup_slices.as_slice()),
-            (Operation::HotPacking, normal_slices.as_slice()),
         ] {
             for &slice in slices {
                 let key = TaskKey {
@@ -1935,8 +1954,16 @@ mod tests {
                 derived: false,
             })
             .expect("invalidate in next bucket");
-        assert_eq!(journal.tasks().count(), 3);
-        assert!(journal.tasks().any(|task| task.key.operation == Operation::HotPacking));
+        // Two, not three: Dedup and the rollup. HotPacking is planned by DEBT
+        // in `plan_compaction_debt` (one day-wide unit per project, only when
+        // the partition really has small or unsorted files), never per slice —
+        // minting it here made file hygiene 22% of the journal with a count
+        // that tracked ingest rather than fragmentation.
+        assert_eq!(journal.tasks().count(), 2);
+        assert!(
+            journal.tasks().all(|task| task.key.operation != Operation::HotPacking),
+            "ingest must not mint file-hygiene work per slice; the debt planner owns it"
+        );
         assert!(journal.tasks().all(|task| task.deadline_micros == FINALIZATION_DELAY_MICROS + 2 * INVALIDATION_DEADLINE_BUCKET_MICROS));
     }
 


### PR DESCRIPTION
`invalidate` minted a `HotPacking` unit for **every ten-minute slice of ingest** — 144 per project per day, a count that tracked **ingest rate** rather than fragmentation. On prod that is **5,498 pending, 22% of the entire journal**, for an operation that produces no rollup coverage.

## It was already duplicated

`plan_compaction_debt` scans the actual file list per `(project, date)` every 60s and mints **one day-wide unit** when the partition really has small or unsorted files:

```rust
let small = files.iter().filter(|f| f.size < small_target || !f.sorted).collect();
if small.len() >= 2 || small.iter().any(|f| !f.sorted) {
    let operation = if date == today { HotPacking } else { SealedConsolidation };
```

That is the debt-driven planner. The per-slice minting was the calendar-driven one, doing the same job with ~144x the units.

## Why it matters now

It is **a third of everything the live frontier creates**, and the frontier is the binding constraint. `LIVE_FRONTIER_WINDOW_MICROS` is **24 hours**, so class 0 is a full day of slices across ~26 streams — measured at **~7.8 units/min created** against a total drain of ~28/min, with `eligible_watermark_lag_seconds` climbing monotonically to 98 minutes earlier this evening.

Removing it should take frontier creation to ~5.2 units/min.

## The codebase already called these waste

Both `migrate_fine_grained_backfill` and `coarsen_sealed_slices` list `HotPacking` as coarsenable, and the comment on the former names it directly in the "~450 durable tasks per (project, date)" expansion that coarse planning exists to undo. This stops minting them instead of collapsing them afterwards.

`blocks_rollup_backfill` does **not** include `HotPacking`, so nothing gates coverage on these.

## Test

`invalidation_is_idempotent_and_extends_the_quiet_period` now asserts **two** tasks per invalidation (Dedup + the rollup) and that ingest mints no file-hygiene work at all.

966/966 tests pass, `cargo lint` clean, `cargo fmt --check` clean.
