### PR TITLE
Route a query that GROUPS BY project_id instead of filtering on it

### DIFF
--- a/docs/plans/2026-08-18-plan-close-the-latency-goal.md
+++ b/docs/plans/2026-08-18-plan-close-the-latency-goal.md
@@ -1,0 +1,129 @@
+# Plan: close the latency goal
+
+Written 2026-08-18. Supersedes the ad-hoc ordering I had been working to. The
+reordering is driven by one measurement taken tonight, not by a new idea.
+
+## Where we actually are
+
+```
+tasks_pending              25,129   <- pinned at BACKFILL_PENDING_CEILING (25,000)
+pending_base_rollup         9,742
+pending_dedup               6,728
+pending_derived_rollup      1,102
+rollup_min_contiguous_days      0   <- THE goal metric. Unmoved.
+rollup_hits_full_total          0
+rollup_hits_hybrid_total        0
+rollup_misses_total         2,948
+  ...of which missing_project 2,870   <- 97%
+```
+
+Deployed SHA is `5c7259d`; #150-#153 are merged and building.
+
+## The measurement that reorders everything
+
+`rollup_miss_sampled` renders the refused plan. Every sample in the last two
+hours is the SAME query:
+
+```sql
+select project_id::text, count(*)::int8
+from otel_logs_and_spans
+where timestamp >= $1 and timestamp < $2
+group by project_id order by count(*) desc limit $3
+```
+
+It is refused by exactly one line:
+
+```rust
+let project_id = project_id.ok_or(MissReason::MissingProject)?;
+```
+
+Routing demands `project_id = <literal>`. This query does not filter on
+project_id — it **groups by** it. So it falls back to a raw scan of every
+project's rows for the window, and it runs at roughly **24 misses/minute**.
+
+That is the largest single consumer of raw scan bandwidth on the box, it is
+concurrent with maintenance, and it is a strong candidate for "with each spill
+or any random thing queries get slow". I had this shape written down as "the
+slowest query", filed under curiosities. It is 97% of all rollup misses.
+
+## Order of work
+
+### 1. Verify #153 in prod (deploy in flight)
+
+`dirty_decay_ms:0 -> 10000`. RSS is the rollback signal — the premise for the
+original setting was memory pressure, and if RSS climbs materially past the
+~12.6 GB baseline the change comes back out. Then re-run
+`perf record -F 99 -g` and confirm `clear_page_erms` /
+`smp_call_function_many_cond` / `native_queued_spin_lock_slowpath` (~18% of CPU
+combined) have fallen. If they have not, the attribution was wrong and this
+gets reverted rather than kept on a hunch.
+
+### 2. Route the cross-project shape (new, highest value per line)
+
+Generalize routing from "one project_id literal" to "project_id is either
+pinned by an equality filter OR carried as a group-by dimension".
+
+The correctness argument is an intersection:
+
+- resolve coverage per project, as today, for each of the 11 active projects
+- the usable rollup range is the **intersection** of their covered ranges
+- everything outside the intersection is read raw, by the existing hybrid union
+
+So a project with no coverage for a window does not produce an undercount — it
+drags that window into the raw leg, which is exactly today's behaviour. No new
+way to return a wrong number, which is the only property that matters here.
+
+Cost to watch: coverage resolution is per (project, source) and does one pass
+over add actions. Doing it 11 times at plan time could make planning slower than
+the scan it saves for narrow windows. Gate on window width and measure before
+enabling for everything.
+
+**Test first**: a routing unit test asserting the group-by shape routes, plus
+one asserting that a project missing coverage for part of the window pushes that
+part to the raw leg rather than dropping it.
+
+### 3. Dedup: stop decoding each partition K times
+
+Root-caused and documented in
+`2026-08-18-dedup-rescans-the-partition-k-times.md`. K is 84-256. This is the
+throughput unlock for the 25,129-task backlog, and no amount of extra
+concurrency substitutes for it.
+
+Order within this item:
+
+1. **Land the K logging** (`feat/log-dedup-shard-amplification`, pushed, no PR
+   yet) so K is measured in prod before anything is tuned.
+2. **Cheap wins**, both independent of the redesign:
+   - replace SQL `md5()` bucketing with a non-cryptographic hash — 5.71% of all
+     CPU, larger than the ZSTD decompression it exists to serve
+   - re-derive `bytes_per_row = 4096` and `inflation = 12` from measurement.
+     Every 2x of over-estimate is 2x the passes, and neither constant has ever
+     been checked against a real decoded-vs-compressed ratio
+3. **The redesign**: sort-based dedup (shape B) — one scan, `SortExec` (which
+   already spills) on `(dedup keys, tiebreak)`, streaming take-winner-per-key.
+   Removes the bucketing and the MD5 entirely and produces sorted output the
+   writer wants anyway.
+
+Non-negotiable, carried through any rewrite: both
+`dedup_rewrite_counts_match` conservation checks, deletion-vector cardinality
+subtraction, tombstone retention, and all-or-nothing per-shard staging. These
+are what stopped the 2026-08-03 data loss. If the rewrite cannot keep them, it
+does not ship.
+
+### 4. Then, and only then, the goal metric
+
+`rollup_min_contiguous_days` -> 30 for every project including shipbubble, and
+a 30d dashboard query returning under 1s without a raw-scan fallback. Items 2
+and 3 are what make this reachable; chasing it directly is what I have been
+doing, and the queue has been pinned at its ceiling the whole time.
+
+## What I am explicitly not doing
+
+- Not raising `MAX_DECODED_BYTES` to divide K. That decode is outside the memory
+  pool, so it trades CPU for untracked heap — the exact shape of the August OOM
+  series.
+- Not relaxing `dependencies_complete`. A rollup silently missing an hour is a
+  wrong answer, which is worse than a slow one.
+- Not rewriting the dedup path and the estimator in one change. The conservation
+  checks are the only thing standing between a speedup and a data loss, and they
+  need to fail loudly against one variable at a time.

--- a/src/database.rs
+++ b/src/database.rs
@@ -1686,6 +1686,33 @@ fn partition_file_fp(mut files: Vec<String>) -> u64 {
 /// UTC dates covered by a `[lo, hi]` microsecond window, or `None` when the
 /// window is unbounded/invalid/wider than a year (bounds the per-date
 /// fingerprint checks; such queries just keep DedupExec).
+/// Sort and coalesce half-open ranges, merging any that touch or overlap.
+fn merge_ranges(mut ranges: Vec<(i64, i64)>) -> Vec<(i64, i64)> {
+    ranges.sort_unstable();
+    ranges.into_iter().fold(Vec::<(i64, i64)>::new(), |mut merged, range| {
+        match merged.last_mut() {
+            Some(last) if range.0 <= last.1 => last.1 = last.1.max(range.1),
+            _ => merged.push(range),
+        }
+        merged
+    })
+}
+
+/// The overlap of two coalesced range sets. Both inputs must already be sorted
+/// and disjoint — `merge_ranges` guarantees that — so one linear sweep suffices.
+fn intersect_ranges(left: &[(i64, i64)], right: &[(i64, i64)]) -> Vec<(i64, i64)> {
+    let (mut i, mut j, mut out) = (0, 0, Vec::new());
+    while i < left.len() && j < right.len() {
+        let (start, end) = (left[i].0.max(right[j].0), left[i].1.min(right[j].1));
+        if start < end {
+            out.push((start, end));
+        }
+        // Retire whichever range ends first; the other may still meet the next.
+        if left[i].1 < right[j].1 { i += 1 } else { j += 1 }
+    }
+    out
+}
+
 fn window_dates(lo: i64, hi: i64) -> Option<Vec<chrono::NaiveDate>> {
     let lo_d = chrono::DateTime::from_timestamp_micros(lo)?.date_naive();
     let hi_d = chrono::DateTime::from_timestamp_micros(hi)?.date_naive();
@@ -3598,7 +3625,17 @@ impl Database {
         if routes.is_empty() {
             return Ok(None);
         }
-        if !self.config.maintenance.rollup_read_enabled_for(&routes[0].project_id) {
+        // A cross-project route reads every project at once, so a per-project
+        // allowlist cannot be honoured: it is enabled only when the rollout is on
+        // for everyone.
+        let enabled = match routes[0].project_id.as_deref() {
+            Some(project) => self.config.maintenance.rollup_read_enabled_for(project),
+            None => {
+                let maintenance = &self.config.maintenance;
+                maintenance.timefusion_rollup_enabled && maintenance.timefusion_rollup_read_enabled && maintenance.timefusion_rollup_read_projects.is_none()
+            }
+        };
+        if !enabled {
             return Ok(None);
         }
         // Try every viable tier, best first, and take the first one that is
@@ -3627,26 +3664,62 @@ impl Database {
         // so any row still in the MemBuffer is absent from it. That is a bound on
         // how far the rollup may be trusted, not a reason to refuse: everything
         // at or above it is read raw.
-        let buffered = self.buffered_layer().and_then(|layer| layer.min_buffered_micros(&route.project_id, &route.source, route.lo, end));
         let dates = window_dates(route.lo, end).ok_or(crate::rollup::MissReason::IncompleteCoverage)?;
+        // A cross-project route reads the unified table's rollup rows for every
+        // tenant at once, and a project on custom storage lives in a table this
+        // pass never sees — so its coverage would be assumed rather than proved,
+        // and an uncovered day would be served as a silent undercount. Refuse
+        // instead. Custom storage is rare, and the map is tiny.
+        if route.project_id.is_none() && self.custom_storage_keys().await.iter().any(|(_, table)| table == &route.source) {
+            return Err(crate::rollup::MissReason::IncompleteCoverage);
+        }
         // ONE pass over the add actions for the whole window. Asking per date
         // rebuilds the entire add-actions batch each time, which on a table with
         // tens of thousands of files is the dominant cost of planning — a 4-day
         // window paid it four times.
+        let lookup_project = route.project_id.clone().unwrap_or_else(|| "default".to_string());
         let fingerprints = {
-            let table = self.resolve_table(&route.project_id, &route.source).await.map_err(|_| crate::rollup::MissReason::IncompleteCoverage)?;
+            let table = self.resolve_table(&lookup_project, &route.source).await.map_err(|_| crate::rollup::MissReason::IncompleteCoverage)?;
             let table = table.read().await;
-            // Each date is fingerprinted to the bound ITS coverage was built to,
-            // so a day still being written is compared on the part the build
-            // actually read. A date with no coverage gets the whole-partition
+            // Each partition is fingerprinted to the bound ITS coverage was built
+            // to, so a day still being written is compared on the part the build
+            // actually read. A partition with no coverage gets the whole-partition
             // question and simply fails to match below.
-            Self::partition_fingerprints_bounded(&table, tiebreak_of(&route.source), &|date| {
+            Self::partition_fingerprints_bounded(&table, tiebreak_of(&route.source), &|project, date| {
                 self.rollup_coverage
-                    .get(&(route.project_id.clone(), route.source.clone(), route.target.clone(), date.to_string()))
+                    .get(&(project.to_string(), route.source.clone(), route.target.clone(), date.to_string()))
                     .map_or(i64::MAX, |coverage| coverage.covered_through)
             })
             .map_err(|_| crate::rollup::MissReason::IncompleteCoverage)?
         };
+        // Pinned: the one project. Grouped: every project the SOURCE holds data
+        // for in this window — taken from the source, never from the tier, so a
+        // project whose rollup was never built still counts against the coverage
+        // rather than quietly vanishing from the answer.
+        let window_dates: std::collections::HashSet<String> = dates.iter().map(chrono::NaiveDate::to_string).collect();
+        let projects: Vec<String> = match &route.project_id {
+            Some(project) => vec![project.clone()],
+            None => {
+                let mut projects: Vec<String> =
+                    fingerprints.keys().filter(|(_, date)| window_dates.contains(date)).map(|(project, _)| project.clone()).collect();
+                projects.sort_unstable();
+                projects.dedup();
+                projects
+            }
+        };
+        if projects.is_empty() {
+            return Err(crate::rollup::MissReason::NotBuilt);
+        }
+        // A rollup partition is built from Delta files only (`query_delta_only`),
+        // so any row still in the MemBuffer is absent from it. That is a bound on
+        // how far the rollup may be trusted, not a reason to refuse: everything
+        // at or above it is read raw. Across projects the EARLIEST such bound
+        // governs, since one project's buffered rows are missing from the answer
+        // just as surely as another's.
+        let buffered = projects
+            .iter()
+            .filter_map(|project| self.buffered_layer().and_then(|layer| layer.min_buffered_micros(project, &route.source, route.lo, end)))
+            .min();
         let mut generations = Vec::with_capacity(dates.len());
         let mut ticket = Vec::with_capacity(dates.len());
         let mut slice_ticket = Vec::new();
@@ -3657,69 +3730,73 @@ impl Database {
         // The certified SET, not a prefix. A gap in the middle used to discard
         // every later date too, so one stale day made a 7-day query scan 8.4M
         // raw rows while six days sat fully built.
-        let mut covered: Vec<(i64, i64)> = Vec::new();
         let mut miss = None;
-        for date in dates {
-            let date = date.to_string();
-            let key = (route.project_id.clone(), route.source.clone(), route.target.clone(), date.clone());
-            let day_start = date_start_micros(&date).ok_or(crate::rollup::MissReason::IncompleteCoverage)?;
-            // `not_built` and `stale_coverage` are the same outcome but opposite
-            // diagnoses: the first says the build never ran, the second says it
-            // ran and the source moved under it. Collapsed into one reason, the
-            // miss histogram cannot tell a missing cron from a churning
-            // partition, which is the only question a rollout has to answer.
-            let Some(coverage) = self.rollup_coverage.get(&key) else {
-                miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
-                continue;
-            };
-            let source_fp = fingerprints
-                .get(&(route.project_id.clone(), date.clone()))
-                .or_else(|| fingerprints.get(&("default".to_string(), date.clone())))
-                .copied()
-                .unwrap_or_default();
-            let source_epoch = self.rollup_source_epochs.get(&(route.project_id.clone(), route.source.clone(), date.clone())).map_or(0, |entry| *entry.value());
-            if coverage.source_fp != source_fp || coverage.source_epoch != source_epoch {
-                miss = miss.or(Some(crate::rollup::MissReason::StaleCoverage));
-                continue;
+        // One project's covered ranges. The rewrite may only read a range EVERY
+        // project has covered, so these are intersected below — a project missing
+        // a day drags that day into the raw leg instead of being silently omitted
+        // from the answer.
+        let mut per_project: Vec<Vec<(i64, i64)>> = Vec::with_capacity(projects.len());
+        for project in &projects {
+            let mut covered: Vec<(i64, i64)> = Vec::new();
+            for date in &dates {
+                let date = date.to_string();
+                let key = (project.clone(), route.source.clone(), route.target.clone(), date.clone());
+                let day_start = date_start_micros(&date).ok_or(crate::rollup::MissReason::IncompleteCoverage)?;
+                // `not_built` and `stale_coverage` are the same outcome but opposite
+                // diagnoses: the first says the build never ran, the second says it
+                // ran and the source moved under it. Collapsed into one reason, the
+                // miss histogram cannot tell a missing cron from a churning
+                // partition, which is the only question a rollout has to answer.
+                let Some(coverage) = self.rollup_coverage.get(&key) else {
+                    miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
+                    continue;
+                };
+                let source_fp = fingerprints
+                    .get(&(project.clone(), date.clone()))
+                    .or_else(|| fingerprints.get(&("default".to_string(), date.clone())))
+                    .copied()
+                    .unwrap_or_default();
+                let source_epoch = self.rollup_source_epochs.get(&(project.clone(), route.source.clone(), date.clone())).map_or(0, |entry| *entry.value());
+                if coverage.source_fp != source_fp || coverage.source_epoch != source_epoch {
+                    miss = miss.or(Some(crate::rollup::MissReason::StaleCoverage));
+                    continue;
+                }
+                debug!(project_id = %project, source = %route.source, target = %route.target, date, rows = coverage.rows, "rollup coverage selected");
+                // Merge with the previous run when the dates are adjacent, so a
+                // contiguous span costs one range predicate rather than one per day.
+                // The build's OWN bound, not the day end. They are the same for a
+                // sealed partition; for a day still being written the build stops
+                // short, and reading past that point would serve buckets the rollup
+                // never aggregated — the silent-wrong-number failure.
+                let end = coverage.covered_through.min(day_start + DAY_MICROS);
+                if end <= day_start {
+                    miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
+                    continue;
+                }
+                match covered.last_mut() {
+                    Some(last) if last.1 == day_start => last.1 = end,
+                    _ => covered.push((day_start, end)),
+                }
+                generations.push((project.clone(), date.clone(), coverage.generation.clone()));
+                ticket.push((key, source_fp, source_epoch, coverage.generation.clone(), coverage.covered_through));
             }
-            debug!(project_id = %route.project_id, source = %route.source, target = %route.target, date, rows = coverage.rows, "rollup coverage selected");
-            // Merge with the previous run when the dates are adjacent, so a
-            // contiguous span costs one range predicate rather than one per day.
-            // The build's OWN bound, not the day end. They are the same for a
-            // sealed partition; for a day still being written the build stops
-            // short, and reading past that point would serve buckets the rollup
-            // never aggregated — the silent-wrong-number failure.
-            let end = coverage.covered_through.min(day_start + DAY_MICROS);
-            if end <= day_start {
-                miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
-                continue;
+            for entry in self.rollup_slice_coverage.iter() {
+                let ((slice_project, source, target, start, end), coverage) = (entry.key(), entry.value());
+                if slice_project != project || source != &route.source || target != &route.target || *start >= route.hi || *end <= route.lo {
+                    continue;
+                }
+                covered.push((*start, *end));
+                if let Some(date) = chrono::DateTime::from_timestamp_micros(*start).map(|time| time.date_naive().to_string()) {
+                    generations.push((project.clone(), date, coverage.generation.clone()));
+                }
+                slice_ticket.push((entry.key().clone(), coverage.source_fp, coverage.generation.clone()));
             }
-            match covered.last_mut() {
-                Some(last) if last.1 == day_start => last.1 = end,
-                _ => covered.push((day_start, end)),
-            }
-            generations.push((date.clone(), coverage.generation.clone()));
-            ticket.push((key, source_fp, source_epoch, coverage.generation.clone(), coverage.covered_through));
+            per_project.push(merge_ranges(covered));
         }
-        for entry in self.rollup_slice_coverage.iter() {
-            let ((project, source, target, start, end), coverage) = (entry.key(), entry.value());
-            if project != &route.project_id || source != &route.source || target != &route.target || *start >= route.hi || *end <= route.lo {
-                continue;
-            }
-            covered.push((*start, *end));
-            if let Some(date) = chrono::DateTime::from_timestamp_micros(*start).map(|time| time.date_naive().to_string()) {
-                generations.push((date, coverage.generation.clone()));
-            }
-            slice_ticket.push((entry.key().clone(), coverage.source_fp, coverage.generation.clone()));
-        }
-        covered.sort_unstable();
-        covered = covered.into_iter().fold(Vec::<(i64, i64)>::new(), |mut merged, range| {
-            match merged.last_mut() {
-                Some(last) if range.0 <= last.1 => last.1 = last.1.max(range.1),
-                _ => merged.push(range),
-            }
-            merged
-        });
+        // The intersection, so a range is read from the rollup only where every
+        // project proved it. For the pinned case there is one element and this is
+        // exactly the old behaviour.
+        let covered = per_project.into_iter().reduce(|left, right| intersect_ranges(&left, &right)).unwrap_or_default();
         generations.sort_unstable();
         generations.dedup();
         // A buffered row is missing from EVERY rollup partition, whichever dates
@@ -3741,7 +3818,7 @@ impl Database {
         // Drop dates no interval actually reads: keeping them in the ticket would
         // let an unrelated partition's churn invalidate a valid plan.
         let reads = |date: &str| interiors.iter().any(|interval| date_intersects(date, *interval));
-        generations.retain(|(date, _)| reads(date));
+        generations.retain(|(_, date, _)| reads(date));
         ticket.retain(|((_, _, _, date), ..)| reads(date));
         slice_ticket.retain(|((_, _, _, start, end), ..)| interiors.iter().any(|(covered_start, covered_end)| *start < *covered_end && *end > *covered_start));
         if generations.is_empty() {
@@ -9133,7 +9210,7 @@ impl Database {
     async fn rollup_source_fingerprint(&self, project_id: &str, source: &str, date: &str, bound: i64) -> Result<u64> {
         let table = self.resolve_table(project_id, source).await?;
         let table = table.read().await;
-        let mut fingerprints = Self::partition_fingerprints_bounded(&table, tiebreak_of(source), &|_| bound)?;
+        let mut fingerprints = Self::partition_fingerprints_bounded(&table, tiebreak_of(source), &|_, _| bound)?;
         Ok(fingerprints
             .remove(&(project_id.to_string(), date.to_string()))
             .or_else(|| fingerprints.remove(&("default".to_string(), date.to_string())))
@@ -11230,10 +11307,10 @@ impl Database {
     /// timestamps. This is the right question for a SEALED partition, and the
     /// only one the sweep, the backfill's candidate scan and recovery ask.
     fn partition_fingerprints(table: &DeltaTable, tiebreak: Option<&str>) -> Result<HashMap<(String, String), u64>> {
-        Self::partition_fingerprints_bounded(table, tiebreak, &|_| i64::MAX)
+        Self::partition_fingerprints_bounded(table, tiebreak, &|_, _| i64::MAX)
     }
 
-    /// `bound_for` gives, per date, an EXCLUSIVE upper bound on the row
+    /// `bound_for` gives, per (project, date), an EXCLUSIVE upper bound on the row
     /// timestamps a file may contain to be folded in. Files entirely at or above
     /// it are ignored.
     ///
@@ -11243,7 +11320,9 @@ impl Database {
     /// files landing ABOVE the bound change nothing, while a rewrite or a late
     /// file BELOW it still moves the fingerprint and correctly invalidates —
     /// which is the only direction that can serve a wrong number.
-    fn partition_fingerprints_bounded(table: &DeltaTable, tiebreak: Option<&str>, bound_for: &dyn Fn(&str) -> i64) -> Result<HashMap<(String, String), u64>> {
+    fn partition_fingerprints_bounded(
+        table: &DeltaTable, tiebreak: Option<&str>, bound_for: &dyn Fn(&str, &str) -> i64,
+    ) -> Result<HashMap<(String, String), u64>> {
         use std::hash::{Hash, Hasher};
         let snapshot = table.snapshot()?.snapshot();
         let actions = snapshot.add_actions_table(true)?;
@@ -11287,12 +11366,13 @@ impl Database {
             let Some(date) = string_at(&dates, row) else { continue };
             // Custom-project tables carry no `project_id` partition; the sweep
             // groups those under "default", so match it exactly.
-            // A file whose rows all sit at or above this date's bound is not part
-            // of what was aggregated, so it must not perturb the fingerprint.
-            if max_ts.as_ref().and_then(|c| c.is_valid(row).then(|| c.value(row))).is_some_and(|hi| hi >= bound_for(&date)) {
+            let project = string_at(&projects, row).unwrap_or_else(|| "default".to_string());
+            // A file whose rows all sit at or above this partition's bound is not
+            // part of what was aggregated, so it must not perturb the fingerprint.
+            if max_ts.as_ref().and_then(|c| c.is_valid(row).then(|| c.value(row))).is_some_and(|hi| hi >= bound_for(&project, &date)) {
                 continue;
             }
-            let key = (string_at(&projects, row).unwrap_or_else(|| "default".to_string()), date);
+            let key = (project, date);
             let entry = by_partition.entry(key).or_insert((0, i64::MAX, i64::MIN, i64::MIN));
             entry.0 += if records.is_valid(row) { records.value(row) } else { 0 };
             if let Some(lo) = min_ts.as_ref().and_then(|c| c.is_valid(row).then(|| c.value(row))) {
@@ -19902,6 +19982,33 @@ mod tests {
     /// `Instant` has no MAX, and adding `Duration::MAX` overflows.
     fn far_future() -> std::time::Instant {
         std::time::Instant::now() + std::time::Duration::from_secs(86_400)
+    }
+
+    /// The intersection is the whole safety argument for cross-project routing:
+    /// a range one project has not covered must NOT be read from the rollup, or
+    /// that project's rows are silently absent from the answer. An undercount is
+    /// worse than a slow query, and nothing downstream can detect it.
+    #[test]
+    fn a_range_only_one_project_covers_is_not_in_the_intersection() {
+        // Project A covered the whole day; project B only its first half.
+        assert_eq!(intersect_ranges(&[(0, 100)], &[(0, 50)]), vec![(0, 50)]);
+        // Disjoint coverage yields nothing at all — everything goes to the raw leg.
+        assert_eq!(intersect_ranges(&[(0, 40)], &[(60, 100)]), Vec::new());
+        // Touching but not overlapping is still nothing: the ranges are half-open.
+        assert_eq!(intersect_ranges(&[(0, 50)], &[(50, 100)]), Vec::new());
+        // A hole in one side splits the other's single range in two.
+        assert_eq!(intersect_ranges(&[(0, 100)], &[(0, 30), (70, 100)]), vec![(0, 30), (70, 100)]);
+        // One project is the identity case: coverage passes through untouched.
+        assert_eq!(intersect_ranges(&[(10, 20), (30, 40)], &[(10, 20), (30, 40)]), vec![(10, 20), (30, 40)]);
+        // Neither side advances past a range the other still overlaps.
+        assert_eq!(intersect_ranges(&[(0, 100)], &[(10, 20), (30, 40), (90, 200)]), vec![(10, 20), (30, 40), (90, 100)]);
+    }
+
+    #[test]
+    fn merging_ranges_coalesces_what_touches_or_overlaps() {
+        assert_eq!(merge_ranges(vec![(30, 40), (0, 10), (10, 20)]), vec![(0, 20), (30, 40)]);
+        assert_eq!(merge_ranges(vec![(0, 100), (20, 30)]), vec![(0, 100)]);
+        assert_eq!(merge_ranges(Vec::new()), Vec::new());
     }
 
     #[test]

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -666,7 +666,11 @@ pub(crate) fn hybrid_branch_count(lo: i64, hi: i64, ranges: &[(i64, i64)]) -> us
 #[derive(Debug)]
 pub(crate) struct RoutedRollup {
     pub source: String,
-    pub project_id: String,
+    /// The project the query pinned with `project_id = '…'`, or `None` when it
+    /// GROUPS BY project_id instead. `None` means the rewrite reads every
+    /// project's rollup rows, so its coverage must hold for every project with
+    /// source data in the window — see `rollup_rewrite_for`.
+    pub project_id: Option<String>,
     pub lo: i64,
     pub hi: i64,
     /// The query gave no upper bound and `hi` is a plan-time stand-in. The
@@ -743,7 +747,14 @@ impl RoutedRollup {
         let ranges = ranges.iter().map(Self::range_sql).collect::<Vec<_>>().join(" OR ");
         let row_filters = self.row_filters.iter().map(|filter| format!(" AND ({filter})")).collect::<String>();
         let group_by = self.group_by();
-        format!("SELECT {select} FROM {table} WHERE project_id = {} AND ({ranges}){extra}{row_filters}{group_by}", sql_literal(&self.project_id))
+        format!("SELECT {select} FROM {table} WHERE {}({ranges}){extra}{row_filters}{group_by}", self.project_predicate())
+    }
+
+    /// `project_id = '…' AND `, or empty when the query groups by project_id.
+    /// Both legs and the single-leg shape share it so the rollup and raw sides
+    /// can never disagree about which projects they read.
+    fn project_predicate(&self) -> String {
+        self.project_id.as_deref().map_or_else(String::new, |project| format!("project_id = {} AND ", sql_literal(project)))
     }
 
     /// The rewrite. `interior` is the grain-aligned `[a, b)` the rollup leg owns;
@@ -753,12 +764,20 @@ impl RoutedRollup {
     /// When the interior is the whole window this collapses to a single
     /// statement against the rollup table, which is both cheaper and the shape
     /// the aligned fast path has always emitted.
-    pub fn sql(&self, generations: &[(String, String)], interiors: &[(i64, i64)]) -> String {
+    pub fn sql(&self, generations: &[(String, String, String)], interiors: &[(i64, i64)]) -> String {
         let generations = format!(
             " AND ({})",
             generations
                 .iter()
-                .map(|(date, generation)| format!("(date = {} AND rollup_generation = {})", sql_literal(date), sql_literal(generation)))
+                // A generation id hashes the project, so a cross-project rewrite
+                // cannot name one per date — it must name one per (project,
+                // date) or it would accept another project's generation for the
+                // same day.
+                .map(|(project, date, generation)| match self.project_id {
+                    Some(_) => format!("(date = {} AND rollup_generation = {})", sql_literal(date), sql_literal(generation)),
+                    None =>
+                        format!("(project_id = {} AND date = {} AND rollup_generation = {})", sql_literal(project), sql_literal(date), sql_literal(generation)),
+                })
                 .collect::<Vec<_>>()
                 .join(" OR ")
         );
@@ -780,9 +799,9 @@ impl RoutedRollup {
             let group_by = self.group_by();
             let having = self.guard.as_ref().map_or_else(String::new, |guard| format!(" HAVING {} > 0", guard.merge.sql(&guard.measures)));
             return format!(
-                "SELECT {select} FROM {} WHERE project_id = {} AND ({}){generations}{row_filters}{group_by}{having}",
+                "SELECT {select} FROM {} WHERE {}({}){generations}{row_filters}{group_by}{having}",
                 self.target,
-                sql_literal(&self.project_id),
+                self.project_predicate(),
                 interiors.iter().map(Self::range_sql).collect::<Vec<_>>().join(" OR "),
             );
         }
@@ -1347,7 +1366,14 @@ async fn route_with_spec(
             (None, None) => promotable.push(term),
         }
     }
-    let project_id = project_id.ok_or(MissReason::MissingProject)?;
+    // A query that neither pins nor groups by project_id would fold every
+    // tenant into one row, so it stays refused. Grouping by it is answerable:
+    // project_id is a real column on the rollup table, and the coverage check
+    // downstream then has to hold for every project in the window rather than
+    // for one.
+    if project_id.is_none() && !aggregate.group_expr.iter().any(|expr| column_name(expr) == Some("project_id")) {
+        return Err(MissReason::MissingProject);
+    }
     // A dashboard panel writes its window as `timestamp >= now() - interval 'N
     // days'` and stops there. Demanding an upper bound sent every such query —
     // the wide ones, the only kind worth accelerating — to a full raw scan.
@@ -1374,7 +1400,12 @@ async fn route_with_spec(
     if too_narrow && promotable.is_empty() {
         return Err(MissReason::TinyInterior);
     }
-    let configured_filters = measure_filters(session, source, spec, &project_id, lo, hi).await?;
+    // The probe's project literal is scaffolding the canonicalizer strips back
+    // out — it exists only to satisfy the scan admission guard, and the result
+    // is memoized across every caller. A cross-project query has no literal to
+    // give it, and any value satisfies the guard's SHAPE check.
+    let probe_project = project_id.as_deref().unwrap_or("rollup-probe");
+    let configured_filters = measure_filters(session, source, spec, probe_project, lo, hi).await?;
 
     // ROW-FILTER PROMOTION. A residual predicate is normally fatal: the rollup
     // aggregated over every row, so re-aggregating it resurrects the groups the
@@ -1459,7 +1490,10 @@ async fn route_with_spec(
     for (index, expression) in aggregate.group_expr.iter().enumerate() {
         let alias = aggregate.schema.field(index).name();
         let expression = match unaliased(expression) {
-            Expr::Column(column) if spec.dimensions.iter().any(|dimension| dimension == &column.name) => column.name.clone(),
+            // `project_id` is not a declared dimension — it is the partition
+            // column, written on every rollup row by `to_rollup_batches` — but
+            // it groups exactly like one.
+            Expr::Column(column) if column.name == "project_id" || spec.dimensions.iter().any(|dimension| dimension == &column.name) => column.name.clone(),
             Expr::ScalarFunction(function)
                 if function.name().eq_ignore_ascii_case("time_bucket") && function.args.len() == 2 && column_name(&function.args[1]) == Some("timestamp") =>
             {
@@ -1916,14 +1950,14 @@ mod tests {
 
     /// The rewrite when the rollup owns the whole window — the single-leg shape.
     fn generated_sql(route: &RoutedRollup) -> String {
-        route.sql(&[("1970-01-01".into(), "generation".into())], &[(route.lo, route.hi)])
+        route.sql(&[("project".into(), "1970-01-01".into(), "generation".into())], &[(route.lo, route.hi)])
     }
 
     /// The rewrite when only part of the window is certified, so raw fringes and
     /// a live tail are unioned in.
     fn hybrid_sql(route: &RoutedRollup, horizon: i64) -> String {
         let interior = interior(route.lo, route.hi, route.grain, horizon).expect("a routable interior");
-        route.sql(&[("1970-01-01".into(), "generation".into())], &[interior])
+        route.sql(&[("project".into(), "1970-01-01".into(), "generation".into())], &[interior])
     }
 
     #[tokio::test]
@@ -1934,8 +1968,43 @@ mod tests {
             .expect("match count")
             .expect("declared rollup route");
         assert_eq!(route.target, TARGET);
-        assert_eq!(route.project_id, "project");
+        assert_eq!(route.project_id.as_deref(), Some("project"));
         assert!(generated_sql(&route).contains("COALESCE(SUM(request_count), 0)"));
+    }
+
+    /// The single largest source of rollup misses in production: monoscope's
+    /// cross-project overview, which GROUPS BY project_id instead of filtering
+    /// on it. 2026-08-18 measured 2,870 of 2,948 misses (97%) as
+    /// `missing_project`, and every sampled plan was this one shape — so it fell
+    /// back to a raw scan of every project's rows roughly 24 times a minute.
+    ///
+    /// `project_id` is a real column on the rollup table (`to_rollup_batches`
+    /// writes it), so grouping by it is answerable; only the demand for an
+    /// equality literal stood in the way.
+    #[tokio::test]
+    async fn a_query_grouping_by_project_id_routes_without_an_equality_filter() {
+        let state = session().await;
+        let sql = format!("SELECT project_id, COUNT(*) FROM {SOURCE} WHERE {WINDOW} GROUP BY 1");
+        let route = route_for(&state, &sql).await.expect("match count").expect("declared rollup route");
+        assert_eq!(route.project_id, None, "no equality filter pins a project");
+        let generated = generated_sql(&route);
+        assert!(!generated.contains("WHERE project_id ="), "a cross-project rewrite must not pin one project: {generated}");
+        assert!(generated.contains("SELECT project_id AS"), "project_id must survive as a group key: {generated}");
+        // A generation id hashes the project, so the generation predicate must
+        // name one per (project, date) rather than accepting any project's
+        // generation for the day.
+        assert!(generated.contains("(project_id = 'project' AND date = '1970-01-01'"), "generations must be qualified by project: {generated}");
+        assert_substitutes(&state, &sql, None).await;
+    }
+
+    /// Grouping by project_id is what makes the query answerable; merely
+    /// omitting the filter does not. Without a group key the rewrite would
+    /// silently fold every project into one row.
+    #[tokio::test]
+    async fn a_query_with_neither_a_project_filter_nor_a_project_group_is_refused() {
+        let state = session().await;
+        let miss = route_for(&state, &format!("SELECT COUNT(*) FROM {SOURCE} WHERE {WINDOW}")).await.expect_err("must be refused");
+        assert!(matches!(miss, MissReason::MissingProject), "expected MissingProject, got {miss:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
97% of production's rollup misses were one refused query shape.

Sampling `rollup_miss_sampled` on 2026-08-18 gave **2,870 of 2,948** misses as `missing_project`, and every rendered plan was monoscope's cross-project overview:

```sql
select project_id::text, count(*)::int8 from otel_logs_and_spans
where timestamp >= $1 and timestamp < $2
group by project_id order by count(*) desc limit $3
```

One line refused it — routing demanded `project_id = '<literal>'`. So it fell back to a raw scan of every project's rows for the window, roughly **24 times a minute**, concurrent with maintenance. That makes it the largest single consumer of raw scan bandwidth on the box.

Grouping by project_id is answerable: project_id is a real column on every rollup row (`to_rollup_batches` writes it). A query that neither pins nor groups by it stays refused — that one would fold every tenant into a single row.

## The safety argument is an intersection

A cross-project rewrite reads every project's rollup rows at once, so it may only read a range **every** project has covered. `intersect_ranges` folds the per-project coverage; anything outside the result falls to the existing raw leg. A project missing a day costs a raw scan of that day, never a silent undercount — which nothing downstream could detect.

Four further edges, each of which would otherwise give a wrong number rather than a slow one:

- a generation id hashes the project, so the generation predicate names one per (project, date) rather than accepting any project's generation for the day
- the project set comes from the SOURCE table's partitions, never from the tier, so a project whose rollup was never built still counts against coverage instead of vanishing
- a project on custom storage lives in a table this pass never sees, so its coverage could only be assumed — the cross-project route refuses outright when any custom-storage project exists for the source
- the buffered-rows horizon takes the EARLIEST bound across projects, and a per-project read allowlist cannot be honoured by a query reading them all, so this route requires the rollout to be on for everyone

## Tests

`a_query_grouping_by_project_id_routes_without_an_equality_filter` (the prod shape, including that generations stay project-qualified), `a_query_with_neither_a_project_filter_nor_a_project_group_is_refused`, and `a_range_only_one_project_covers_is_not_in_the_intersection` covering the partial, disjoint, half-open-touching, holey and identity cases.

775/775 lib tests pass from a clean journal; `cargo lint` and `cargo fmt` clean.