### PR TITLE
A base file without slice tags is prunable, not unreadable

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10203,15 +10203,45 @@ impl Database {
                     // distinguishable: #139 fixed day-tagged files being
                     // unselectable, and if any tier still comes back empty this
                     // is the number that says whether tags are the reason.
-                    let (Some(start), Some(end)) = (
+                    match (
                         tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
                         tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
-                    ) else {
-                        untagged_inputs = untagged_inputs.saturating_add(1);
-                        continue;
-                    };
-                    if tag(crate::maintenance_coordinator::TAG_PROJECT) != Some(key.project_id.as_str()) || !key.slice.overlaps(start, end) {
-                        continue;
+                    ) {
+                        (Some(start), Some(end)) => {
+                            if tag(crate::maintenance_coordinator::TAG_PROJECT) != Some(key.project_id.as_str()) || !key.slice.overlaps(start, end) {
+                                continue;
+                            }
+                        }
+                        // No slice tags — a file written before tagging existed.
+                        // Prune it on its OWN timestamp statistics, exactly as the
+                        // base branch above already does, instead of dropping it.
+                        //
+                        // Dropping it was silent and permanent: prod 2026-08-18
+                        // logged `maintenance_rollup_untagged_input` 15 times in 20
+                        // minutes, and EVERY rollup published in that window was a
+                        // derived unit with rows=0. The 1h tier — the one 14d/30d
+                        // queries read — sat at 6 days while the 1m tier had 22,
+                        // because history written before tagging can never reach it.
+                        //
+                        // Safe because this is pruning, not correctness: the
+                        // candidate set is already scoped to this (project, date)
+                        // partition, and the aggregation SQL filters `project_id`,
+                        // `date` and the timestamp range itself. A file kept here
+                        // that does not belong costs IO; a file dropped here loses
+                        // its rows for good. Missing statistics therefore mean
+                        // KEEP, never skip.
+                        _ => {
+                            untagged_inputs = untagged_inputs.saturating_add(1);
+                            if let Ok(Some(stats)) = add.get_stats()
+                                && let (Some(min), Some(max)) = (
+                                    stats.min_values.get("timestamp").and_then(|value| value.as_value()).and_then(delta_stat_micros),
+                                    stats.max_values.get("timestamp").and_then(|value| value.as_value()).and_then(delta_stat_micros),
+                                )
+                                && (min >= key.slice.end_micros || max < key.slice.start_micros)
+                            {
+                                continue;
+                            }
+                        }
                     }
                 }
                 let decoded = u64::try_from(add.size.max(0)).unwrap_or(0).saturating_mul(12);


### PR DESCRIPTION
**This is why the 1h tier — the one 14d/30d queries actually read — sat at 6 days while the 1m tier had 22.**

A derived unit selects its base inputs by slice tags. A base file written before tagging existed has none, so it was dropped outright. The counter #144 added to detect exactly this says it happens constantly — prod 2026-08-18:

- `maintenance_rollup_untagged_input` logged **15 times in 20 minutes**
- **every** rollup published in that window was a derived unit with `rows=0` — 16 of 16, across both `otel_metrics_rollup_metrics_1h_v2` and `otel_logs_and_spans_rollup_dashboard_1h_v2`

History written before tagging can never reach the coarse tier, and the unit *completes*, so it reads exactly like a genuinely empty slice.

## Fix

An untagged file is now pruned on its **own timestamp statistics** — the same test the non-derived branch three lines above already applies, using the same `delta_stat_micros` helper — instead of being discarded.

## Why this is safe

It is pruning, not correctness. The candidate set is already scoped to this (project, date) partition, and the aggregation SQL filters `project_id`, `date` and the timestamp range itself. A file kept here that does not belong costs IO; a file dropped here loses its rows for good. Missing statistics therefore mean **keep**, never skip — the same rule as `PartitionStats::overlaps` on the read side.

The tagged path is unchanged, so nothing that already worked changes shape.

982/982 tests pass; `cargo lint` and `cargo fmt` clean.