### PR TITLE
Log what a dedup shard actually decoded to, against the estimate

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9086,9 +9086,11 @@ impl Database {
                                 );
                                 let mut stream = ctx.sql(&sql).await?.execute_stream().await?;
                                 let mut shard_after = 0usize;
+                                let mut decoded_bytes = 0usize;
                                 while let Some(batch) = stream.next().await {
                                     let batch = cast_variant_columns_to_binary(batch?)?;
                                     shard_after = shard_after.saturating_add(batch.num_rows());
+                                    decoded_bytes = decoded_bytes.saturating_add(batch.get_array_memory_size());
                                     let casted = deltalake::kernel::schema::cast_record_batch(&batch, target_schema.clone(), true, true)?;
                                     writer.write(casted).await.map_err(|e| anyhow::anyhow!("dedup rewrite stage: {e}"))?;
                                     if writer.buffer_len() >= max_file_bytes {
@@ -9097,11 +9099,46 @@ impl Database {
                                         );
                                     }
                                 }
+                                // The coordinator takes this streaming branch, so the
+                                // collecting branch's identical probe below would never fire in
+                                // production. Post-dedup rows, so this UNDER-states the input
+                                // volume — a ratio at or above the estimate is therefore
+                                // conclusive, one below it is not.
+                                if shard == 0 {
+                                    info!(
+                                        shards,
+                                        rows = shard_after,
+                                        actual_decoded_mb = decoded_bytes / (1 << 20),
+                                        predicted_decoded_mb = (est_decoded_bytes / shards.max(1)) / (1 << 20),
+                                        event = "dedup_shard_decoded",
+                                        stage = "streamed",
+                                        "what one dedup shard decoded to, against what the estimate predicted"
+                                    );
+                                }
                                 (shard_before, shard_after)
                             } else {
                                 let batches: Vec<RecordBatch> =
                                     ctx.sql(&rows_sql).await?.collect().await?.into_iter().map(|batch| drop_batch_column(batch, DEDUP_FILE_COL)).collect();
                                 let shard_before = batches.iter().map(RecordBatch::num_rows).sum();
+                                // K is driven entirely by `est_decoded_bytes`, and every 2x of
+                                // over-estimate is a whole extra pass over the data. Neither
+                                // `bytes_per_row = 4096` nor `inflation = 12` has ever been
+                                // checked against a real decoded-vs-compressed ratio, so log
+                                // what this shard ACTUALLY decoded to next to what was
+                                // predicted for it. One shard, not all K, so a 256-way rewrite
+                                // cannot flood the log.
+                                if shard == 0 {
+                                    let actual: usize = batches.iter().map(RecordBatch::get_array_memory_size).sum();
+                                    info!(
+                                        shards,
+                                        rows = shard_before,
+                                        actual_decoded_mb = actual / (1 << 20),
+                                        predicted_decoded_mb = (est_decoded_bytes / shards.max(1)) / (1 << 20),
+                                        event = "dedup_shard_decoded",
+                                        stage = "collected",
+                                        "what one dedup shard decoded to, against what the estimate predicted"
+                                    );
+                                }
                                 if shard_before == 0 {
                                     return Ok((0, 0));
                                 }


### PR DESCRIPTION
K — the number of times the dedup rewrite rescans a partition — is driven entirely by `est_decoded_bytes`:

```
est_decoded_bytes = max(rows x 4096, compressed x 12) x 2
shards            = ceil(est_decoded_bytes / 512 MiB)
```

Every 2x of over-estimate is a whole extra pass over the same bytes. Neither `bytes_per_row = 4096` nor `inflation = 12` has ever been checked against a real decoded-vs-compressed ratio, so there is no way to tell a tuned constant from a lucky one — and lowering the estimate divides K directly, which is the cheapest throughput win short of the redesign in `docs/plans/2026-08-18-dedup-rescans-the-partition-k-times.md`.

Logs `dedup_shard_decoded` with what one shard actually decoded to beside what the estimate predicted for it. Shard 0 only, so a 256-way rewrite cannot flood the log.

**Both branches are instrumented, and they are not interchangeable.** The coordinator takes the STREAMING branch, so instrumenting only the collecting one would have produced nothing in production. The streamed figure sums post-dedup batches, so it UNDER-states input volume — a ratio at or above the estimate is conclusive, one below it is not. The collected figure is exact.

Measurement only; no behaviour changes. 775 lib + 98 dedup tests pass; `cargo lint` and `cargo fmt` clean.