### PR TITLE
Log how much of its deadline a slow maintenance unit actually used

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10877,8 +10877,33 @@ impl Database {
                     Operation::HotPacking | Operation::SealedConsolidation | Operation::Repair => self.run_coordinator_compaction_once(operation).await,
                 }
             };
+            // A unit's DURATION is the number every deadline decision needs and
+            // none of them has. Raising a deadline only helps if the units that
+            // miss it would finish in the longer window; if they would not, the
+            // waste per timeout rises with the deadline instead of falling.
+            // Prod 2026-08-18 has that question open for three operations at once
+            // — dedup (15 timeouts per 30 min at 300s, ~16% of capacity), sealed
+            // consolidation (3, ~9%) and repair (2, ~6%) — and it cannot be
+            // answered from the timeout count alone, because a timeout says only
+            // "longer than the deadline", never how much longer.
+            let started = std::time::Instant::now();
             let completed = match tokio::time::timeout(timeout, work).await {
-                Ok(result) => result?,
+                Ok(result) => {
+                    let elapsed = started.elapsed();
+                    // Only the slow tail: a unit finishing well inside its
+                    // deadline says nothing, and this runs on every claim.
+                    if elapsed.as_secs_f64() > timeout.as_secs_f64() / 4.0 {
+                        info!(
+                            ?operation,
+                            elapsed_secs = elapsed.as_secs(),
+                            deadline_secs = timeout.as_secs(),
+                            headroom_pct = (100.0 * (1.0 - elapsed.as_secs_f64() / timeout.as_secs_f64())) as i64,
+                            event = "maintenance_unit_slow",
+                            "a maintenance unit used a large share of its deadline"
+                        );
+                    }
+                    result?
+                }
                 Err(_) => {
                     // Dropping the operation future drops its TaskLease. The
                     // claimed unit is durably requeued and all resource tokens


### PR DESCRIPTION
A unit's **duration** is the number every deadline decision needs, and none of them has it. A timeout says only *"longer than the deadline"* — never how much longer. So raising a deadline is a coin flip: it helps only if the units that miss it would finish in the longer window; if they would not, the waste per timeout rises **with** the deadline instead of falling.

Prod 2026-08-18 has that question open for three operations at once, over 30 minutes against 318 starts:

| operation | timeouts | deadline | ≈ capacity |
| --- | --- | --- | --- |
| Dedup | 15 | 300s | ~16% |
| SealedConsolidation | 3 | 900s | ~9% |
| Repair | 2 | 900s | ~6% |

The dedup case is sharpest. #161 replaced K serial hash-sharded passes with one streaming pass — which is *why* its timeouts quadrupled, since the single pass is longer than any one shard was. Giving it the 900s the other rewrites get looks obvious, and the existing rationale for 300s ("its memory is bounded by input size, unlike a rollup") no longer holds now that the streaming branch is a `BoundedWindowAggExec` over a spillable sort.

But obvious is not measured: if those units need 2000s, raising the deadline turns 15×300s of waste into 15×900s. Twice tonight a well-argued "obvious" fix was refuted by measuring it (the dedup byte estimate, and the scheduling reweight).

Logs only the slow tail — over a quarter of the deadline — since this runs on every claim and a unit finishing well inside its budget says nothing.

Measurement only; no behaviour changes. The deadline change follows once the distribution is known.

787 lib tests pass; `cargo lint` and `cargo fmt` clean.