### PR TITLE
Revert: put dedup's deadline back to 5 minutes

### DIFF
--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -65,12 +65,35 @@ pub const fn operation_deadline_secs(operation: Operation) -> u64 {
         // which `split_time_task` refuses. So the unit retries whole, forever, at
         // full cost — the same trap #168 fixed for repair.
         //
-        // REVERT TRIGGER: if dedup timeouts do not fall, this makes things WORSE,
-        // because the waste per timeout scales with the deadline (12 x 300s ->
-        // 12 x 900s). Watch `maintenance_coordinator_unit_timed_out` with
-        // `operation=Dedup`; if it holds near 12 per 20 minutes, put this back to
-        // 5 * 60 and shrink the units instead.
-        Operation::Dedup => 15 * 60,
+        // REVERTED 2026-08-18, ~15 minutes after it shipped. Prod took a 125.1 GB
+        // OOM (exit 137, `tokio-rt-worker`) at 11:38 UTC, and the interval
+        // between OOMs had shortened from 15 hours to 4.2:
+        //
+        //     08-17 09:39 -> 16:39   7h
+        //     08-18 07:27           15h
+        //     08-18 11:38          4.2h   <- with the 900s deadline live
+        //
+        // Not proven — this OOM signature predates the change and its likeliest
+        // driver is a query-side join (see the handover, section 6.4). But the
+        // mechanism is precisely what the original 5 minutes was protecting: a
+        // dedup unit holds a rewrite permit AND its Arrow decode is OUTSIDE the
+        // DataFusion memory pool, so tripling the deadline triples how long that
+        // untracked memory is held, times the concurrent units.
+        //
+        // The argument for raising it was that #161 made the streaming branch a
+        // `BoundedWindowAggExec` over a spillable sort. That is true of the
+        // STREAMING branch; the collecting branch still materialises. Overriding
+        // a comment that named this exact risk, on a partial reading of which
+        // branch runs, was the mistake.
+        //
+        // The measurement that motivated it still stands and is still worth
+        // acting on — dedup units are bimodal, and 5 minutes is below what
+        // comparable file rewrites (320-440s) cost. The right fix is to make the
+        // units FIT, not to let them run longer: `byte_bounded_units` bisects in
+        // time only above MIN_SLICE_MICROS and emits hash shards below it, which
+        // `split_time_task` refuses outright. Teaching it to accept hash-sharded
+        // children would let an oversized unit shrink instead of retrying whole.
+        Operation::Dedup => 5 * 60,
         Operation::HotPacking | Operation::SealedConsolidation | Operation::Repair | Operation::BaseRollup | Operation::DerivedRollup => 15 * 60,
     }
 }


### PR DESCRIPTION
Prod took a **125.1 GB OOM** (exit 137, `tokio-rt-worker`) at 11:38 UTC, ~15 minutes after #175 raised dedup's deadline to 900s. The interval between OOMs had shortened from 15 hours to 4.2:

```
08-17 09:39 -> 16:39    7h
08-18 07:27            15h
08-18 11:38           4.2h   <- with the 900s deadline live
```

**Not proven.** This OOM signature predates the change, recurs on its own, and its likeliest driver is a query-side join (handover §6.4). But the mechanism is exactly what the original 5 minutes protected against: a dedup unit holds a rewrite permit **and** its Arrow decode sits outside the DataFusion memory pool, so tripling the deadline triples how long that untracked memory is held, times the concurrent units.

My argument for raising it was that #161 made the streaming branch a `BoundedWindowAggExec` over a spillable sort. That is true of the **streaming** branch; the collecting branch still materialises. Overriding a comment that named this exact risk, on a partial reading of which branch runs, was the mistake. The cost of being wrong is another OOM; the cost of reverting is the status quo.

## What still stands

The measurement behind #175 is still valid and still worth acting on: dedup units are bimodal, and 5 minutes is below what comparable file rewrites (320–440s, measured) cost.

The right fix is to make the units **fit**, not to let them run longer. `byte_bounded_units` bisects in time only above `MIN_SLICE_MICROS` and emits hash shards below it, which `split_time_task` refuses outright — so an oversized minimum-width unit can never shrink. Teaching the split to accept hash-sharded children reduces memory per unit instead of extending its lifetime, which is the opposite of what #175 did.

787 lib tests pass; `cargo lint` and `cargo fmt` clean.