### PR TITLE
Bucket dedup shards with a fast hash instead of md5

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2388,7 +2388,7 @@ pub struct MaintenanceConfig {
     #[serde(default = "d_true")]
     pub timefusion_count_pushdown: bool,
     /// Per-shard COMPRESSED-bytes target for a dedup chunk rewrite (`sum(add.size)`).
-    /// The rewrite is split into `ceil(compressed_bytes / this)` md5-bucketed passes
+    /// The rewrite is split into `ceil(compressed_bytes / this)` hash-bucketed passes
     /// so each pass reads ~this much. 0 disables this ceiling's contribution to the
     /// shard count. See `d_dedup_max_rewrite_bytes`.
     #[serde(default = "d_dedup_max_rewrite_bytes")]
@@ -2398,7 +2398,7 @@ pub struct MaintenanceConfig {
     /// Variant/JSON columns, and the `SELECT * … collect()` Arrow buffers are NOT
     /// accounted by DataFusion's memory pool — so a compressed-under-budget chunk
     /// once decoded to tens of GB and OOM-killed the process (prod 2026-07-04, 89GB
-    /// cgroup kill). The rewrite now SHARDS by an md5 hash of the dedup keys into
+    /// cgroup kill). The rewrite now SHARDS by a hash of the dedup keys into
     /// `ceil(est_decoded / this)` passes so each pass materializes ~this much; a
     /// single key group that alone exceeds this is unshardable and skipped (read-side
     /// dedup keeps queries correct). 0 → one shard for this ceiling. See

--- a/src/database.rs
+++ b/src/database.rs
@@ -893,7 +893,17 @@ fn build_optimize_session_state_tuned(
     // `runtime_env` is the dedicated bounded maintenance pool (see
     // `maintenance_runtime_env`): allocations still fail as errors rather than
     // OOM-killing the process, but are isolated from query pressure and can spill.
-    SessionStateBuilder::new().with_config(cfg).with_runtime_env(runtime_env).with_default_features().build()
+    let mut state = SessionStateBuilder::new().with_config(cfg).with_runtime_env(runtime_env).with_default_features().build();
+    // `hash_bucket` is ours, not a DataFusion builtin, and the sharded dedup
+    // rewrite and the maintenance slice builder both put it in generated SQL.
+    // These states are built bare — no `register_custom_functions` — so without
+    // this every sharded rewrite fails to PLAN. That is exactly what happened
+    // when the bucketing moved off `md5` (a builtin, so it had worked in every
+    // context): `dedup_shards_over_budget_and_preserves_rows` failed with
+    // "Invalid function 'hash_bucket'". Registered on the one builder every
+    // maintenance context goes through rather than at each call site.
+    datafusion::execution::FunctionRegistry::register_udf(&mut state, Arc::new(crate::functions::hash_bucket_udf())).ok();
+    state
 }
 
 /// Days of rollup coverage counting back from yesterday with NO hole, minimised
@@ -8565,11 +8575,11 @@ impl Database {
                     filter.clone()
                 } else {
                     let keys_varchar = schema.dedup_keys.iter().map(|key| format!("CAST(\"{key}\" AS VARCHAR)")).collect::<Vec<_>>().join(", ");
-                    let bucket_expr = format!("substr(md5(concat_ws(chr(31), {keys_varchar})), 1, 2)");
+                    let bucket_expr = format!("hash_bucket(arrow_cast(concat_ws(chr(31), {keys_varchar}), 'Utf8View'), {DEDUP_BUCKET_COUNT})");
                     let lo = u64::try_from(shard).unwrap_or(u64::MAX).saturating_mul(DEDUP_BUCKET_COUNT) / u64::try_from(probe_shards).unwrap_or(1);
                     let hi = u64::try_from(shard + 1).unwrap_or(u64::MAX).saturating_mul(DEDUP_BUCKET_COUNT) / u64::try_from(probe_shards).unwrap_or(1);
-                    let upper = if hi < DEDUP_BUCKET_COUNT { format!(" AND {bucket_expr} < '{hi:02x}'") } else { String::new() };
-                    format!("{filter} AND {bucket_expr} >= '{lo:02x}'{upper}")
+                    let upper = if hi < DEDUP_BUCKET_COUNT { format!(" AND {bucket_expr} < {hi}") } else { String::new() };
+                    format!("{filter} AND {bucket_expr} >= {lo}{upper}")
                 };
                 duplicate_starts.extend(Self::dup_bin_starts(&ctx, &shard_filter, &keys_csv).await?);
             }
@@ -8791,9 +8801,10 @@ impl Database {
             // 3. Decide the shard count. A dedup `SELECT * … collect()` decodes to
             // Arrow at 5-20× compressed OUTSIDE the memory pool, so an over-budget
             // chunk used to be skipped (dupe left forever). Instead we split the
-            // rewrite into K passes bucketed by an md5 hash of the dedup keys — every
-            // copy of a key hashes to one bucket (never split), and md5 (not `key % K`,
-            // which collides for ms-aligned values) spreads evenly and is NULL-safe.
+            // rewrite into K passes bucketed by a hash of the dedup keys — every
+            // copy of a key hashes to one bucket (never split), and hashing (not
+            // `key % K`, which collides for ms-aligned values) spreads evenly and is
+            // NULL-safe.
             // K = ceil(estimated decoded bytes / budget); the estimate is the
             // row-count-vs-inflation MAX ×2 documented on the config fields.
             let rewrite_bytes: i64 = targets.iter().map(|a| a.size).sum();
@@ -8831,11 +8842,16 @@ impl Database {
                 .saturating_mul(2); // RowConverter keyed copy in dedup_batches
             let shards = dedup_shard_count(est_decoded_bytes, rewrite_bytes.max(0) as u64, decoded_budget, compressed_budget);
             let in_list = file_ids.iter().map(|v| format!("'{}'", v.replace('\'', "''"))).collect::<Vec<_>>().join(", ");
-            // Bucket = first byte of md5 over the dedup keys (2 hex chars =
-            // DEDUP_BUCKET_COUNT buckets, evenly spread); chr(31) separates keys so
-            // distinct tuples can't collide. Also the GROUP BY for the skew probe below.
+            // Bucket = `hash_bucket` over the dedup keys, in `[0, DEDUP_BUCKET_COUNT)`
+            // and evenly spread; chr(31) separates keys so distinct tuples can't
+            // collide. Also the GROUP BY for the skew probe below.
+            //
+            // This was `substr(md5(…), 1, 2)` until 2026-08-18, when a live CPU
+            // profile put `md5::compress` at 5.71% of all CPU — larger than the ZSTD
+            // decompression it serves, because each of K passes hashes every row to
+            // keep 1/K of them.
             let keys_varchar = schema.dedup_keys.iter().map(|k| format!("CAST(\"{k}\" AS VARCHAR)")).collect::<Vec<_>>().join(", ");
-            let bucket_expr = format!("substr(md5(concat_ws(chr(31), {keys_varchar})), 1, 2)");
+            let bucket_expr = format!("hash_bucket(arrow_cast(concat_ws(chr(31), {keys_varchar}), 'Utf8View'), {DEDUP_BUCKET_COUNT})");
             // Independent narrow oracle for the staged output count. The
             // Arrow rewrite below chooses the greatest tiebreak per key, but it
             // must still emit exactly one row per distinct key (tombstones are
@@ -8920,8 +8936,8 @@ impl Database {
                                 // Contiguous bucket range per shard (even ±1); string compare of
                                 // zero-padded lowercase hex == numeric order.
                                 let (lo, hi) = (shard * DEDUP_BUCKET_COUNT / shards, (shard + 1) * DEDUP_BUCKET_COUNT / shards);
-                                let upper = if hi < DEDUP_BUCKET_COUNT { format!(" AND {bucket_expr} < '{hi:02x}'") } else { String::new() };
-                                format!(" AND {bucket_expr} >= '{lo:02x}'{upper}")
+                                let upper = if hi < DEDUP_BUCKET_COUNT { format!(" AND {bucket_expr} < {hi}") } else { String::new() };
+                                format!(" AND {bucket_expr} >= {lo}{upper}")
                             } else {
                                 String::new()
                             };
@@ -9971,7 +9987,11 @@ impl Database {
                 std::iter::once("project_id".to_owned()).chain(std::iter::once("timestamp".to_owned())).chain(spec.dimensions.iter().cloned()).collect();
         }
         let shard_key_sql = shard_keys.iter().map(|field| format!("CAST(\"{}\" AS VARCHAR)", field.replace('"', "\"\""))).collect::<Vec<_>>().join(", ");
-        let shard_hash = format!("substr(md5(concat_ws(chr(31), {shard_key_sql})), 1, 4)");
+        // Same reasoning as the dedup rewrite's bucketing: an even, stable spread
+        // is all this needs, and a cryptographic digest evaluated per row is not
+        // free — see `hash_bucket`.
+        const MAINTENANCE_SLICE_BUCKETS: u64 = 65_536;
+        let shard_hash = format!("hash_bucket(arrow_cast(concat_ws(chr(31), {shard_key_sql}), 'Utf8View'), {MAINTENANCE_SLICE_BUCKETS})");
         let mut shard_states = Vec::new();
         let mut aggregate = Vec::new();
         for shard in 0..hash_shards {
@@ -9979,10 +9999,10 @@ impl Database {
             let shard_predicate = if hash_shards == 1 {
                 String::new()
             } else {
-                let lo = shard * 65_536 / hash_shards;
-                let hi = (shard + 1) * 65_536 / hash_shards;
-                let upper = if hi < 65_536 { format!(" AND {shard_hash} < '{hi:04x}'") } else { String::new() };
-                format!(" AND {shard_hash} >= '{lo:04x}'{upper}")
+                let lo = shard * MAINTENANCE_SLICE_BUCKETS / hash_shards;
+                let hi = (shard + 1) * MAINTENANCE_SLICE_BUCKETS / hash_shards;
+                let upper = if hi < MAINTENANCE_SLICE_BUCKETS { format!(" AND {shard_hash} < {hi}") } else { String::new() };
+                format!(" AND {shard_hash} >= {lo}{upper}")
             };
             let input_sql = if derived || source_schema.dedup_keys.is_empty() {
                 format!(
@@ -14986,8 +15006,8 @@ fn build_query_runtime_env(
 ///
 /// Footer honesty is tied to the returned bool — never assumed. A single batch
 /// skips the concat copy; an already-ordered batch skips the `take` copy.
-/// Number of md5-prefix buckets the sharded dedup rewrite hashes into — the first
-/// digest byte, i.e. 2 hex chars. Shard count is clamped to this: shards partition
+/// Number of buckets the sharded dedup rewrite hashes into (`hash_bucket`).
+/// Shard count is clamped to this: shards partition
 /// `[0, DEDUP_BUCKET_COUNT)` into contiguous ranges, so more shards than buckets
 /// would leave rows uncovered. Doubles as a runaway-shard-count backstop.
 const DEDUP_BUCKET_COUNT: u64 = 256;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -456,6 +456,7 @@ pub fn register_custom_functions(ctx: &mut datafusion::execution::context::Sessi
     ctx.register_udaf(AggregateUDF::from(HllAggUDF::default()));
     ctx.register_udaf(create_hll_merge_udaf());
     ctx.register_udf(create_hll_count_udf());
+    ctx.register_udf(hash_bucket_udf());
 
     // text_match(col, 'query') for tantivy-accelerated full-text search. Naive
     // substring fallback keeps correctness when tantivy is disabled or when
@@ -1513,6 +1514,114 @@ fn create_hll_count_udf() -> ScalarUDF {
         }) as ScalarFunctionImplementation,
     )
     .with_aliases(["distinct_count"])
+}
+
+/// `hash_bucket(text, n)` — a stable, evenly-spread bucket in `[0, n)`.
+///
+/// The sharded dedup rewrite used `substr(md5(…), 1, 2)` for this. A live CPU
+/// profile on 2026-08-18 put `md5::compress` at **5.71% of all CPU**, larger
+/// than the ZSTD decompression it exists to serve, because each of K passes
+/// hashes every row to keep 1/K of them. Bucketing needs an even, stable spread
+/// — not a cryptographic digest — so this uses the same non-cryptographic mixer
+/// the HLL sketches already hash with.
+///
+/// NULL hashes as the empty string rather than to NULL: a NULL bucket satisfies
+/// neither `>= lo` nor `< hi`, so such a row would silently fall out of every
+/// shard.
+pub fn hash_bucket_udf() -> ScalarUDF {
+    create_udf(
+        "hash_bucket",
+        vec![DataType::Utf8View, DataType::Int64],
+        DataType::Int64,
+        Volatility::Immutable,
+        Arc::new(|args: &[ColumnarValue]| {
+            let [value, buckets] = args else {
+                return Err(DataFusionError::Execution("hash_bucket requires exactly 2 arguments: value and bucket count".to_string()));
+            };
+            let buckets = match buckets {
+                ColumnarValue::Scalar(scalar) => i64::try_from(scalar.clone()).unwrap_or(0),
+                _ => return Err(DataFusionError::Execution("hash_bucket's bucket count must be a literal".to_string())),
+            };
+            let buckets = u64::try_from(buckets).ok().filter(|n| *n > 0).ok_or_else(|| {
+                // A zero count would divide by zero; a negative one is a caller bug.
+                DataFusionError::Execution("hash_bucket's bucket count must be positive".to_string())
+            })?;
+            let array = as_array(value)?;
+            let strings = array
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .ok_or_else(|| DataFusionError::Execution(format!("hash_bucket expects a Utf8View value, got {}", array.data_type())))?;
+            let buckets: Int64Array =
+                strings.iter().map(|value| Some((crate::hll::hash_bytes(value.unwrap_or_default().as_bytes()) % buckets) as i64)).collect();
+            Ok(ColumnarValue::Array(Arc::new(buckets)))
+        }) as ScalarFunctionImplementation,
+    )
+}
+
+#[cfg(test)]
+mod hash_bucket_tests {
+    use datafusion::prelude::SessionContext;
+
+    /// Bucketing is only correct if it PARTITIONS: every row lands in exactly one
+    /// bucket of `[0, n)`, and equal keys always land together — that is what lets
+    /// the dedup rewrite process one shard at a time without splitting a key's
+    /// copies across passes.
+    #[tokio::test]
+    async fn hash_bucket_partitions_and_keeps_equal_keys_together() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(super::hash_bucket_udf());
+        let one = |sql: &str| {
+            let ctx = ctx.clone();
+            let sql = sql.to_string();
+            async move {
+                let batches = ctx.sql(&sql).await.expect("plan").collect().await.expect("run");
+                datafusion::arrow::util::pretty::pretty_format_batches(&batches).expect("format").to_string()
+            }
+        };
+        // In range, and the same input always gives the same bucket.
+        let rendered = one("SELECT hash_bucket(arrow_cast(v, 'Utf8View'), 256) AS b FROM (VALUES ('a'), ('a'), ('b')) AS t(v)").await;
+        let buckets: Vec<i64> = rendered.lines().filter_map(|line| line.trim_matches(|c: char| c == '|' || c.is_whitespace()).parse::<i64>().ok()).collect();
+        assert_eq!(buckets.len(), 3, "three rows: {rendered}");
+        assert!(buckets.iter().all(|b| (0..256).contains(b)), "every bucket in range: {buckets:?}");
+        assert_eq!(buckets[0], buckets[1], "equal keys must share a bucket");
+        // NULL must not vanish: it buckets as the empty string, not as NULL.
+        let rendered = one("SELECT hash_bucket(arrow_cast(NULL, 'Utf8View'), 256) AS b").await;
+        assert!(!rendered.contains("NULL"), "NULL must bucket, not propagate: {rendered}");
+    }
+
+    /// A row that hashes outside every shard's range is a row the rewrite never
+    /// reads and never rewrites — silent data loss that the conservation checks
+    /// would only catch after the work was done. Spread matters too: a skewed
+    /// bucketing makes one shard carry the memory the split existed to avoid.
+    #[tokio::test]
+    async fn hash_bucket_spreads_evenly_enough_to_shard_on() {
+        let ctx = SessionContext::new();
+        ctx.register_udf(super::hash_bucket_udf());
+        let batches = ctx
+            .sql(
+                "SELECT count(*) AS n, count(DISTINCT hash_bucket(arrow_cast(v, 'Utf8View'), 256)) AS distinct_buckets, \
+                 min(hash_bucket(arrow_cast(v, 'Utf8View'), 256)) AS lo, max(hash_bucket(arrow_cast(v, 'Utf8View'), 256)) AS hi \
+                 FROM (SELECT CAST(i AS VARCHAR) AS v FROM generate_series(1, 5000) AS t(i))",
+            )
+            .await
+            .expect("plan")
+            .collect()
+            .await
+            .expect("run");
+        let rendered = datafusion::arrow::util::pretty::pretty_format_batches(&batches).expect("format").to_string();
+        // The one data row renders as `| n | distinct | lo | hi |`; every other
+        // line is a border or the header.
+        let row = rendered
+            .lines()
+            .find_map(|line| {
+                let cells: Vec<i64> = line.split('|').filter_map(|cell| cell.trim().parse::<i64>().ok()).collect();
+                (cells.len() == 4).then_some(cells)
+            })
+            .unwrap_or_else(|| panic!("one four-column data row: {rendered}"));
+        assert_eq!(row[0], 5000, "all rows counted: {rendered}");
+        assert_eq!(row[1], 256, "5000 keys must reach every one of 256 buckets: {rendered}");
+        assert!((0..256).contains(&row[2]) && (0..256).contains(&row[3]), "bounds inside [0, 256): {rendered}");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A live CPU profile of the prod process on 2026-08-18 (83,399 samples, 23 of 48 cores busy) put `md5::compress` at **5.71% of all CPU** — larger than `ZSTD_decompressSequences_bmi2` at 3.20%, the decompression it exists to serve.

The call graph puts it under `FilterExecStream`: DataFusion's SQL `md5()`, evaluated per row inside a filter. That filter is the dedup rewrite's shard predicate. A rewrite is split into K passes bucketed by `substr(md5(concat_ws(chr(31), <keys>)), 1, 2)`; each pass scans the same files and hashes every row to keep 1/K of them. K reaches 84–256 for a large partition, so the digest is computed K times per row.

Bucketing needs an even, stable, NULL-safe spread — not a cryptographic digest. `hash_bucket(value, n)` uses the same non-cryptographic mixer the HLL sketches already hash with and returns an integer, so shard predicates compare numbers rather than zero-padded hex. The maintenance slice builder's 65,536-way `substr(md5(…), 1, 4)` sharding moves for the same reason.

**This does not reduce K** — that is the separate redesign in `docs/plans/2026-08-18-dedup-rescans-the-partition-k-times.md`. It makes each of the K passes cheaper.

## The trap this hit

`hash_bucket` is ours, not a builtin. Maintenance session states are built bare, so registering it only in `register_custom_functions` left every sharded rewrite failing to **plan**. `dedup_shards_over_budget_and_preserves_rows` caught it ("Invalid function 'hash_bucket'") — `md5` is a DataFusion builtin and had therefore worked in every context, so nothing else would have. It is now registered on `build_optimize_session_state_tuned`, the one builder every maintenance context goes through.

## Tests

The properties sharding depends on: every row lands in exactly one bucket of [0, n); equal keys always share a bucket; NULL buckets as the empty string rather than propagating to NULL (a NULL bucket satisfies neither bound and would drop the row from every shard); 5,000 keys reach all 256 buckets.

973/973 tests pass (full suite, clean journal); `cargo lint` and `cargo fmt` clean.