### PR TITLE
A missing date-level entry is not evidence the rollup was not built

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -3792,22 +3792,24 @@ impl Database {
                 // miss histogram cannot tell a missing cron from a churning
                 // partition, which is the only question a rollout has to answer.
                 let Some(coverage) = self.rollup_coverage.get(&key) else {
-                    miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
-                    // A miss counter alone cannot be acted on — the same lesson
-                    // `rollup_miss_sampled` exists for. `not_built` folds every
-                    // project into one number, and with coverage intersected
-                    // across the set a SINGLE uncovered project refuses the whole
-                    // query. Name it, or finding it costs a manual sweep.
+                    // Deliberately does NOT set `miss`. `recover_rollup_coverage`
+                    // repopulates SLICE coverage after a restart and never this
+                    // date-level map, so on a process that has not itself rebuilt
+                    // the partition this lookup misses for EVERY date while the
+                    // slice loop below still covers the window completely.
                     //
-                    // NOT reported here, deliberately. `recover_rollup_coverage`
-                    // repopulates SLICE coverage after a restart, never this
-                    // date-level map, so on a process that has not rebuilt a
-                    // partition itself this lookup misses for every date while the
-                    // slice loop below still covers the window completely. Reported
-                    // from the per-project result instead, which is the honest
-                    // question: did this project contribute any covered range at
-                    // all? (The first version of this log fired on the date miss
-                    // and named a project whose coverage was in fact fine.)
+                    // Setting `miss` here made `not_built` the reported reason for
+                    // every later refusal, whatever actually caused it, because the
+                    // returns below are `miss.unwrap_or(<real reason>)`. Prod
+                    // 2026-08-18: 5,454 of 5,516 misses were `not_built`, and the
+                    // real reason was invisible. It also meant the strict
+                    // (non-realtime) path refused every window on a freshly
+                    // restarted process even when slice coverage served it whole —
+                    // rollup reads worked at all only because
+                    // `TIMEFUSION_ROLLUP_REALTIME_TAIL` happened to be on.
+                    //
+                    // Genuine absence is caught after the slice loop, from whether
+                    // the project contributed any covered range at all.
                     continue;
                 };
                 let source_fp = fingerprints
@@ -3850,7 +3852,10 @@ impl Database {
                 slice_ticket.push((entry.key().clone(), coverage.source_fp, coverage.generation.clone()));
             }
             let covered = merge_ranges(covered);
+            // The honest NotBuilt: this project produced no covered range for the
+            // window by EITHER route — date-level or slice.
             if covered.is_empty() {
+                miss = miss.or(Some(crate::rollup::MissReason::NotBuilt));
                 first_uncovered.get_or_insert_with(|| project.clone());
             }
             per_project.push(covered);


### PR DESCRIPTION
`recover_rollup_coverage` repopulates SLICE coverage after a restart and **never** the date-level `rollup_coverage` map. So on a process that has not itself rebuilt a partition, that lookup misses for every date — while the slice loop immediately below it may cover the window completely.

It set `miss = NotBuilt` anyway, and every later refusal returns `miss.unwrap_or(<real reason>)`. Two consequences, both measured:

**1. The miss taxonomy was unusable.** Prod 2026-08-18: **5,454 of 5,516** misses reported `not_built`, masking whatever actually blocked — an empty interior, a horizon shortfall, a sub-grain remnant. `not_built` is the one reason that says *go build more coverage*, so it pointed at the most expensive possible remedy while hiding the real one. I spent real time chasing it.

**2. The strict path refused everything on a freshly restarted process.** With `timefusion_rollup_realtime_tail` off, `miss.is_some()` alone refuses the window even when slice coverage serves it whole. Rollup reads work in prod only because that flag happens to be on — neither intended nor written down.

Genuine absence is still caught, and more honestly: after the slice loop, a project that contributed **no** covered range by either route sets `NotBuilt`. That is the claim the reason is supposed to make.

Pairs with #163's `rollup_empty_interior`, which can now be believed — the reason it reports is no longer overwritten by a lookup that is expected to miss.

976/976 tests pass; `cargo lint` and `cargo fmt` clean.