### PR TITLE
The untagged-input log no longer says the rows are lost

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10252,13 +10252,25 @@ impl Database {
         };
         if untagged_inputs > 0 {
             crate::metrics::maintenance_stats().rollup_untagged_inputs.fetch_add(untagged_inputs, std::sync::atomic::Ordering::Relaxed);
+            // Since #169 these files are KEPT — pruned on their own timestamp
+            // statistics rather than discarded — so this is no longer a report of
+            // data that can never arrive. It now measures how much of the base
+            // tier predates tagging and is therefore being selected by the wider,
+            // stats-only test. Left at `warn` while that population is still
+            // large; it should shrink as those partitions are rewritten.
+            //
+            // The old text said "their rows can never reach this tier", which was
+            // true when it was written and false the moment #169 shipped. Stale
+            // log text is worse than none: this exact line was the evidence used
+            // to diagnose the empty coarse tier, and it would have been read the
+            // same way again.
             warn!(
                 table = %key.physical_table,
                 project_id = %key.project_id,
                 slice_start = key.slice.start_micros,
                 untagged_inputs,
                 event = "maintenance_rollup_untagged_input",
-                "base files carry no slice tags; their rows can never reach this tier"
+                "base files carry no slice tags; selected on timestamp statistics instead"
             );
         }
         if estimated_bytes > MAX_DECODED_BYTES && key.slice.width() > crate::maintenance_coordinator::MIN_SLICE_MICROS {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -722,10 +722,20 @@ atomic_stats! {
     /// file already covered them. Expected to be rare; if it is not, a late row
     /// inside an already-published day may be going stale in the coarse tier.
     rollup_skipped_covered_by_wider,
-    /// Base rollup files a derived unit could not read because they carry no
-    /// parseable slice tags. Such a file is invisible to the coarse tier
-    /// forever, and the unit publishes rows=0 and completes — indistinguishable
-    /// from a genuinely empty slice unless this is counted.
+    /// Base rollup files carrying no parseable slice tags — history written
+    /// before tagging existed.
+    ///
+    /// Until #169 such a file was DROPPED, so it was invisible to the coarse
+    /// tier forever while the unit published rows=0 and completed,
+    /// indistinguishable from a genuinely empty slice. That is what this counter
+    /// was added to expose, and it did: 15 hits in 20 minutes against 16 of 16
+    /// derived publications at rows=0.
+    ///
+    /// It now counts files SELECTED by the fallback — pruned on their own
+    /// timestamp statistics instead of discarded — so it measures how much of the
+    /// base tier predates tagging, not how much is unreachable. Expect it to
+    /// shrink as those partitions are rewritten; a rise means older history is
+    /// being reached, which is the point.
     rollup_untagged_inputs,
     /// Contiguous sealed days of rollup coverage, counting back from yesterday,
     /// minimised over every (project, declared tier).


### PR DESCRIPTION
`maintenance_rollup_untagged_input` said *"their rows can never reach this tier"*. True when written; false the moment #169 shipped, since those files are now **kept** — pruned on their own timestamp statistics rather than discarded.

Worth correcting rather than leaving. This exact line is what diagnosed the empty coarse tier a few hours ago (15 hits in 20 minutes, against 16 of 16 derived publications at `rows=0`). Left as-is it would be read the same way again and send the next reader after a problem that is already fixed.

The counter's meaning changed with it: it now measures how much of the base tier **predates tagging** and is therefore selected by the wider stats-only test, not how much is unreachable. It should shrink as those partitions are rewritten — and a *rise* means older history is being reached, which is the point.

787 lib tests pass; `cargo lint` and `cargo fmt` clean.