### PR TITLE
fix(maintenance): reconcile missed commits by touched hours, not whole days

### DIFF
--- a/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
+++ b/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
@@ -321,33 +321,26 @@ which cross-validates the drain side of the model.
 
 ## 6. Phase 2 — aim the backfill at the goal (enqueue control)
 
-The planner (`plan_rollup_backfill`, `database.rs:9700`) already enqueues
-day-sized units for only the missing tiers, newest-first. Two changes make it
-goal-directed — and both are validated in the simulator (Phase 0.1) against a
-real journal before they ship:
+**IMPLEMENTED 2026-08-18** as `backfill_cells_by_contiguity` (`database.rs`,
+regression guard `backfill_ordering_fills_the_worst_projects_earliest_hole_first`):
 
-1. **Contiguity-targeted ordering.** Today it walks newest-first over all
-   missing (project, day) cells uniformly. Instead, score each cell by whether
-   completing it *extends a contiguous run back from yesterday* for its
-   (project, source, tier) — the exact predicate `min_contiguous_days`
-   measures. A day that fills a hole in a run of 12 outranks a day that starts
-   a new run at 29 days ago. This maximizes G1 per unit of work instead of per
-   unit of calendar.
-   → verify: sim says contiguity rises faster than newest-first; in a test
-   fixture with holey coverage, the enqueue order fills holes before extending
-   depth; on prod, `rollup_min_contiguous_days` rises within hours, not days.
-2. **Admit the backlog is triage, and say so in the journal.** While
-   `coverage_is_short()` (14-day gate, `database.rs:1726`), cells beyond the
-   30-day goal window for projects already at 30 should not be enqueued at
-   all — the 35-day horizon (`d_rollup_backfill_days`) is a dedup-certification
-   requirement, not a rollup-routing requirement, and the two horizons are
-   currently conflated in one planner. Split them: certification keeps 35 days,
-   rollup backfill aims at the contiguous-30 target.
-   → verify: enqueue rate from the planner drops; G1 keeps rising;
-   certification coverage (its own gauge) is unaffected.
+1. **Contiguity-targeted ordering.** Each 60s pass now admits the worst
+   project's earliest holes first — (run length ASC, hole distance ASC) —
+   instead of uniformly newest-first. This orders ADMISSION; execution order
+   in the journal remains `claim_next`'s. With rollup units measured at ~3s
+   and the restart-driven growth fixed, admission cadence (24 cells/pass) was
+   the binding constraint, so admission order is where the leverage is.
+2. **Deferral at the goal.** While `coverage_is_short()`, cells for projects
+   already at 30 contiguous days are not enqueued at all — the triage half of
+   the horizon split. The full certification/routing horizon split is NOT
+   done: the deferral achieves the triage without a new knob (§12: no
+   flexibility knobs without a measurement).
 
-**Explicitly not doing:** another slot-mix reweighting. #167 proved the mix is
-not binding. `dependencies_complete` already orders BaseRollup → DerivedRollup.
+Original sketch, for the record:
+
+1. ~~Contiguity-targeted ordering~~ and 2. ~~triage~~ — as above.
+   → verify: unit test pins hole-filling before depth-extending; on prod,
+   `rollup_min_contiguous_days` rises within hours of the deploy, not days.
 
 ---
 

--- a/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
+++ b/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
@@ -1,0 +1,532 @@
+# An architecture that keeps up: maintenance throughput and 1s 30d dashboards
+
+**Status:** plan. Written 2026-08-18, superseding the approach in
+`2026-08-18-plan-close-the-latency-goal.md`, whose failure is documented in
+`2026-08-18-handover-maintenance-and-rollup.md`. Every number below is either
+measured on prod (dated) or labelled an estimate.
+
+Second pass, same day: added Phase 0 (iteration infrastructure). The overnight
+session's real cost was not CI — it was the deploy → restart → 2h-quiet →
+ambiguous-counter loop, ~half a day per hypothesis. No design decision in this
+plan should require a prod deploy to evaluate; Phase 0 builds the tools that
+make that true.
+
+---
+
+## 1. The goal, measurably
+
+| # | Goal | Metric | Target | Where read |
+|---|------|--------|--------|-----------|
+| G1 | 30d dashboards fast, all projects | `rollup_min_contiguous_days` | **30** | `timefusion_stats` |
+| G2 | 30d dashboard latency | real query wall time, per active project | **p50 < 1s, no raw-scan fallback** | timed `psql`, `rollup_hits_full` / `rollup_misses` |
+| G3 | Maintenance keeps up | frontier: `eligible_watermark_lag_seconds`; sealed: goal-relevant backlog age | **< 600s** (`FRONTIER_LAG_BUDGET_SECS`); backlog → 0 | `timefusion_stats` |
+| G4 | No OOM query death | `exit 137` count | **0 for 7 consecutive days** | `docker service ps` |
+| G5 | Tantivy reindex concludes | `tantivy_uncovered_files` | **0** | `timefusion_stats` |
+| G6 | 10x projects, same server | creation rate vs drain rate at 130 projects (arithmetic, not prod) | **drain >= creation by design** | section 3 |
+
+G1–G4 are the user-visible goal. G5 is a standing debt item gated on the same
+capacity. G6 is a design constraint checked by arithmetic and the simulator
+(Phase 0.1), not by prod.
+
+**A metric is not the goal.** The 2026-08-18 session raised hit rates and tier
+depths while no dashboard got faster. Every phase below has an exit criterion
+stated in terms of G1–G4, and a phase is not done until its criterion is
+measured with a real query against real coverage.
+
+---
+
+## 2. What the last session established (do not re-litigate)
+
+Confirmed root causes, all fixed or understood — see the handover for evidence:
+
+- Rollup routing had four stacked silent refusals (#155, #159, #166, #169);
+  routing now works. `rollup_output_rows_total` 6 → 5,180.
+- Repair units burned 44% of maintenance capacity on a ~78% retry duty cycle
+  (#168 fixed the backoff floor).
+- The miss taxonomy lied (`not_built` was a recovery artifact, #163/#164).
+- The dedup byte estimate is **accurate** (#157) — do not "fix" it; lowering it
+  causes OOMs.
+- Slot-mix reweighting (#167) changed the mix exactly as designed and moved
+  throughput not at all. **Per-unit cost and enqueue volume are the only
+  levers. Do not tune the cycle again without first changing one of those.**
+- Removing dedup sharding from the streaming branch (#161) without raising its
+  300s deadline made dedup timeouts 2.5x worse. The deadline fix exists,
+  measured, on branch `fix/dedup-deadline` (30d7b45): `maintenance_unit_slow`
+  shows SealedConsolidation at 440s/363s/335s and HotPacking at 320s against a
+  900s deadline, while dedup gets 300s.
+
+Process lessons that constrain HOW this plan executes (from the handover, §8):
+
+1. **No deploy churn during measurement.** Each deploy kills in-flight units
+   (dedup commits: 0 on a 30-min-old process vs 7 on a 2-hour-old one) and
+   resets the date-level coverage map, so a restarted process reads as all-miss.
+   Minimum 2 hours between deploys before trusting any throughput number. One
+   change per measurement window. Phase 0 exists to make this affordable: most
+   questions should never need a prod deploy at all.
+2. **Depth-first, not breadth-first.** 60 project-days spread across 13
+   projects × 21 days left every project at 0 contiguous days. One project
+   fully covered end-to-end teaches more than the fleet partially covered.
+3. **Reconcile the arithmetic before believing a rate.** The handover's pending
+   delta (+12,906) and its measured net rate (+1.9/min × 206 min = +391) are
+   33x apart. The divergence was dominated by the backfill planner enqueueing
+   the horizon — **the queue growth was substantially self-inflicted**, which
+   means enqueue policy is a primary lever, not an afterthought.
+
+---
+
+## 3. The arithmetic that constrains everything
+
+Unit costs, measured (2026-08-17/18):
+
+- Small frontier unit (10-min slice): ~50–80s, dominated by object-store fixed
+  cost "regardless of how little data it covers".
+- Heavy day-sized unit: 300–450s (#172's `maintenance_unit_slow`).
+- Concurrency: 16 coordinator jobs, each capped at 512 MiB decoded
+  (`MAX_DECODED_BYTES`).
+
+### Steady state at 13 projects (26 rollup-declared streams)
+
+Frontier creation (`invalidate()`, `maintenance_coordinator.rs:597`):
+
+```
+per stream per day:  144 x Dedup(10m) + 144 x BaseRollup(10m) + 24 x DerivedRollup(1h)
+                   = 312 units
+fleet:               26 streams x 312 = ~8,100 units/day  (~5.6/min)
+```
+
+Capacity for small units: 16 jobs / ~65s ≈ **14.8 units/min**. The frontier
+fits with ~9 units/min to spare — *if* the spare actually reaches sealed work
+(the sealed reservation in `claim_next` exists because it did not).
+
+Sealed backlog — the goal-relevant set is bounded and enumerable:
+
+```
+worst case:   13 projects x 2 sources x 35 days x <=3 units  = ~2,700 units
+goal-relevant: 30 contiguous days x 13 x 2 (1h tier + the base it derives from)
+```
+
+At 9 spare units/min of small-unit capacity — or far fewer heavy 400s slots —
+the sealed backlog is a **days-long convergence process, not a queue that
+drains**. That is acceptable IF the convergence is aimed at the goal
+(Phase 2) and the frontier stays healthy (G3). It is not acceptable to pretend
+break-even is keep-up.
+
+### At 130 projects (10x, G6) — the model breaks here
+
+```
+frontier creation: 260 streams x 312 = ~81,000 units/day  (~56/min)
+small-unit capacity: still ~14.8/min                     -> diverges ~3.8x
+claim_next:          O(n) scan per claim per worker over ~300k+ tasks
+```
+
+**The enumerated 10-minute durable frontier unit does not scale to 10x.** This
+is the single most important architectural finding in this plan: the frontier's
+per-slice units exist so a crash cannot lose work, but the WAL already
+guarantees the data — the unit is only a trigger. Deriving frontier work from
+a per-stream cursor (or minting hour-wide frontier units) makes creation
+independent of project count. This is open question #1 from
+`2026-08-17-maintenance-unit-economics-at-10x.md`, promoted here from
+"exploration" to **required for G6** (Phase 4.1). The simulator (Phase 0.1) is
+where the cursor design gets validated — at 130 synthetic projects, in
+seconds, before a line of it ships.
+
+### Why latency has two independent halves
+
+A 30d query = rollup leg + live tail. Measured on a shipbubble 1-day query
+(warm): **139ms rollup leg + ~6s live tail**
+(`2026-08-17-live-tail-read-amplification.md`). Building 30 days of coverage
+(G1) does nothing for the tail: a rolling window always has an uncovered tail,
+and today the Delta leg re-reads from S3 what the hot tier already holds on
+local disk (~72% of served hot files fail to exclude their window). G2
+requires BOTH the coverage work (Phases 2–4) AND the read-path work
+(Phase 5). Either alone leaves dashboards slow.
+
+---
+
+## 4. Phase 0 — iteration infrastructure (build these first)
+
+The overnight session's iteration loop was build (~15 min release) → deploy →
+restart (kills in-flight units, resets the coverage map) → 2h quiet → discover
+the counters can't answer the question → repeat. Call it half a day per
+hypothesis. This phase compresses **time-to-knowledge** to ~an hour. What it
+cannot compress is **time-to-convergence**: draining ~2,700 heavy units is
+~19h of slot time whatever we do — but convergence runs unattended once the
+design is proven, so the only thing worth buying is knowledge speed.
+
+Everything here is tooling; nothing here touches prod behavior.
+
+1. **Journal-replay simulator.** ✅ **Landed** (`src/maintenance_sim.rs`, CLI
+   `timefusion sim <journal.json|data-dir> [--hours N] [--workers N] [--streams N]
+   [--scale F] [--seed N] [--no-mint] [--json]`). The coordinator is
+   deliberately IO-free (its module contract is "no scan implementation") and
+   its journal is a plain file — `maintenance_tasks.json`, loadable via
+   `Coordinator::load` (`maintenance_coordinator.rs:298`), fetchable from prod
+   over the read-only SSH access we already have. The sim replays the journal
+   on virtual time through the REAL scheduler: `claim_next`, `abandon_running`
+   (bisect-on-repeat, deadline-floored backoff), the shared
+   `operation_cycle()` (one definition with the server — they cannot drift),
+   and frontier minting via the real `invalidate()`. Durations are sampled
+   from the measured ranges per operation and width class (`--scale` to
+   stress). 48 virtual hours over ~3k tasks replays in ~15s wall.
+   - Verified: unit tests pin 13-projects-hold vs 10x-diverges (the §3
+     arithmetic, executable), sealed-backlog contiguity, timeout bisection,
+     and per-seed determinism.
+   - First use is a **backtest**: replay tonight's real journal with today's
+     policy and check the sim reproduces the observed lag/queue shape. A sim
+     that cannot reproduce the present is not trusted with the future.
+   - Then: every scheduler-policy question in this plan (sealed reservation
+     share, contiguity-targeted ordering, cursor frontier, 130 synthetic
+     projects) is a local run, not a prod experiment.
+   → verify: backtest matches the observed 2026-08-18 queue shape within a
+   stated tolerance; a 130-project synthetic journal answers
+   "diverges or not" in seconds.
+2. **`run-unit` CLI.** ✅ **Landed** (`timefusion run-unit --project ID
+   [--source T] [--date D] [--op base|derived|dedup|hot|sealed|repair]
+   [--slice-hours N]`). Same one-shot pattern as `optimize` / `redrive-dml` /
+   `migrate-columns` under the MaintenanceCli budget profile (`main.rs:143`):
+   enqueues exactly one unit into a scratch journal and runs it through the
+   real coordinator path, printing the scan/stage/commit/e2e counter deltas
+   plus wall time. This is handover §7.2 — "nobody has ever profiled where the
+   8 minutes go" — turned into a five-minute command runnable from a laptop
+   against a scratch R2 prefix. Point TIMEFUSION_DATA_DIR at a scratch dir so
+   the journal holds no other claimable work.
+   → verify: one BaseRollup day unit's time budget printed end-to-end; the
+   Phase 4 ordering gets re-derived from its output.
+3. **Staging that can actually carry throughput experiments.** MinIO tests
+   validate correctness, not cost: the 50–80s per-unit fixed cost is
+   object-store round trips, so experiments need real R2 latency and
+   whale-shaped partitions (1.8 GB one-minute windows, 77x ZSTD). A
+   `timefusion-staging` CapRover service pointed at a scratch prefix on the
+   same R2, seeded with a copied whale day plus a few shipbubble days, makes
+   deploys and restarts free — no coverage-map resets on the serving process,
+   no customer OOM risk, no 2h-quiet rule. The vertical slice (Phase 3) runs
+   here first.
+   → verify: staging ingests, builds rollups, and serves queries against the
+   scratch prefix; a staging restart is a non-event.
+4. **Flags per deploy, batch the experiments.** The repo already ships
+   kill-switch env vars (`TIMEFUSION_REPAIR_RESUME_ENABLED`,
+   `TIMEFUSION_PLAN_CACHE_TIME_FNS`). Scheduler-policy variants go behind flags
+   in ONE image, so a single prod deploy (when one is finally needed) carries
+   the whole experiment matrix instead of N deploy-restart-measure cycles.
+   → verify: policy switchable by env without a rebuild.
+5. **Standing `timefusion_stats` snapshots.** Half the lost nights were
+   *re-measurements* — a gauge lied, a counter was unwired, no before/after was
+   captured. Cron a periodic dump (pgwire `SELECT` into a file/otel) so every
+   experiment has a baseline without anyone remembering to take one.
+   → verify: snapshots exist covering every future experiment window.
+
+**The target loop once these exist:**
+
+```
+0:00  edit scheduler policy / unit-cost change
+0:05  cargo nextest run <targeted>          (correctness)
+0:10  sim replay vs tonight's prod journal  (divergence / lag / contiguity)
+0:15  run-unit or staging deploy            (real-storage cost)
+0:45  decide from printed numbers
+```
+
+Prod is touched only after 1–3 agree, under the deploy rules in §12.
+
+---
+
+## 5. Phase 1 — honest baseline, defuse landmines (before any optimization)
+
+Everything in this phase is measurement or one-line risk removals. No tuning.
+Items 1–3 use the Phase 0 tools; they should cost hours, not nights.
+
+1. **Decompose one heavy unit end-to-end.** ✅ **Answered 2026-08-18** (prod
+   counters + #174 phase timing): rollup units are NOT slow — 174 starts, not
+   one over 60s; e2e counters (~15.0M ms over ~4.8k rebuilds) put a rollup
+   unit at **~3.1s, split scan ~44% / staging ~12% / commit ~44%**. The slow
+   units are debt: HotPacking 320-895s, SealedConsolidation 294-767s, dedup
+   bimodal (quick or >300s). The "~8 minutes per rollup unit" that drove the
+   handover's arithmetic was an averaging artifact across operations (see
+   #176's commit message). Consequence: the rollup chain's cost is commit- and
+   scan-bound in roughly equal halves — fewer, larger units and shared commits
+   attack BOTH halves; decode/sort is not the story.
+2. **Split enqueue accounting by source.** ✅ **Root cause found 2026-08-18,
+   via the sim backtest** (below): the dominant enqueue source is
+   **restart-triggered whole-day re-invalidation**. On boot,
+   `reconcile_maintenance_task_cursors` enqueues `ALL_HOURS` per partition
+   with commits since the durable cursor — and unified-table flush commits
+   touch every project at once, so even a 5-minute OOM restart re-enqueues
+   ~312 tasks x every active stream AND resets the day's COMPLETE frontier
+   tasks to Pending (`invalidate` upsert semantics). That is the handover's
+   +12,906 (5 restarts that night) and the +5,876 base-rollup jump measured
+   across the 14:05 OOM restart. The per-source enqueue counters are still
+   worth adding, but the fix is structural: **the boot reconcile must not
+   re-enqueue partitions whose dirty state is already journaled** — the write
+   path records precise dirty hours durably (`rollup_invalidations.json`), so
+   re-invalidating a whole day for partitions the journal already covers is
+   pure rework. Only partitions with commits during downtime AND no journaled
+   invalidation need the conservative ALL_HOURS enqueue.
+   **IMPLEMENTED 2026-08-18** (more precise than sketched): instead of
+   skipping journaled partitions, the reconcile now derives the touched hours
+   from the missed commits' Add-action timestamp stats
+   (`rollup::hours_from_stats_json`; a partition seen only via Removes, or a
+   file without stats, still gets ALL_HOURS). A restart now enqueues ~13
+   tasks per touched stream-hour instead of ~312 tasks per stream-day, and no
+   longer resets completed frontier work outside the touched hours.
+   Regression guard: `reconcile_enqueues_only_the_hours_a_missed_commit_touched`.
+3. **Verify the goal metric against ground truth.** This codebase has shipped
+   three lying gauges (miss taxonomy, unpopulated counters, `MIN(date)`
+   "progress"). Check `rollup_min_contiguous_days` against a direct Delta-log
+   partition listing for two projects.
+   → verify: gauge == hand-computed contiguous days.
+4. **Time one real 30d query** on a mid-size project (NOT the whale — a heavy
+   ad-hoc query on the busiest tenant OOM'd the box once already; CLAUDE.md's
+   prod-read rules apply). Establishes the G2 baseline and proves the raw-scan
+   fallback is what we think it is.
+   → verify: a dated wall-time number + `rollup_miss` reason recorded here.
+5. **Defuse the restart landmine.** Rollup reads work only because
+   `TIMEFUSION_ROLLUP_REALTIME_TAIL` happens to be on:
+   `recover_rollup_coverage` repopulates slice coverage but never the
+   date-level map (`database.rs:3820` comment). One flag flip + one restart =
+   every window refused. Either rebuild date-level coverage in recovery or pin
+   the flag on in config with a comment naming the dependency.
+   → verify: restart with the flag off routes a covered window, or the flag is
+   pinned and the dependency is documented at the definition site.
+6. **~~Merge `fix/dedup-deadline`~~ SUPERSEDED by events.** #175 merged it,
+   an OOM followed (~15 min later; correlation not proof), and #177 reverted
+   it. The current understanding (#177's comment): dedup units are bimodal and
+   the right fix is to make oversized units FIT — teach `split_time_task` to
+   accept hash-sharded children below `MIN_SLICE_MICROS` — not to let them run
+   longer. Do not re-raise the deadline without that.
+   → verify: dedup day units split instead of timing out; `dedup` timeout rate
+   falls without a deadline change.
+
+### Sim backtest result (2026-08-18, real prod journal)
+
+T0 = prod journal fetched 14:02 UTC (65,261 non-complete tasks); one restart
+modeled at +3 min (the 14:05 OOM boot); replayed 66 min forward against the
+15:08 stats snapshot:
+
+| op | sim @+66min | actual @15:08 |
+|---|---|---|
+| total pending | 84,310 | 60,077 |
+| base_rollup | 45,870 | 37,047 |
+| dedup | 29,875 | 14,472 |
+| derived / hot / sealed / repair | 427 / 5,345 / 2,255 / 538 | 483 / 5,376 / 2,275 / 534 |
+
+The pre-restart model MISSED the growth entirely (pending shrank); with restart
+modeling the shape matches — pending grows, base balloons — with magnitude
+overshoot ~2.5x on base/dedup, attributable to known simplifications (the sim
+re-invalidates EVERY stream; the real reconcile touches only projects with
+commits during downtime, and unified-table commits usually touch all of them).
+Conclusion: the sim is trusted for POLICY COMPARISONS (relative ordering), not
+absolute prediction. File-hygiene ops (hot/sealed/repair) match within 1%,
+which cross-validates the drain side of the model.
+
+---
+
+## 6. Phase 2 — aim the backfill at the goal (enqueue control)
+
+The planner (`plan_rollup_backfill`, `database.rs:9700`) already enqueues
+day-sized units for only the missing tiers, newest-first. Two changes make it
+goal-directed — and both are validated in the simulator (Phase 0.1) against a
+real journal before they ship:
+
+1. **Contiguity-targeted ordering.** Today it walks newest-first over all
+   missing (project, day) cells uniformly. Instead, score each cell by whether
+   completing it *extends a contiguous run back from yesterday* for its
+   (project, source, tier) — the exact predicate `min_contiguous_days`
+   measures. A day that fills a hole in a run of 12 outranks a day that starts
+   a new run at 29 days ago. This maximizes G1 per unit of work instead of per
+   unit of calendar.
+   → verify: sim says contiguity rises faster than newest-first; in a test
+   fixture with holey coverage, the enqueue order fills holes before extending
+   depth; on prod, `rollup_min_contiguous_days` rises within hours, not days.
+2. **Admit the backlog is triage, and say so in the journal.** While
+   `coverage_is_short()` (14-day gate, `database.rs:1726`), cells beyond the
+   30-day goal window for projects already at 30 should not be enqueued at
+   all — the 35-day horizon (`d_rollup_backfill_days`) is a dedup-certification
+   requirement, not a rollup-routing requirement, and the two horizons are
+   currently conflated in one planner. Split them: certification keeps 35 days,
+   rollup backfill aims at the contiguous-30 target.
+   → verify: enqueue rate from the planner drops; G1 keeps rising;
+   certification coverage (its own gauge) is unaffected.
+
+**Explicitly not doing:** another slot-mix reweighting. #167 proved the mix is
+not binding. `dependencies_complete` already orders BaseRollup → DerivedRollup.
+
+---
+
+## 7. Phase 3 — the vertical slice (prove the chain on ONE project)
+
+Before scaling anything, prove the whole path on one project — on staging
+(Phase 0.3) first, prod second:
+
+- **Subject:** shipbubble (named in the goal; mid-size; not the whale).
+- **Work:** burn its 30 contiguous 1h-tier days for `otel_logs_and_spans`
+  (base tier where missing, then derived). This is ~30–90 units — hours of
+  drain, not days.
+- **Then measure, in order:**
+  1. `rollup_min_contiguous_days` contribution for shipbubble == 30
+     (ground-truthed per Phase 1.3).
+  2. A real shipbubble 30d dashboard query, timed, with `rollup_hits_full` /
+     `hits_hybrid` / `misses` recorded.
+  3. If >= 1s: the gap decomposition is already known — rollup leg vs live
+     tail (§3). A slow rollup leg means coverage or routing is still broken;
+     a slow tail means Phase 5 is the whole game. Either way the slice tells
+     us WHERE the remaining time is before we spend fleet-wide effort.
+
+→ **Exit criterion: a dated table — project, contiguous days, 30d query wall
+time, hit/miss reason — for shipbubble.** This is the first time anyone will
+have timed a 30d query against built coverage. If it is < 1s, the architecture
+is validated and Phases 4/5 are scaling work. If not, this plan's later phases
+get re-ordered by where the time actually is.
+
+---
+
+## 8. Phase 4 — unit cost and the frontier model (the binding constraints)
+
+Ordered by the Phase 1.1 decomposition. Expected candidates, with the evidence
+already pointing at them:
+
+1. **Frontier work derived from a cursor, not enumerated units** (REQUIRED for
+   G6; the §3 arithmetic shows 10x diverges 3.8x otherwise). Per stream, keep a
+   durable high-water cursor (`rollup_done_through_micros`); the coordinator
+   materializes at most one in-flight unit per stream per operation, covering
+   `[cursor, now - FINALIZATION_DELAY)`. Crash recovery = cursor + WAL replay,
+   which already guarantees the data. Creation becomes O(streams) per tick
+   instead of O(streams × slices × ops). Design validated in the sim at 130
+   synthetic projects before implementation starts.
+   → verify: sim at 130 projects shows creation <= drain; on prod, frontier
+   lag gauge unchanged after the switch.
+2. **Whatever Phase 1.1 says the 400s is.** If object-store fixed cost: widen
+   sealed units beyond a day where certification allows (fewer, larger units —
+   the direction day-sizing already proved). If decode/sort: the memory-pool
+   and spill paths are already the tuned ones; measure before touching. If
+   commit: the shared-wave machinery (`commit_rollup_wave`,
+   `database.rs:11337`) exists — check heavy units actually use it.
+3. **`claim_next` index.** O(n) per claim per worker over the task set
+   (`maintenance_coordinator.rs:697`) was already rewritten once under
+   pressure; at 10x (n ~ 300k) it needs an index keyed by
+   `(class, operation, eligibility)`. Do this WITH the cursor change, since the
+   cursor shrinks n for the frontier and the index serves the sealed journal.
+   → verify: claim latency p99 in `timefusion_stats`; no starvation regression
+   (sealed reservation tests stay green).
+
+**Not in this phase:** raising `MAX_DECODED_BYTES` or the dedup decoded budget.
+That decode is explicitly outside the memory pool; raising it trades CPU for
+untracked heap — the exact shape of the August OOM series.
+
+---
+
+## 9. Phase 5 — the read path (the other half of G2)
+
+1. **Resolve the hot-tier exclusion soundness question, then relax the gate.**
+   `plan_leg` only excludes a bucket from the Delta leg when one file both
+   covers the window and is the bucket's ONLY file — because `demote` can be
+   skipped under queue pressure (`demote_skipped_total` = 20 in prod), a
+   double-drained bucket can hold one file claiming `covers_window` over a span
+   it half holds. Step 1 is answering, from the code: *can a bucket drain twice
+   with a demote skip between?* If yes, `covers_window` must carry the drain's
+   own completeness (a generation/drain-id in the file metadata), not the
+   caller's constant. Only then relax to "all files of the bucket served and
+   all complete". A slow dashboard is visible; an under-counted one is not —
+   this ordering is not negotiable.
+   → verify: the shipbubble 1-day tail goes from ~6s toward the rollup leg's
+   ~139ms; `hot_tier.unproven_windows_total` / `read_hits_total` ratio falls
+   from ~72%; **zero parity failures** in the rollup-vs-raw parity suite.
+2. **Group-by-covered-set routing legs.** Coverage is intersected across
+   projects, so one thin project voids a cross-project window for everyone
+   (#166 split covered/raw legs; the follow-up — one rollup leg per distinct
+   covered-set with `project_id IN (...)`, bounded by the existing 32-branch
+   check — was never built). Without it, G2 for cross-project dashboards
+   depends on the WEAKEST project, forever.
+   → verify: a cross-project 30d query with one uncovered project still routes
+   the covered projects (`rollup_hits_hybrid` rises, no corresponding
+   `misses`); parity tests for the split legs.
+3. **Kill the two known OOM shapes** (G4):
+   - *Service-map self-join* (handover §6.4): monoscope's
+     `dispatchServiceMapRollups` fans out a 6-reference CTE (hash self-join +
+     two anti-joins) per project per 5-min bucket, concurrently; DataFusion
+     inlines the CTE, and the scan guard structurally cannot see it. Two
+     independent fixes, either sufficient: bound the job's concurrency in
+     monoscope (one line, safe — it is a background job), and/or materialize
+     `sp` once. TF-side hardening: per-query peak-memory attribution in
+     `timefusion_stats` so the NEXT join-shaped OOM is visible before the
+     oom-killer fires.
+   - *The 32.8 GB `SELECT metric_name, count(*) ... GROUP BY metric_name`*
+     full-history scan: answer distinct metric names from metadata/statistics,
+     or require a time bound. This query shape should be refused or
+     rewritten, not survived.
+   → verify: no `exit 137` for 7 days (G4); the two query shapes above are
+   measurably cheap or measurably refused.
+4. **Realtime tail, deliberately.** After Phase 1.5 the realtime-tail path is
+   either load-bearing-by-design (documented, tested on restart) or replaced.
+   → verify: restart-then-route test in the suite.
+
+---
+
+## 10. Phase 6 — tantivy to zero (G5)
+
+Gated on the same maintenance capacity; do not start until G3 holds
+(frontier lag < 600s sustained) or it will steal from coverage. 3,031 uncovered
+files at handover. The oversized-file unblock (#142) already landed; what
+remains is scheduling throughput.
+
+→ verify: `tantivy_uncovered_files` = 0 and stays 0 for 48h.
+
+---
+
+## 11. Phase 7 — 10x readiness check (G6)
+
+Arithmetic and simulation, not prod. At 130 projects × 2 sources, recompute §3
+with the cursor-based frontier and the indexed `claim_next`, and confirm the
+sim agrees:
+
+- creation <= drain by construction (not by coincidence, as 2026-08-17's
+  ~11,700 created vs ~12,000 retired was);
+- journal size bounded by sealed work only; `BACKFILL_PENDING_CEILING` still
+  meaningful;
+- the maintenance memory pool still fits `coordinator_jobs × 512 MiB`
+  (`config.rs` DerivedBudget asserts this per box; re-run the derivation at
+  prod's actual limit).
+
+If the box cannot hold both the query pool and 16 × 512 MiB of maintenance at
+10x ingest, the honest lever is the existing `BudgetProfile::MaintenanceCli`
+split — a maintenance-only process on the same server, memory-partitioned —
+which the codebase already budgets for. That is a decision to take WITH the
+Phase 1 numbers, not now.
+
+---
+
+## 12. Explicitly not doing
+
+- **No slot-mix reweighting** (#167: proved non-binding).
+- **No lowering the dedup byte estimate** (#157: it is accurate; lowering it
+  OOMs).
+- **No unsharding the non-streaming dedup branch** without a deadline that
+  matches its measured cost (#161/#172 lesson, generalized: never change a
+  unit's time structure without re-deriving its deadline from measurement).
+- **No ingestion-time partial aggregation** (excluded in the 08-15 redesign:
+  not idempotent under WAL replay, not invertible under merge-on-read).
+- **No prod-deploy-per-hypothesis.** If a question can be answered by the sim,
+  `run-unit`, or staging, it must be (Phase 0).
+- **No "flexibility" knobs.** Every constant above was earned by a measurement;
+  new ones need one too.
+
+---
+
+## 13. How to tell this is working
+
+Per-phase exit criteria are inline. Globally, in order:
+
+1. `rollup_min_contiguous_days` climbs and reaches 30 (G1) — ground-truthed
+   once (Phase 1.3), then trusted.
+2. A timed 30d dashboard query per active project, p50 < 1s, with
+   `rollup_hits_full`/`hits_hybrid` and no raw fallback (G2) — the shipbubble
+   slice first (Phase 3), the fleet after Phase 4.
+3. `eligible_watermark_lag_seconds` < 600 sustained (G3); enqueue-by-source
+   counters show the planner is no longer the dominant source.
+4. Zero `exit 137` for 7 days (G4).
+5. `tantivy_uncovered_files` = 0 (G5).
+6. The 10x arithmetic closes by construction, confirmed in the sim (G6).
+
+**Operating rules while executing this plan:** prod is the last resort, not the
+loop — sim, `run-unit`, and staging first (Phase 0); one change per deploy;
+>= 2h quiet before believing a throughput number; never run an unbounded
+ad-hoc query against the largest tenant; every PR states which goal metric it
+moves and how that will be measured — a PR that cannot name one does not merge.

--- a/src/database.rs
+++ b/src/database.rs
@@ -9622,7 +9622,9 @@ impl Database {
                             let mask = chrono::NaiveDate::parse_from_str(&partition.1, "%Y-%m-%d")
                                 .ok()
                                 .and_then(|date| date.and_hms_opt(0, 0, 0))
-                                .and_then(|day| add.stats.as_deref().and_then(|stats| crate::rollup::hours_from_stats_json(stats, day.and_utc().timestamp_micros())))
+                                .and_then(|day| {
+                                    add.stats.as_deref().and_then(|stats| crate::rollup::hours_from_stats_json(stats, day.and_utc().timestamp_micros()))
+                                })
                                 .unwrap_or(crate::rollup::ALL_HOURS);
                             partitions_with_adds.insert(partition.clone());
                             *partition_hours.entry(partition).or_insert(0) |= mask;
@@ -10169,19 +10171,12 @@ impl Database {
     /// inference. Point TIMEFUSION_DATA_DIR at a scratch dir: the journal must
     /// hold no other claimable work, or the coordinator may claim that first.
     pub async fn run_unit_once(
-        &self,
-        source: &str,
-        project_id: &str,
-        date: chrono::NaiveDate,
-        operation: crate::maintenance_coordinator::Operation,
-        slice_hours: i64,
+        &self, source: &str, project_id: &str, date: chrono::NaiveDate, operation: crate::maintenance_coordinator::Operation, slice_hours: i64,
     ) -> Result<UnitRunReport> {
         use crate::maintenance_coordinator::{MAX_DECODED_BYTES, MaintenanceTask, Operation, TaskKey, TaskState, TimeSlice};
         use std::sync::atomic::Ordering::Relaxed;
         let schema = get_schema(source).ok_or_else(|| anyhow::anyhow!("unknown source table {source}"))?;
-        let base_table = || {
-            schema.rollups.iter().find(|spec| spec.derive_from.is_none()).map(|spec| spec.table_name(source))
-        };
+        let base_table = || schema.rollups.iter().find(|spec| spec.derive_from.is_none()).map(|spec| spec.table_name(source));
         let physical_table = match operation {
             Operation::BaseRollup => base_table().ok_or_else(|| anyhow::anyhow!("{source} declares no base rollup"))?,
             Operation::DerivedRollup => schema

--- a/src/database.rs
+++ b/src/database.rs
@@ -1743,12 +1743,8 @@ pub const COVERAGE_SHORT_DAYS: u64 = 14;
 /// This orders ADMISSION into the journal (bounded per pass); execution order
 /// within the journal remains `claim_next`'s (width, recency, fairness).
 fn backfill_cells_by_contiguity(
-    mut want: Vec<(String, chrono::NaiveDate)>,
-    covered_per_tier: &[(usize, HashSet<(String, chrono::NaiveDate)>)],
-    today: chrono::NaiveDate,
-    horizon_days: i64,
-    goal_days: i64,
-    coverage_short: bool,
+    mut want: Vec<(String, chrono::NaiveDate)>, covered_per_tier: &[(usize, HashSet<(String, chrono::NaiveDate)>)], today: chrono::NaiveDate,
+    horizon_days: i64, goal_days: i64, coverage_short: bool,
 ) -> Vec<(String, chrono::NaiveDate)> {
     if covered_per_tier.is_empty() {
         // No tier resolved: contiguity is unknowable, so keep the historical
@@ -1764,13 +1760,8 @@ fn backfill_cells_by_contiguity(
             })
             .count() as i64
     };
-    let runs: HashMap<String, i64> = want
-        .iter()
-        .map(|(project, _)| project.as_str())
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .map(|project| (project.to_owned(), run_of(project)))
-        .collect();
+    let runs: HashMap<String, i64> =
+        want.iter().map(|(project, _)| project.as_str()).collect::<HashSet<_>>().into_iter().map(|project| (project.to_owned(), run_of(project))).collect();
     if coverage_short {
         want.retain(|(project, _)| runs.get(project).copied().unwrap_or(0) < goal_days);
     }
@@ -20913,9 +20904,8 @@ mod tests {
     fn backfill_ordering_fills_the_worst_projects_earliest_hole_first() {
         let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
         let day = |back: i64| today - chrono::Duration::days(back);
-        let covered = |project: &str, backs: &[i64]| -> HashSet<(String, chrono::NaiveDate)> {
-            backs.iter().map(|back| (project.to_owned(), day(*back))).collect()
-        };
+        let covered =
+            |project: &str, backs: &[i64]| -> HashSet<(String, chrono::NaiveDate)> { backs.iter().map(|back| (project.to_owned(), day(*back))).collect() };
         // Two tiers; a day counts only when BOTH have it. mid's day-2 is in
         // only one tier, so its run is 1, not 2 — holey tiers must not count.
         let tier_a: HashSet<(String, chrono::NaiveDate)> = covered("mid", &[1, 2]).into_iter().chain(covered("done", &[1, 2, 3, 4])).collect();

--- a/src/database.rs
+++ b/src/database.rs
@@ -1728,6 +1728,57 @@ impl PartitionStats {
 /// contiguity model.
 pub const COVERAGE_SHORT_DAYS: u64 = 14;
 
+/// Sort backfill cells to maximize the fleet-min contiguous coverage per unit
+/// of work, and defer projects already at the goal while coverage is short.
+///
+/// `rollup_min_contiguous_days` is a MIN over (project, tier) of contiguous
+/// days back from yesterday, so a cell's marginal value is zero unless it
+/// extends the worst project's run: order by (project's current run ASC, hole
+/// distance from yesterday ASC) — the worst project's earliest hole first. A
+/// project at `goal_days` contiguous has nothing left that moves the metric,
+/// so while `coverage_short` its older cells wait rather than compete for the
+/// same queue. Newest-first built every project to the same shallow depth and
+/// left the min at zero — breadth-first was the 2026-08-18 failure mode.
+///
+/// This orders ADMISSION into the journal (bounded per pass); execution order
+/// within the journal remains `claim_next`'s (width, recency, fairness).
+fn backfill_cells_by_contiguity(
+    mut want: Vec<(String, chrono::NaiveDate)>,
+    covered_per_tier: &[(usize, HashSet<(String, chrono::NaiveDate)>)],
+    today: chrono::NaiveDate,
+    horizon_days: i64,
+    goal_days: i64,
+    coverage_short: bool,
+) -> Vec<(String, chrono::NaiveDate)> {
+    if covered_per_tier.is_empty() {
+        // No tier resolved: contiguity is unknowable, so keep the historical
+        // newest-first behavior rather than silently dropping or keeping all.
+        want.sort_by(|(_, a), (_, b)| b.cmp(a));
+        return want;
+    }
+    let run_of = |project: &str| -> i64 {
+        (0..horizon_days)
+            .take_while(|back| {
+                let day = today - chrono::Duration::days(back + 1);
+                covered_per_tier.iter().all(|(_, covered)| covered.contains(&(project.to_owned(), day)))
+            })
+            .count() as i64
+    };
+    let runs: HashMap<String, i64> = want
+        .iter()
+        .map(|(project, _)| project.as_str())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .map(|project| (project.to_owned(), run_of(project)))
+        .collect();
+    if coverage_short {
+        want.retain(|(project, _)| runs.get(project).copied().unwrap_or(0) < goal_days);
+    }
+    let yesterday = today - chrono::Duration::days(1);
+    want.sort_by_key(|(project, date)| (runs.get(project).copied().unwrap_or(0), (yesterday - *date).num_days()));
+    want
+}
+
 /// Is contiguous rollup coverage short enough to be worth reweighting for?
 ///
 /// Reads the gauge `rollup_coverage_contiguity` publishes — the minimum over
@@ -9970,10 +10021,14 @@ impl Database {
             if want.is_empty() {
                 continue;
             }
-            // Newest first: recent days are what dashboards actually read, and
-            // an oldest-first pass spends the whole horizon on data nobody has
-            // queried yet.
-            want.sort_by(|(pa, da), (pb, db)| db.cmp(da).then_with(|| pa.cmp(pb)));
+            // Contiguity-greedy, not newest-first: the goal metric is the MIN
+            // over projects of contiguous days back from yesterday, so a pass
+            // spends its budget on the worst project's earliest holes, and a
+            // project already at the 30-day goal is deferred entirely while
+            // coverage is short. Newest-first built every project to the same
+            // shallow depth and left the min at zero — breadth-first was the
+            // 2026-08-18 overnight failure mode.
+            let mut want = backfill_cells_by_contiguity(want, &covered_per_tier, today, horizon, 30, coverage_is_short());
             let total = want.len();
             want.truncate(BACKFILL_PARTITIONS_PER_PASS);
             // DAY-sized units, not the frontier's ten-minute slices.
@@ -20849,6 +20904,41 @@ mod tests {
         assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0);
         assert_eq!(db.maintenance_tasks.lock().unwrap().source_cursor(cursor_key), Some(version));
         Ok(())
+    }
+
+    /// The backfill admission order must spend each pass on the worst project's
+    /// earliest hole, and must not spend anything on a project already at the
+    /// goal while coverage is short — the min-metric cannot move otherwise.
+    #[test]
+    fn backfill_ordering_fills_the_worst_projects_earliest_hole_first() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        let day = |back: i64| today - chrono::Duration::days(back);
+        let covered = |project: &str, backs: &[i64]| -> HashSet<(String, chrono::NaiveDate)> {
+            backs.iter().map(|back| (project.to_owned(), day(*back))).collect()
+        };
+        // Two tiers; a day counts only when BOTH have it. mid's day-2 is in
+        // only one tier, so its run is 1, not 2 — holey tiers must not count.
+        let tier_a: HashSet<(String, chrono::NaiveDate)> = covered("mid", &[1, 2]).into_iter().chain(covered("done", &[1, 2, 3, 4])).collect();
+        let tier_b: HashSet<(String, chrono::NaiveDate)> = covered("mid", &[1]).into_iter().chain(covered("done", &[1, 2, 3, 4])).collect();
+        let tiers = vec![(0usize, tier_a), (1usize, tier_b)];
+        let want: Vec<(String, chrono::NaiveDate)> = [("worst", 1), ("worst", 2), ("worst", 3), ("mid", 2), ("mid", 3), ("done", 5), ("done", 6)]
+            .into_iter()
+            .map(|(project, back)| (project.to_owned(), day(back)))
+            .collect();
+
+        let ordered = backfill_cells_by_contiguity(want.clone(), &tiers, today, 10, 4, true);
+        let position = |project: &str, back: i64| ordered.iter().position(|cell| cell == &(project.to_owned(), day(back)));
+        assert!(position("worst", 1) < position("worst", 2) && position("worst", 2) < position("worst", 3), "within a project, earliest hole first");
+        assert!(position("worst", 3) < position("mid", 2), "the run-less project outranks a hole in a run of 1");
+        assert!(position("mid", 2) < position("mid", 3));
+        assert!(!ordered.iter().any(|(project, _)| project == "done"), "a project at the 4-day goal is deferred while coverage is short");
+
+        // Healthy fleet: the deferral releases, and the done project's older
+        // cells sort behind everything that extends a run.
+        let ordered = backfill_cells_by_contiguity(want, &tiers, today, 10, 4, false);
+        let at = |project: &str, back: i64| ordered.iter().position(|cell| cell == &(project.to_owned(), day(back))).unwrap_or(usize::MAX);
+        assert_ne!(at("done", 5), usize::MAX, "goal projects are backfilled once coverage is healthy");
+        assert!(at("mid", 3) < at("done", 5), "run-extending cells still outrank beyond-goal cells");
     }
 
     /// Reconciling a missed commit must invalidate only the hours the commit's

--- a/src/database.rs
+++ b/src/database.rs
@@ -1723,8 +1723,10 @@ impl PartitionStats {
 ///
 /// A 14d panel is the most common wide dashboard window and the cheapest useful
 /// target; 30d follows once 14 holds. Set at the goal rather than at 1 so the
-/// weighting does not flap the moment the first day lands.
-const COVERAGE_SHORT_DAYS: u64 = 14;
+/// weighting does not flap the moment the first day lands. Pub for the journal
+/// simulator (`maintenance_sim`), which drives the same switch from its own
+/// contiguity model.
+pub const COVERAGE_SHORT_DAYS: u64 = 14;
 
 /// Is contiguous rollup coverage short enough to be worth reweighting for?
 ///
@@ -2869,6 +2871,43 @@ fn fair_tantivy_backfill_work(mut queues: Vec<(String, VecDeque<(String, String)
         if !added {
             return work;
         }
+    }
+}
+
+/// What a single `run-unit` execution produced. The phase counters are deltas
+/// of the global `maintenance_stats` atomics over the unit's run; the CLI owns
+/// the process, so nothing else is moving them.
+pub struct UnitRunReport {
+    pub operation: crate::maintenance_coordinator::Operation,
+    pub project_id: String,
+    pub date: chrono::NaiveDate,
+    pub wall_ms: u64,
+    pub scan_ms: u64,
+    pub staging_ms: u64,
+    pub commit_ms: u64,
+    pub end_to_end_ms: u64,
+    pub cohorts: u64,
+    pub state: Option<crate::maintenance_coordinator::TaskState>,
+    pub retry_reason: Option<String>,
+}
+
+impl std::fmt::Display for UnitRunReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "run-unit: {:?} {} {} | wall {}ms | scan {}ms staging {}ms commit {}ms e2e {}ms | cohorts {} | state {:?}{}",
+            self.operation,
+            self.project_id,
+            self.date,
+            self.wall_ms,
+            self.scan_ms,
+            self.staging_ms,
+            self.commit_ms,
+            self.end_to_end_ms,
+            self.cohorts,
+            self.state,
+            self.retry_reason.as_deref().map_or(String::new(), |reason| format!(" | retry_reason {reason}")),
+        )
     }
 }
 
@@ -9559,31 +9598,56 @@ impl Database {
                 continue;
             }
             let cursor = current_cursor.expect("missing cursor handled above");
-            let mut partitions = HashSet::new();
+            // Per partition, the hours the missed commits can have touched —
+            // derived from the Add actions' timestamp stats. The naive form
+            // invalidated ALL_HOURS per changed partition: a unified-table
+            // flush commit names every active project, so EVERY restart
+            // re-enqueued ~312 durable tasks per active stream AND reset the
+            // day's completed frontier work to Pending (`invalidate` upsert
+            // semantics). Measured 2026-08-18 across the 14:05 OOM boot:
+            // +5,876 pending base rollups in one hour from ONE restart — the
+            // queue's dominant growth source under deploy churn.
+            let mut partition_hours: HashMap<(String, String), u32> = HashMap::new();
             for commit_version in cursor.saturating_add(1)..=version {
                 let bytes = log_store
                     .read_commit_entry(commit_version)
                     .await?
                     .ok_or_else(|| anyhow::anyhow!("source commit {commit_version} is unavailable for {cursor_key}; cursor remains at {cursor}"))?;
+                let mut partitions_with_adds = HashSet::new();
+                let mut remove_only: HashSet<(String, String)> = HashSet::new();
                 for action in deltalake::logstore::get_actions(commit_version, &bytes)? {
-                    let changed = match action {
+                    match action {
                         deltalake::kernel::Action::Add(add) if add.data_change => {
-                            Self::maintenance_partition_from_action(&add.path, Some(&add.partition_values))
+                            let Some(partition) = Self::maintenance_partition_from_action(&add.path, Some(&add.partition_values)) else { continue };
+                            let mask = chrono::NaiveDate::parse_from_str(&partition.1, "%Y-%m-%d")
+                                .ok()
+                                .and_then(|date| date.and_hms_opt(0, 0, 0))
+                                .and_then(|day| add.stats.as_deref().and_then(|stats| crate::rollup::hours_from_stats_json(stats, day.and_utc().timestamp_micros())))
+                                .unwrap_or(crate::rollup::ALL_HOURS);
+                            partitions_with_adds.insert(partition.clone());
+                            *partition_hours.entry(partition).or_insert(0) |= mask;
                         }
+                        // A Remove carries no stats; in a rewrite commit its
+                        // span is covered by the paired Adds. Only a partition
+                        // with removes and NO adds anywhere in the missed
+                        // commits (a deletion) needs the conservative day.
                         deltalake::kernel::Action::Remove(remove) if remove.data_change => {
-                            Self::maintenance_partition_from_action(&remove.path, remove.partition_values.as_ref())
+                            let Some(partition) = Self::maintenance_partition_from_action(&remove.path, remove.partition_values.as_ref()) else { continue };
+                            remove_only.insert(partition);
                         }
-                        _ => None,
-                    };
-                    if let Some(partition) = changed {
-                        partitions.insert(partition);
+                        _ => {}
+                    }
+                }
+                for partition in remove_only {
+                    if !partitions_with_adds.contains(&partition) {
+                        partition_hours.insert(partition, crate::rollup::ALL_HOURS);
                     }
                 }
             }
-            for (partition_project, date) in partitions {
+            for ((partition_project, date), hours) in partition_hours {
                 let project = if storage_project.is_empty() { partition_project } else { storage_project.clone() };
-                self.enqueue_maintenance_hours(&project, &source, &date, crate::rollup::ALL_HOURS)?;
-                queued = queued.saturating_add(24 * schema.rollups.len());
+                self.enqueue_maintenance_hours(&project, &source, &date, hours)?;
+                queued = queued.saturating_add(usize::try_from(hours.count_ones()).unwrap_or(24) * schema.rollups.len());
             }
             let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             journal.set_source_cursor(cursor_key, version);
@@ -10097,6 +10161,113 @@ impl Database {
             }
         }
         Ok(true)
+    }
+
+    /// Execute ONE maintenance unit end-to-end and report where its time went.
+    /// Backs the `run-unit` CLI: the per-unit cost decomposition (handover
+    /// §7.2, plan Phase 1.1) as a five-minute command instead of fleet-counter
+    /// inference. Point TIMEFUSION_DATA_DIR at a scratch dir: the journal must
+    /// hold no other claimable work, or the coordinator may claim that first.
+    pub async fn run_unit_once(
+        &self,
+        source: &str,
+        project_id: &str,
+        date: chrono::NaiveDate,
+        operation: crate::maintenance_coordinator::Operation,
+        slice_hours: i64,
+    ) -> Result<UnitRunReport> {
+        use crate::maintenance_coordinator::{MAX_DECODED_BYTES, MaintenanceTask, Operation, TaskKey, TaskState, TimeSlice};
+        use std::sync::atomic::Ordering::Relaxed;
+        let schema = get_schema(source).ok_or_else(|| anyhow::anyhow!("unknown source table {source}"))?;
+        let base_table = || {
+            schema.rollups.iter().find(|spec| spec.derive_from.is_none()).map(|spec| spec.table_name(source))
+        };
+        let physical_table = match operation {
+            Operation::BaseRollup => base_table().ok_or_else(|| anyhow::anyhow!("{source} declares no base rollup"))?,
+            Operation::DerivedRollup => schema
+                .rollups
+                .iter()
+                .find(|spec| spec.derive_from.is_some())
+                .ok_or_else(|| anyhow::anyhow!("{source} declares no derived rollup"))?
+                .table_name(source),
+            _ => source.to_owned(),
+        };
+        let day_start = date.and_hms_opt(0, 0, 0).ok_or_else(|| anyhow::anyhow!("invalid date {date}"))?.and_utc().timestamp_micros();
+        let slice = TimeSlice::new(day_start, day_start.saturating_add(slice_hours.saturating_mul(3_600_000_000)))?;
+        let key = TaskKey { physical_table, source: source.to_owned(), project_id: project_id.to_owned(), slice, operation };
+        let now = crate::clock::now_micros();
+        {
+            let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if operation == Operation::DerivedRollup {
+                // A derived unit is unclaimable until its base generation is
+                // Complete; a scratch journal has none. Seed the dependency
+                // with a synthetic completed base covering the whole day.
+                let base_key = TaskKey {
+                    physical_table: base_table().ok_or_else(|| anyhow::anyhow!("{source} declares no base rollup"))?,
+                    slice: TimeSlice::new(day_start, day_start.saturating_add(86_400_000_000))?,
+                    operation: Operation::BaseRollup,
+                    ..key.clone()
+                };
+                journal.upsert(MaintenanceTask {
+                    key: base_key,
+                    state: TaskState::Complete,
+                    deadline_micros: 0,
+                    estimated_decoded_bytes: 0,
+                    hash_shard: 0,
+                    hash_shards: 1,
+                    attempts: 0,
+                    created_unix_ms: 0,
+                    retry_reason: None,
+                    publication: None,
+                });
+            }
+            journal.enqueue(key.clone(), now, MAX_DECODED_BYTES, u64::try_from(now.div_euclid(1_000)).unwrap_or_default());
+        }
+        let stats = crate::metrics::maintenance_stats();
+        let counters = [
+            stats.rollup_scan_duration_ms.load(Relaxed),
+            stats.rollup_staging_duration_ms.load(Relaxed),
+            stats.rollup_commit_duration_ms.load(Relaxed),
+            stats.rollup_end_to_end_duration_ms.load(Relaxed),
+            stats.rollup_scan_cohorts.load(Relaxed),
+        ];
+        let started = std::time::Instant::now();
+        match operation {
+            Operation::Dedup => {
+                self.run_coordinator_dedup_once().await?;
+            }
+            Operation::BaseRollup | Operation::DerivedRollup => {
+                self.run_coordinator_rollup_once(operation).await?;
+            }
+            _ => {
+                self.run_coordinator_compaction_once(operation).await?;
+            }
+        }
+        let wall = started.elapsed();
+        let after = [
+            stats.rollup_scan_duration_ms.load(Relaxed),
+            stats.rollup_staging_duration_ms.load(Relaxed),
+            stats.rollup_commit_duration_ms.load(Relaxed),
+            stats.rollup_end_to_end_duration_ms.load(Relaxed),
+            stats.rollup_scan_cohorts.load(Relaxed),
+        ];
+        let (state, retry_reason) = {
+            let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            journal.tasks().find(|task| task.key == key).map(|task| (Some(task.state), task.retry_reason.clone())).unwrap_or((None, None))
+        };
+        Ok(UnitRunReport {
+            operation,
+            project_id: project_id.to_owned(),
+            date,
+            wall_ms: u64::try_from(wall.as_millis()).unwrap_or(u64::MAX),
+            scan_ms: after[0] - counters[0],
+            staging_ms: after[1] - counters[1],
+            commit_ms: after[2] - counters[2],
+            end_to_end_ms: after[3] - counters[3],
+            cohorts: after[4] - counters[4],
+            state,
+            retry_reason,
+        })
     }
 
     async fn run_coordinator_rollup_once(&self, operation: crate::maintenance_coordinator::Operation) -> Result<bool> {
@@ -10904,49 +11075,12 @@ impl Database {
             }
         }
         // Interleave dependent publication with dedup instead of draining the
-        // entire historical dedup backlog first. Dedup/base receive three
-        // slots each; derived and file work each receive one. `claim_next`
-        // still applies deadline, recent-slice, dependency, and project fairness.
-        const CYCLE: [Operation; 10] = [
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::HotPacking,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::SealedConsolidation,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::Repair,
-        ];
-        // While contiguous coverage is short, the rollup chain takes the slots.
-        //
-        // `dependencies_complete` makes BaseRollup depend on NOTHING — base
-        // publication does its own bounded dedup before aggregating — so of the
-        // balanced cycle above, six slots in ten go to work that cannot advance
-        // the metric governing 14d/30d latency. Measured 2026-08-18: 15,799
-        // pending base+derived rollup tasks against 19,351 of dedup, packing,
-        // consolidation and repair, with the 1h tier holding 3-6 days per project
-        // and `rollup_min_contiguous_days` at 0.
-        //
-        // The trade is explicit and is the one the goal asks for: deferring dedup
-        // leaves more duplicates for read-side `DedupExec` to collapse, which
-        // costs raw scans time — but a day the rollup covers is not raw-scanned at
-        // all. Every operation keeps at least one slot, so nothing starves, and
-        // this reverts to the balanced cycle by itself once coverage is healthy.
-        const COVERAGE_SHORT_CYCLE: [Operation; 10] = [
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::BaseRollup,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::HotPacking,
-            Operation::BaseRollup,
-            Operation::SealedConsolidation,
-            Operation::Repair,
-        ];
-        let cycle = if coverage_is_short() { &COVERAGE_SHORT_CYCLE } else { &CYCLE };
+        // entire historical dedup backlog first. The cycles live in
+        // `maintenance_coordinator` (one definition shared with the journal
+        // simulator); the coverage-short reweighting is self-limiting via
+        // `coverage_is_short`. `claim_next` still applies deadline,
+        // recent-slice, dependency, and project fairness.
+        let cycle = crate::maintenance_coordinator::operation_cycle(coverage_is_short());
         let start = self.maintenance_schedule_cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % cycle.len();
         let mut attempted = [false; 6];
         for offset in 0..cycle.len() {
@@ -20467,43 +20601,17 @@ mod tests {
     /// degraded every query (2026-08-01), so each operation keeps a slot.
     #[test]
     fn the_coverage_short_cycle_favours_rollup_without_starving_file_work() {
-        use crate::maintenance_coordinator::Operation;
-        // Mirrors the two cycles in `run_coordinator_maintenance_once`. Kept here
-        // as data so the ratios are asserted rather than merely intended.
-        let balanced = [
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::HotPacking,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::SealedConsolidation,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::Repair,
-        ];
-        let coverage_short = [
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::BaseRollup,
-            Operation::Dedup,
-            Operation::BaseRollup,
-            Operation::DerivedRollup,
-            Operation::HotPacking,
-            Operation::BaseRollup,
-            Operation::SealedConsolidation,
-            Operation::Repair,
-        ];
+        use crate::maintenance_coordinator::{CYCLE_BALANCED, CYCLE_COVERAGE_SHORT, Operation};
         let count = |cycle: &[Operation; 10], op: Operation| cycle.iter().filter(|candidate| **candidate == op).count();
         let chain = |cycle: &[Operation; 10]| count(cycle, Operation::BaseRollup) + count(cycle, Operation::DerivedRollup);
 
-        assert_eq!(chain(&balanced), 4, "precondition: the balanced cycle gives the rollup chain 4 of 10");
-        assert_eq!(chain(&coverage_short), 6, "the coverage-short cycle must give the rollup chain 6 of 10");
+        assert_eq!(chain(&CYCLE_BALANCED), 4, "precondition: the balanced cycle gives the rollup chain 4 of 10");
+        assert_eq!(chain(&CYCLE_COVERAGE_SHORT), 6, "the coverage-short cycle must give the rollup chain 6 of 10");
         // Nothing starves. Each of these has its own incident behind it.
         for op in [Operation::Dedup, Operation::HotPacking, Operation::SealedConsolidation, Operation::Repair] {
-            assert!(count(&coverage_short, op) >= 1, "{op:?} must keep at least one slot");
+            assert!(count(&CYCLE_COVERAGE_SHORT, op) >= 1, "{op:?} must keep at least one slot");
         }
-        assert_eq!(balanced.len(), coverage_short.len(), "same length, so the rotating cursor behaves identically");
+        assert_eq!(CYCLE_BALANCED.len(), CYCLE_COVERAGE_SHORT.len(), "same length, so the rotating cursor behaves identically");
     }
 
     /// The reweighting is self-limiting: it must switch off once coverage reaches
@@ -20745,6 +20853,43 @@ mod tests {
 
         assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0);
         assert_eq!(db.maintenance_tasks.lock().unwrap().source_cursor(cursor_key), Some(version));
+        Ok(())
+    }
+
+    /// Reconciling a missed commit must invalidate only the hours the commit's
+    /// files actually span, never the whole partition-day. The old form
+    /// enqueued `ALL_HOURS` per changed partition, and unified-table flush
+    /// commits name every active project — so every restart re-enqueued ~312
+    /// durable tasks per active stream AND reset the day's completed frontier
+    /// work. Prod 2026-08-18, one OOM restart: +5,876 pending base rollups in
+    /// an hour. This test's commit touches ONE hour: the reconcile must add
+    /// nothing beyond the write path's own one-hour invalidation (13 tasks).
+    #[tokio::test]
+    async fn reconcile_enqueues_only_the_hours_a_missed_commit_touched() -> Result<()> {
+        let db = Database::with_config(create_test_config("reconcile-precise-hours")).await?;
+        // The reconcile inspects cached handles only, so the table must exist
+        // before the cursor baselines.
+        db.get_or_create_unified_table("otel_logs_and_spans").await?;
+        assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0, "first reconcile baselines the cursor");
+
+        let project = format!("recon_{}", uuid::Uuid::new_v4().simple());
+        let ts = (Utc::now() - chrono::Duration::hours(3)).timestamp_micros();
+        let day = chrono::DateTime::from_timestamp_micros(ts).unwrap().date_naive();
+        let day_start = day.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_micros();
+        let hour_start = ts.div_euclid(3_600_000_000) * 3_600_000_000;
+        for id in ["a", "b"] {
+            db.insert_records_batch(&project, "otel_logs_and_spans", vec![json_to_batch(vec![test_span_ts(id, "op", &project, ts)])?], true, None).await?;
+        }
+        let queued = db.reconcile_maintenance_task_cursors().await?;
+
+        let journal = db.maintenance_tasks.lock().unwrap();
+        let tasks = journal.tasks().filter(|task| task.key.project_id == project).collect::<Vec<_>>();
+        assert_eq!(tasks.len(), 13, "one touched hour: 6 dedup + 6 base + 1 derived, not 312 for the whole day");
+        assert!(
+            tasks.iter().all(|task| task.key.slice.start_micros >= hour_start && task.key.slice.end_micros <= hour_start + 3_600_000_000),
+            "every reconciled task must lie inside the touched hour; day {day} starts {day_start}"
+        );
+        assert_eq!(queued, 2, "one dirty hour x two rollup specs");
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod hot_tier;
 pub mod insert_coerce;
 pub mod logical_count_index;
 pub mod maintenance_coordinator;
+pub mod maintenance_sim;
 pub mod mem_buffer;
 pub mod metrics;
 pub mod object_store_cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,12 +134,19 @@ fn main() -> anyhow::Result<()> {
     if subcommand.as_deref() == Some("encrypt-secret") {
         return secret_crypto::run_cli();
     }
+    // `timefusion sim <journal.json|data-dir>` — replays a prod maintenance
+    // journal through the real scheduler on virtual time. Pure and config-free:
+    // the whole point is answering scheduler questions WITHOUT a deploy, so it
+    // must not need a bucket, a config, or a running anything.
+    if subcommand.as_deref() == Some("sim") {
+        return run_sim_cli();
+    }
 
     // Maintenance CLIs get the maintenance-heavy budget shape (the server
     // shape strands a small cgroup's memory in query/ingest slices a one-shot
     // CLI never uses). Must precede init_config, which snapshots the tree.
     // SAFETY: no threads exist yet - we're before the Tokio runtime is built.
-    if matches!(subcommand.as_deref(), Some("optimize" | "redrive-dml" | "migrate-columns")) {
+    if matches!(subcommand.as_deref(), Some("optimize" | "redrive-dml" | "migrate-columns" | "run-unit")) {
         unsafe { std::env::set_var("TIMEFUSION_BUDGET_PROFILE", "maintenance-cli") };
     }
 
@@ -154,6 +161,7 @@ fn main() -> anyhow::Result<()> {
         Some("redrive-dml") => rt.block_on(run_redrive_dml_cli(cfg)),
         Some("optimize") => rt.block_on(run_optimize_cli(cfg)),
         Some("migrate-columns") => rt.block_on(run_migrate_columns_cli(cfg)),
+        Some("run-unit") => rt.block_on(run_unit_cli(cfg)),
         _ => {
             let result = rt.block_on(async_main(cfg));
             // The server path must END THE PROCESS here: dropping the runtime
@@ -268,6 +276,120 @@ fn init_cli_tracing() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")))
         .try_init();
+}
+
+/// `timefusion sim <journal.json | data-dir> [--hours N] [--workers N]
+/// [--streams N] [--scale F] [--seed N] [--no-mint] [--json]`
+///
+/// Replay a copied-out prod maintenance journal through the real scheduler on
+/// virtual time (`timefusion::maintenance_sim`). The answer to "does this
+/// policy keep up" without a deploy. Fetch the input with e.g.
+/// `ssh ubuntu@captain.s.past3.tech 'docker cp <container>:/data/.timefusion_meta/maintenance_tasks.json -'`.
+fn run_sim_cli() -> anyhow::Result<()> {
+    use timefusion::maintenance_sim::{SimConfig, load_sandboxed, run};
+    let mut it = std::env::args().skip(2);
+    let usage = "usage: timefusion sim <journal.json|data-dir> [--hours N] [--workers N] [--streams N] [--scale F] [--seed N] [--no-mint] [--json]";
+    let input = it.next().context(usage)?;
+    let mut cfg = SimConfig::default();
+    let mut json = false;
+    while let Some(a) = it.next() {
+        let mut value = |name: &str| -> anyhow::Result<String> { it.next().with_context(|| format!("{name} needs a value")) };
+        match a.as_str() {
+            "--hours" => cfg.horizon_micros = (value("--hours")?.parse::<f64>().context("--hours must be a number")? * 3_600_000_000.0) as i64,
+            "--workers" => cfg.workers = value("--workers")?.parse().context("--workers must be an integer")?,
+            "--streams" => cfg.streams = Some(value("--streams")?.parse().context("--streams must be an integer")?),
+            "--scale" => cfg.duration_scale = value("--scale")?.parse().context("--scale must be a number")?,
+            "--seed" => cfg.seed = u64::from_str_radix(value("--seed")?.trim_start_matches("0x"), 16).context("--seed must be hex")?,
+            "--restarts-every-hours" => {
+                cfg.restart_every_micros = (value("--restarts-every-hours")?.parse::<f64>().context("--restarts-every-hours must be a number")? * 3_600_000_000.0) as i64
+            }
+            "--restart-at-hours" => {
+                cfg.restart_at_micros = Some((value("--restart-at-hours")?.parse::<f64>().context("--restart-at-hours must be a number")? * 3_600_000_000.0) as i64)
+            }
+            "--no-mint" => cfg.mint_frontier = false,
+            "--json" => json = true,
+            other => anyhow::bail!("unknown argument: {other} ({usage})"),
+        }
+    }
+    let (journal, _sandbox) = load_sandboxed(std::path::Path::new(&input))?;
+    let report = run(journal, &cfg, clock::now_micros())?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    println!(
+        "sim: {:.1}h virtual | {} workers | scale {:.2} | {} streams | seed {:#x}",
+        report.hours,
+        cfg.workers,
+        cfg.duration_scale,
+        cfg.streams.map_or("journal".to_owned(), |n| n.to_string()),
+        cfg.seed
+    );
+    println!("pending: {} -> {} | executions: {} | splits: {}", report.pending_start, report.pending_end, report.executions, report.splits);
+    let mut completions = report.completions.iter().collect::<Vec<_>>();
+    completions.sort();
+    println!("completions: {}", completions.iter().map(|(op, n)| format!("{op}={n}")).collect::<Vec<_>>().join(" "));
+    if !report.timeouts.is_empty() {
+        let mut timeouts = report.timeouts.iter().collect::<Vec<_>>();
+        timeouts.sort();
+        println!("timeouts:    {}", timeouts.iter().map(|(op, n)| format!("{op}={n}")).collect::<Vec<_>>().join(" "));
+    }
+    println!("frontier lag max: {}s", report.frontier_lag_secs_max);
+    println!(
+        "min contiguous days at end: {} (14d at {}, 30d at {})",
+        report.min_contiguous_days_end,
+        report.hours_to_contiguous_14.map_or("never".to_owned(), |h| format!("{h:.1}h")),
+        report.hours_to_contiguous_30.map_or("never".to_owned(), |h| format!("{h:.1}h"))
+    );
+    for sample in &report.samples {
+        println!("  h={:5.1} pending={:>7} lag={:>6}s contiguous={}", sample.hour, sample.pending, sample.frontier_lag_secs, sample.min_contiguous_days);
+    }
+    Ok(())
+}
+
+/// `timefusion run-unit --project ID [--source TABLE] [--date YYYY-MM-DD]
+/// [--op base|derived|dedup|hot|sealed|repair] [--slice-hours N]`
+///
+/// Execute ONE maintenance unit against the configured storage and print where
+/// its time went (scan/stage/commit/end-to-end deltas + wall). The per-unit
+/// cost decomposition as a command, not a fleet-counter inference. Point
+/// TIMEFUSION_DATA_DIR at a scratch dir so the journal holds no other
+/// claimable work.
+async fn run_unit_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
+    init_cli_tracing();
+    let mut source = "otel_logs_and_spans".to_string();
+    let mut project: Option<String> = None;
+    let mut date: Option<chrono::NaiveDate> = None;
+    let mut operation = timefusion::maintenance_coordinator::Operation::BaseRollup;
+    let mut slice_hours: i64 = 24;
+    let mut it = std::env::args().skip(2);
+    while let Some(a) = it.next() {
+        let mut value = |name: &str| -> anyhow::Result<String> { it.next().with_context(|| format!("{name} needs a value")) };
+        match a.as_str() {
+            "--source" => source = value("--source")?,
+            "--project" => project = Some(value("--project")?),
+            "--date" => date = Some(value("--date")?.parse().context("--date must be YYYY-MM-DD")?),
+            "--slice-hours" => slice_hours = value("--slice-hours")?.parse().context("--slice-hours must be an integer")?,
+            "--op" => {
+                operation = match value("--op")?.as_str() {
+                    "base" => timefusion::maintenance_coordinator::Operation::BaseRollup,
+                    "derived" => timefusion::maintenance_coordinator::Operation::DerivedRollup,
+                    "dedup" => timefusion::maintenance_coordinator::Operation::Dedup,
+                    "hot" => timefusion::maintenance_coordinator::Operation::HotPacking,
+                    "sealed" => timefusion::maintenance_coordinator::Operation::SealedConsolidation,
+                    "repair" => timefusion::maintenance_coordinator::Operation::Repair,
+                    other => anyhow::bail!("unknown --op {other}: base|derived|dedup|hot|sealed|repair"),
+                }
+            }
+            other => anyhow::bail!("unknown argument: {other} (usage: timefusion run-unit --project ID [--source T] [--date D] [--op OP] [--slice-hours N])"),
+        }
+    }
+    let project = project.context("--project is required")?;
+    let date = date.unwrap_or_else(|| clock::today_utc() - chrono::Duration::days(1));
+    let db = Database::with_config(Arc::new(cfg.clone())).await?;
+    let report = db.run_unit_once(&source, &project, date, operation, slice_hours).await?;
+    println!("{report}");
+    Ok(())
 }
 
 /// `timefusion redrive-dml [--dir PATH] [--dry-run]` — replay parked quarantine/dml

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,10 +301,12 @@ fn run_sim_cli() -> anyhow::Result<()> {
             "--scale" => cfg.duration_scale = value("--scale")?.parse().context("--scale must be a number")?,
             "--seed" => cfg.seed = u64::from_str_radix(value("--seed")?.trim_start_matches("0x"), 16).context("--seed must be hex")?,
             "--restarts-every-hours" => {
-                cfg.restart_every_micros = (value("--restarts-every-hours")?.parse::<f64>().context("--restarts-every-hours must be a number")? * 3_600_000_000.0) as i64
+                cfg.restart_every_micros =
+                    (value("--restarts-every-hours")?.parse::<f64>().context("--restarts-every-hours must be a number")? * 3_600_000_000.0) as i64
             }
             "--restart-at-hours" => {
-                cfg.restart_at_micros = Some((value("--restart-at-hours")?.parse::<f64>().context("--restart-at-hours must be a number")? * 3_600_000_000.0) as i64)
+                cfg.restart_at_micros =
+                    Some((value("--restart-at-hours")?.parse::<f64>().context("--restart-at-hours must be a number")? * 3_600_000_000.0) as i64)
             }
             "--no-mint" => cfg.mint_frontier = false,
             "--json" => json = true,

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -139,6 +139,50 @@ impl Operation {
     }
 }
 
+/// The operation mix a maintenance worker rotates through. One definition for
+/// the server loop (`run_coordinator_maintenance_once`) and the journal-replay
+/// simulator (`maintenance_sim`) — the sim exists to evaluate changes to this
+/// mix, so the two must never be able to drift apart.
+///
+/// BALANCED interleaves dependent publication with dedup: dedup/base receive
+/// three slots each; derived and file work each receive one. `claim_next`
+/// still applies deadline, recent-slice, dependency, and project fairness.
+///
+/// COVERAGE_SHORT gives the rollup chain the slots while
+/// `rollup_min_contiguous_days` is below goal: `dependencies_complete` makes
+/// BaseRollup depend on NOTHING, so of the balanced cycle six slots in ten go
+/// to work that cannot advance the metric governing 14d/30d latency (measured
+/// 2026-08-18). Every operation keeps at least one slot — file debt left at
+/// zero is how file counts ran to 2-3k and degraded every query (2026-08-01).
+pub const CYCLE_BALANCED: [Operation; 10] = [
+    Operation::Dedup,
+    Operation::BaseRollup,
+    Operation::DerivedRollup,
+    Operation::HotPacking,
+    Operation::Dedup,
+    Operation::BaseRollup,
+    Operation::SealedConsolidation,
+    Operation::Dedup,
+    Operation::BaseRollup,
+    Operation::Repair,
+];
+pub const CYCLE_COVERAGE_SHORT: [Operation; 10] = [
+    Operation::BaseRollup,
+    Operation::DerivedRollup,
+    Operation::BaseRollup,
+    Operation::Dedup,
+    Operation::BaseRollup,
+    Operation::DerivedRollup,
+    Operation::HotPacking,
+    Operation::BaseRollup,
+    Operation::SealedConsolidation,
+    Operation::Repair,
+];
+
+pub fn operation_cycle(coverage_short: bool) -> &'static [Operation; 10] {
+    if coverage_short { &CYCLE_COVERAGE_SHORT } else { &CYCLE_BALANCED }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct TimeSlice {
     pub start_micros: i64,

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -69,7 +69,16 @@ pub struct SimConfig {
 
 impl Default for SimConfig {
     fn default() -> Self {
-        Self { workers: 16, horizon_micros: 24 * 60 * 60 * MICROS, mint_frontier: true, streams: None, duration_scale: 1.0, restart_every_micros: 0, restart_at_micros: None, seed: 0x5EED }
+        Self {
+            workers: 16,
+            horizon_micros: 24 * 60 * 60 * MICROS,
+            mint_frontier: true,
+            streams: None,
+            duration_scale: 1.0,
+            restart_every_micros: 0,
+            restart_at_micros: None,
+            seed: 0x5EED,
+        }
     }
 }
 
@@ -193,9 +202,12 @@ impl Coverage {
         for (source, project) in &self.pairs {
             let mut contiguous = 0u64;
             let mut day = yesterday;
-            while self.days.get(&(source.clone(), project.clone())).and_then(|days| days.get(&day)).is_some_and(|widths| {
-                widths[0] >= DAY_MICROS && widths[1] >= DAY_MICROS
-            }) {
+            while self
+                .days
+                .get(&(source.clone(), project.clone()))
+                .and_then(|days| days.get(&day))
+                .is_some_and(|widths| widths[0] >= DAY_MICROS && widths[1] >= DAY_MICROS)
+            {
                 contiguous += 1;
                 day -= DAY_MICROS;
             }
@@ -282,10 +294,7 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
         streams.truncate(target);
     }
 
-    let mut coverage = Coverage {
-        days: HashMap::new(),
-        pairs: streams.iter().map(|s| (s.source.clone(), s.project_id.clone())).collect(),
-    };
+    let mut coverage = Coverage { days: HashMap::new(), pairs: streams.iter().map(|s| (s.source.clone(), s.project_id.clone())).collect() };
     // Seed coverage from already-complete rollup tasks so a fetched journal
     // starts with the coverage prod actually has.
     for task in journal.tasks() {
@@ -294,7 +303,11 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
         }
     }
 
-    let mut report = SimReport { hours: cfg.horizon_micros as f64 / 3_600_000_000.0, pending_start: journal.tasks().filter(|t| t.state != TaskState::Complete).count(), ..Default::default() };
+    let mut report = SimReport {
+        hours: cfg.horizon_micros as f64 / 3_600_000_000.0,
+        pending_start: journal.tasks().filter(|t| t.state != TaskState::Complete).count(),
+        ..Default::default()
+    };
     let mut workers = (0..cfg.workers).map(|_| Worker { busy_until: start_micros, current: None, cycle_pos: 0 }).collect::<Vec<_>>();
     let mut next_mint = start_micros + MINT_INTERVAL_MICROS;
     let mut next_restart = match (cfg.restart_at_micros, cfg.restart_every_micros) {
@@ -602,12 +615,7 @@ mod tests {
 
         let cfg_10x = SimConfig { streams: Some(260), ..cfg(2) };
         let report_10x = run(journal_with_streams(13), &cfg_10x, start).unwrap();
-        assert!(
-            report_10x.pending_end > 10 * pending_13.max(1),
-            "10x must diverge: pending {} vs {} at 13 projects",
-            report_10x.pending_end,
-            pending_13
-        );
+        assert!(report_10x.pending_end > 10 * pending_13.max(1), "10x must diverge: pending {} vs {} at 13 projects", report_10x.pending_end, pending_13);
         assert!(report_10x.frontier_lag_secs_max > report_13.frontier_lag_secs_max + 600, "10x lag must clearly exceed the 13-project lag");
     }
 

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -1,0 +1,678 @@
+//! Journal-replay simulator: run a real production `TaskJournal` through the
+//! PRODUCTION scheduler (`claim_next`, `abandon_running`, the shared operation
+//! cycle) on virtual time, with unit durations drawn from measured
+//! distributions. This is the iteration loop for scheduler policy: questions
+//! like "does the queue diverge at 130 projects" or "does contiguity-targeted
+//! ordering reach 30 days first" are answered here in seconds, not by a prod
+//! deploy followed by two hours of quiet (plan:
+//! `docs/plans/2026-08-18-an-architecture-that-keeps-up.md`, Phase 0.1).
+//!
+//! Fidelity, and where it deliberately stops:
+//! - REAL: task selection (`claim_next` with its sealed reservation, deadline
+//!   gating, dependency and fairness rules), timeout handling
+//!   (`abandon_running`: bisect-on-repeat, deadline-floored backoff), the
+//!   balanced/coverage-short cycle switch (driven by the sim's own contiguity
+//!   model), and frontier minting via `invalidate` (the same function the
+//!   write path calls).
+//! - MODELED: unit durations (uniform over a measured range per operation and
+//!   width class, `--scale` to stress), and the ingest mint cadence (one
+//!   10-minute invalidation per stream per 10 virtual minutes). Byte-driven
+//!   capacity splits (`retry_or_split`) and memory admission are NOT modeled —
+//!   a unit that would split on observed bytes in prod is a source of error
+//!   here, so day-sized whale units are the known fudge.
+//! - The real workers execute one unit per operation per call, sequentially;
+//!   the sim's workers claim one unit, run it, then claim again. Throughput is
+//!   equivalent; only intra-call op ordering is approximated.
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Context as _;
+use serde::Serialize;
+
+use crate::maintenance_coordinator::{Invalidation, MaintenanceTask, Operation, TaskJournal, TaskKey, TaskState, operation_cycle, operation_deadline_secs};
+
+const MICROS: i64 = 1_000_000;
+const DAY_MICROS: i64 = 86_400_000_000;
+/// Write path flushes a MemBuffer bucket every ten minutes; each flush
+/// invalidates its range. The sim mints on the same cadence.
+const MINT_INTERVAL_MICROS: i64 = crate::maintenance_coordinator::NORMAL_SLICE_MICROS;
+/// An idle worker re-polls at this cadence, so a task whose deadline matures
+/// while every worker is idle is still claimed promptly.
+const IDLE_POLL_MICROS: i64 = 5 * MICROS;
+
+#[derive(Clone, Debug)]
+pub struct SimConfig {
+    /// Coordinator jobs (prod: 16).
+    pub workers: usize,
+    /// Virtual time to simulate.
+    pub horizon_micros: i64,
+    /// Model ongoing ingest invalidations for the streams found in the journal.
+    pub mint_frontier: bool,
+    /// Override the minted stream count (10x experiments: 260 streams at 130
+    /// projects). Extra streams clone the first real stream's tables under
+    /// synthetic project ids.
+    pub streams: Option<usize>,
+    /// Multiplier on every sampled duration.
+    pub duration_scale: f64,
+    /// Model deploy/OOM restarts: re-invalidate the whole current day for
+    /// every stream — exactly what `reconcile_maintenance_task_cursors` does
+    /// on boot (per changed partition: `enqueue_maintenance_hours(ALL_HOURS)`,
+    /// which resets the day's COMPLETE frontier tasks back to Pending). The
+    /// dominant enqueue source under deploy churn: ~312 tasks per active
+    /// project per restart. `restart_every_micros` repeats on an interval
+    /// (0 = no periodic restarts); `restart_at_micros` fires ONE restart at a
+    /// fixed offset (backtesting a known boot time).
+    pub restart_every_micros: i64,
+    pub restart_at_micros: Option<i64>,
+    pub seed: u64,
+}
+
+impl Default for SimConfig {
+    fn default() -> Self {
+        Self { workers: 16, horizon_micros: 24 * 60 * 60 * MICROS, mint_frontier: true, streams: None, duration_scale: 1.0, restart_every_micros: 0, restart_at_micros: None, seed: 0x5EED }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct SimSample {
+    pub hour: f64,
+    pub pending: usize,
+    pub frontier_lag_secs: u64,
+    pub min_contiguous_days: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct SimReport {
+    pub hours: f64,
+    pub completions: HashMap<String, u64>,
+    pub timeouts: HashMap<String, u64>,
+    pub splits: u64,
+    pub executions: u64,
+    pub pending_start: usize,
+    pub pending_end: usize,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub tasks_end: HashMap<String, usize>,
+    pub frontier_lag_secs_max: u64,
+    pub min_contiguous_days_end: u64,
+    pub hours_to_contiguous_14: Option<f64>,
+    pub hours_to_contiguous_30: Option<f64>,
+    pub samples: Vec<SimSample>,
+}
+
+/// Measured duration ranges in seconds, per operation and width class.
+/// Sources: rollup phase timing (#174, prod 2026-08-18): 174 rollup starts,
+/// NOT ONE over 60s; the rollup counters put e2e at ~3s/unit. Debt units are
+/// the slow ones (#176): HotPacking 320-895s, SealedConsolidation 294-767s.
+/// Dedup is BIMODAL (#175/#177): quick, or past its 300s deadline — nothing
+/// finished between 75s and 300s in the measured window.
+fn duration_range_secs(operation: Operation, width_micros: i64, rng: &mut Rng) -> u64 {
+    let frontier = width_micros < DAY_MICROS;
+    let range = match (operation, frontier) {
+        (Operation::Dedup, true) => (50, 80),
+        (Operation::BaseRollup, true) => (5, 15),
+        (Operation::BaseRollup, false) => (10, 60),
+        (Operation::DerivedRollup, true) => (5, 15),
+        (Operation::DerivedRollup, false) => (10, 60),
+        (Operation::HotPacking, _) => (320, 895),
+        (Operation::SealedConsolidation, _) => (294, 767),
+        (Operation::Repair, _) => (600, 1200),
+        (Operation::Dedup, false) => {
+            // 70% quick, 30% past the deadline — the bimodal shape #175
+            // measured, and the reason a deadline change alone cannot fix it.
+            if rng.next() % 10 < 7 { (60, 240) } else { (300, 900) }
+        }
+    };
+    rng.uniform_secs(range.0, range.1)
+}
+
+/// Debt work = file rewrites that cannot advance rollup coverage
+/// (`dependencies_complete`): the operations #176's occupancy cap applies to.
+fn is_debt_op(operation: Operation) -> bool {
+    matches!(operation, Operation::Dedup | Operation::HotPacking | Operation::SealedConsolidation | Operation::Repair)
+}
+
+/// SplitMix64 — deterministic, dependency-free, good enough for a sim.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn uniform_secs(&mut self, lo: u64, hi: u64) -> u64 {
+        lo + self.next() % (hi - lo + 1)
+    }
+}
+
+/// One ingest stream: the tables a project invalidates per flush.
+#[derive(Clone, Debug)]
+struct Stream {
+    source_table: String,
+    base_rollup_table: String,
+    derived_rollup_table: Option<String>,
+    source: String,
+    project_id: String,
+}
+
+/// Contiguity model mirroring `min_contiguous_days`: a day counts once its
+/// base tier AND its derived tier each cover a full day's width; contiguity
+/// counts back from yesterday; the gauge is the MIN over active (source,
+/// project) pairs — including pairs with NO completed coverage, which count 0.
+struct Coverage {
+    /// (source, project) -> day_start -> [base_width, derived_width] micros.
+    days: HashMap<(String, String), BTreeMap<i64, [i64; 2]>>,
+    /// The active set: every stream found in the journal. The real gauge reads
+    /// recent source partitions, which is the same set by construction here.
+    pairs: Vec<(String, String)>,
+}
+
+impl Coverage {
+    fn record(&mut self, key: &TaskKey) {
+        let tier = match key.operation {
+            Operation::BaseRollup => 0,
+            Operation::DerivedRollup => 1,
+            _ => return,
+        };
+        // A slice can straddle midnight after time-bisection; credit each day
+        // it overlaps, clamped to that day.
+        let mut day = key.slice.start_micros.div_euclid(DAY_MICROS) * DAY_MICROS;
+        while day < key.slice.end_micros {
+            let overlap = (key.slice.end_micros.min(day + DAY_MICROS) - key.slice.start_micros.max(day)).max(0);
+            self.days.entry((key.source.clone(), key.project_id.clone())).or_default().entry(day).or_default()[tier] += overlap;
+            day += DAY_MICROS;
+        }
+    }
+
+    fn min_contiguous_days(&self, now_micros: i64) -> u64 {
+        let yesterday = (now_micros.div_euclid(DAY_MICROS) - 1) * DAY_MICROS;
+        let mut min = u64::MAX;
+        for (source, project) in &self.pairs {
+            let mut contiguous = 0u64;
+            let mut day = yesterday;
+            while self.days.get(&(source.clone(), project.clone())).and_then(|days| days.get(&day)).is_some_and(|widths| {
+                widths[0] >= DAY_MICROS && widths[1] >= DAY_MICROS
+            }) {
+                contiguous += 1;
+                day -= DAY_MICROS;
+            }
+            min = min.min(contiguous);
+        }
+        if min == u64::MAX { 0 } else { min }
+    }
+}
+
+/// One ingest flush (or one restart reconciliation) for one stream: the base
+/// invalidation mints Dedup + BaseRollup over the range's 10-minute slices;
+/// the derived invalidation mints the hour-aligned DerivedRollup units.
+/// `observed_at` sets the finalization deadline — the flush time for minting,
+/// the boot time for a restart reconcile.
+fn mint_stream(journal: &mut TaskJournal, stream: &Stream, start_micros: i64, end_micros: i64, observed_at_micros: i64) {
+    for derived in [false, true] {
+        if derived && stream.derived_rollup_table.is_none() {
+            continue;
+        }
+        let rollup_table = if derived { stream.derived_rollup_table.as_deref().unwrap_or(&stream.base_rollup_table) } else { &stream.base_rollup_table };
+        // Minting must not fail the sim on a pathological journal; an
+        // invalidation error means a skipped window, not a crash.
+        let _ = journal.invalidate(Invalidation {
+            source_table: &stream.source_table,
+            rollup_table,
+            source: &stream.source,
+            project_id: &stream.project_id,
+            start_micros,
+            end_micros,
+            observed_at_micros,
+            derived,
+        });
+    }
+}
+
+struct Worker {
+    busy_until: i64,
+    current: Option<(TaskKey, u64)>,
+    cycle_pos: usize,
+}
+
+/// Replayed over `[start_micros, start_micros + horizon)`. The journal's own
+/// deadlines are in real time, so `start_micros` should be real "now" for a
+/// freshly fetched prod journal.
+pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyhow::Result<SimReport> {
+    let mut rng = Rng(cfg.seed);
+    let end = start_micros.saturating_add(cfg.horizon_micros);
+
+    // Streams from the journal: dedup tasks name the source table, rollup
+    // tasks name the tier tables. No tasks -> no minting (an empty journal
+    // just idles, which is itself a valid answer).
+    let mut streams: Vec<Stream> = Vec::new();
+    for task in journal.tasks() {
+        let key = &task.key;
+        let position = match streams.iter().position(|s| s.source == key.source && s.project_id == key.project_id) {
+            Some(position) => position,
+            None => {
+                streams.push(Stream {
+                    source_table: key.source.clone(),
+                    base_rollup_table: key.physical_table.clone(),
+                    derived_rollup_table: None,
+                    source: key.source.clone(),
+                    project_id: key.project_id.clone(),
+                });
+                streams.len() - 1
+            }
+        };
+        let stream = &mut streams[position];
+        match key.operation {
+            Operation::Dedup | Operation::HotPacking => stream.source_table = key.physical_table.clone(),
+            Operation::BaseRollup => stream.base_rollup_table = key.physical_table.clone(),
+            Operation::DerivedRollup => stream.derived_rollup_table = Some(key.physical_table.clone()),
+            _ => {}
+        }
+    }
+    anyhow::ensure!(!streams.is_empty() || !cfg.mint_frontier, "no streams found in journal; pass --no-mint");
+    if let Some(target) = cfg.streams {
+        let Some(template) = streams.first().cloned() else { anyhow::bail!("--streams needs at least one real stream in the journal") };
+        while streams.len() < target {
+            let mut synthetic = template.clone();
+            synthetic.project_id = format!("synth-{}", streams.len());
+            streams.push(synthetic);
+        }
+        streams.truncate(target);
+    }
+
+    let mut coverage = Coverage {
+        days: HashMap::new(),
+        pairs: streams.iter().map(|s| (s.source.clone(), s.project_id.clone())).collect(),
+    };
+    // Seed coverage from already-complete rollup tasks so a fetched journal
+    // starts with the coverage prod actually has.
+    for task in journal.tasks() {
+        if task.state == TaskState::Complete {
+            coverage.record(&task.key);
+        }
+    }
+
+    let mut report = SimReport { hours: cfg.horizon_micros as f64 / 3_600_000_000.0, pending_start: journal.tasks().filter(|t| t.state != TaskState::Complete).count(), ..Default::default() };
+    let mut workers = (0..cfg.workers).map(|_| Worker { busy_until: start_micros, current: None, cycle_pos: 0 }).collect::<Vec<_>>();
+    let mut next_mint = start_micros + MINT_INTERVAL_MICROS;
+    let mut next_restart = match (cfg.restart_at_micros, cfg.restart_every_micros) {
+        (Some(at), _) => start_micros + at,
+        (None, every) if every > 0 => start_micros + every,
+        _ => i64::MAX,
+    };
+    let tick = (cfg.horizon_micros / 48).max(3_600 * MICROS);
+    let mut next_tick = start_micros + tick;
+    let mut now = start_micros;
+    // #176: (jobs * 3 / 4).max(1) — the floor keeps debt work possible at all
+    // on a one-worker box.
+    let debt_cap = (cfg.workers * 3 / 4).max(1);
+    // Per-op "known empty until" memo. `claim_next` is deterministic given
+    // (journal state, now), and a None result can only be invalidated by (a) a
+    // state change — completion, timeout/abandon, mint, restart — or (b) a
+    // deadline maturing. So a None at time T holds until the op's next future
+    // deadline; memoizing that collapses the idle-worker rescans that
+    // otherwise dominate wall time on a production-sized journal (16 workers x
+    // up to 12 full scans per wake event). One side effect is lost: the
+    // skipped calls would have bumped `claim_tick`, so the sealed-reservation
+    // parity shifts slightly — reservation SHARE over time is unchanged.
+    let mut none_until = [0i64; 6];
+    // Evaluated before any claim, so the initial cycle matches the journal's
+    // seeded coverage.
+    let mut coverage_short = coverage.min_contiguous_days(now) < crate::database::COVERAGE_SHORT_DAYS;
+
+    while now < end {
+        let next_worker_free = workers.iter().map(|w| w.busy_until).min().unwrap_or(end);
+        now = next_worker_free.min(next_mint).min(next_tick).min(next_restart).min(end);
+        if now >= end {
+            break;
+        }
+
+        if now >= next_mint {
+            if cfg.mint_frontier {
+                for stream in &streams {
+                    mint_stream(&mut journal, stream, next_mint - MINT_INTERVAL_MICROS, next_mint, next_mint);
+                }
+            }
+            none_until = [0; 6];
+            // The cadence advances whether or not minting is on — otherwise
+            // `next_mint` pins `now` here forever.
+            next_mint += MINT_INTERVAL_MICROS;
+        }
+
+        if now >= next_restart {
+            for stream in &streams {
+                // The boot reconcile enqueues per partition that saw commits
+                // while down. PRE-FIX behavior modeled here: ALL_HOURS per
+                // partition (~312 tasks per active stream per restart), because
+                // Delta commit granularity is the partition-day. The 2026-08-18
+                // fix derives the touched hours from commit file stats, which
+                // shrinks this to ~13 tasks per stream — rerun the backtest
+                // with restarts after it deploys and the queue growth should
+                // be gone; this model is the before/after measurement.
+                let day_start = now.div_euclid(DAY_MICROS) * DAY_MICROS;
+                mint_stream(&mut journal, stream, day_start, day_start + DAY_MICROS, now);
+            }
+            none_until = [0; 6];
+            next_restart = if cfg.restart_every_micros > 0 { next_restart + cfg.restart_every_micros } else { i64::MAX };
+        }
+
+        let mut debt_busy = workers.iter().filter(|w| w.current.as_ref().is_some_and(|(key, _)| is_debt_op(key.operation))).count();
+        for worker in &mut workers {
+            if worker.busy_until > now {
+                continue;
+            }
+            if let Some((key, duration_secs)) = worker.current.take() {
+                if is_debt_op(key.operation) {
+                    debt_busy -= 1;
+                }
+                let deadline_secs = operation_deadline_secs(key.operation);
+                if duration_secs <= deadline_secs {
+                    journal.complete(&key);
+                    none_until = [0; 6];
+                    if matches!(key.operation, Operation::BaseRollup | Operation::DerivedRollup) {
+                        coverage.record(&key);
+                        let contiguous = coverage.min_contiguous_days(now);
+                        coverage_short = contiguous < crate::database::COVERAGE_SHORT_DAYS;
+                        // Capture milestones at the crossing event, not just at
+                        // report ticks — a tick can land just short of a day
+                        // boundary and read one day less.
+                        if contiguous >= 14 && report.hours_to_contiguous_14.is_none() {
+                            report.hours_to_contiguous_14 = Some((now - start_micros) as f64 / 3_600_000_000.0);
+                        }
+                        if contiguous >= 30 && report.hours_to_contiguous_30.is_none() {
+                            report.hours_to_contiguous_30 = Some((now - start_micros) as f64 / 3_600_000_000.0);
+                        }
+                    }
+                    *report.completions.entry(format!("{:?}", key.operation)).or_default() += 1;
+                } else {
+                    // Timeout: the worker burned the whole deadline, then the
+                    // lease drop abandons the unit — bisect on repeat, else
+                    // deadline-floored backoff. Real code, not a re-imagination.
+                    journal.abandon_running(&key, now);
+                    none_until = [0; 6];
+                    match journal.state(&key) {
+                        Some(TaskState::Superseded) => report.splits += 1,
+                        _ => *report.timeouts.entry(format!("{:?}", key.operation)).or_default() += 1,
+                    }
+                }
+                report.executions += 1;
+            }
+            // Claim the next unit, rotating through the shared cycle exactly
+            // like `run_coordinator_maintenance_once`. While coverage is short,
+            // debt work may occupy at most 3/4 of workers — #176's
+            // `maintenance_debt_slots`, the occupancy cap that keeps
+            // quarter-hour file rewrites from starving seconds-long rollups.
+            let cycle = operation_cycle(coverage_short);
+            let mut claimed: Option<MaintenanceTask> = None;
+            for offset in 0..cycle.len() {
+                let position = (worker.cycle_pos + offset) % cycle.len();
+                let operation = cycle[position];
+                if coverage_short && is_debt_op(operation) && debt_busy >= debt_cap {
+                    continue;
+                }
+                if now < none_until[operation as usize] {
+                    continue;
+                }
+                if let Some(task) = journal.claim_next(operation, now) {
+                    if is_debt_op(operation) {
+                        debt_busy += 1;
+                    }
+                    worker.cycle_pos = position + 1;
+                    claimed = Some(task);
+                    break;
+                }
+                // A None holds until this op's next deadline matures or any
+                // state change (all of which reset the memo above).
+                none_until[operation as usize] = journal
+                    .tasks()
+                    .filter(|t| t.key.operation == operation && matches!(t.state, TaskState::Pending | TaskState::Retry) && t.deadline_micros > now)
+                    .map(|t| t.deadline_micros)
+                    .min()
+                    .unwrap_or(i64::MAX);
+            }
+            match claimed {
+                Some(task) => {
+                    let duration_secs = (duration_range_secs(task.key.operation, task.key.slice.width(), &mut rng) as f64 * cfg.duration_scale) as u64;
+                    let burn_secs = duration_secs.min(operation_deadline_secs(task.key.operation));
+                    worker.current = Some((task.key, duration_secs));
+                    worker.busy_until = now + (burn_secs as i64) * MICROS;
+                }
+                None => {
+                    // Nothing claimable: jump straight to the next eligibility
+                    // instant instead of polling — an idle worker re-scanning
+                    // 38k tasks every 5 virtual seconds is what made the sim
+                    // itself slow, not any property of the schedule.
+                    let next_eligible = journal
+                        .tasks()
+                        .filter(|t| matches!(t.state, TaskState::Pending | TaskState::Retry) && t.deadline_micros > now)
+                        .map(|t| t.deadline_micros)
+                        .min();
+                    worker.busy_until = next_eligible.unwrap_or(now + IDLE_POLL_MICROS).max(now + 1);
+                }
+            }
+        }
+
+        if now >= next_tick {
+            let lag = frontier_lag_secs(&journal, now);
+            report.frontier_lag_secs_max = report.frontier_lag_secs_max.max(lag);
+            let contiguous = coverage.min_contiguous_days(now);
+            if contiguous >= 14 && report.hours_to_contiguous_14.is_none() {
+                report.hours_to_contiguous_14 = Some((now - start_micros) as f64 / 3_600_000_000.0);
+            }
+            if contiguous >= 30 && report.hours_to_contiguous_30.is_none() {
+                report.hours_to_contiguous_30 = Some((now - start_micros) as f64 / 3_600_000_000.0);
+            }
+            report.samples.push(SimSample {
+                hour: (now - start_micros) as f64 / 3_600_000_000.0,
+                pending: journal.tasks().filter(|t| !matches!(t.state, TaskState::Complete | TaskState::Superseded)).count(),
+                frontier_lag_secs: lag,
+                min_contiguous_days: contiguous,
+            });
+            next_tick += tick;
+        }
+    }
+
+    report.min_contiguous_days_end = coverage.min_contiguous_days(now);
+    report.pending_end = journal.tasks().filter(|t| !matches!(t.state, TaskState::Complete | TaskState::Superseded)).count();
+    for task in journal.tasks() {
+        *report.tasks_end.entry(format!("{:?}/{:?}", task.key.operation, task.state)).or_default() += 1;
+    }
+    Ok(report)
+}
+
+/// `eligible_watermark_lag_seconds`, simplified for the sim: the oldest
+/// eligible, unfinished frontier task's lateness. The production gauge adds a
+/// per-stream watermark; the sim needs only the trend.
+fn frontier_lag_secs(journal: &TaskJournal, now_micros: i64) -> u64 {
+    journal
+        .tasks()
+        .filter(|task| {
+            !matches!(task.state, TaskState::Complete | TaskState::Superseded)
+                && task.deadline_micros <= now_micros
+                && task.key.slice.end_micros >= now_micros.saturating_sub(crate::maintenance_coordinator::LIVE_FRONTIER_WINDOW_MICROS)
+        })
+        .map(|task| u64::try_from(now_micros.saturating_sub(task.deadline_micros).div_euclid(MICROS)).unwrap_or_default())
+        .max()
+        .unwrap_or_default()
+}
+
+/// Load a journal from a copied-out prod file or data dir WITHOUT ever being
+/// able to write back to the source: the inputs are copied into a tempdir and
+/// the journal is loaded from there. Returns the journal and the tempdir
+/// guard (dropped last -> files cleaned up).
+pub fn load_sandboxed(input: &std::path::Path) -> anyhow::Result<(TaskJournal, tempfile::TempDir)> {
+    let dir = tempfile::tempdir().context("create sim sandbox")?;
+    let meta = dir.path().join(".timefusion_meta");
+    std::fs::create_dir_all(&meta)?;
+    let (json, wal) = if input.is_dir() {
+        (input.join(".timefusion_meta/maintenance_tasks.json"), input.join(".timefusion_meta/maintenance_tasks.wal"))
+    } else {
+        (input.to_path_buf(), input.with_extension("wal"))
+    };
+    std::fs::copy(&json, meta.join("maintenance_tasks.json")).with_context(|| format!("copy {}", json.display()))?;
+    if wal.exists() {
+        std::fs::copy(&wal, meta.join("maintenance_tasks.wal")).with_context(|| format!("copy {}", wal.display()))?;
+    }
+    let journal = TaskJournal::load(dir.path())?;
+    Ok((journal, dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::maintenance_coordinator::{MAX_DECODED_BYTES, TimeSlice};
+
+    const HOUR: i64 = 3_600 * MICROS;
+
+    fn key(project: &str, op: Operation, start: i64, width: i64) -> TaskKey {
+        let table = match op {
+            Operation::BaseRollup => "otel_logs_and_spans_rollup_dashboard_1m_v3",
+            Operation::DerivedRollup => "otel_logs_and_spans_rollup_dashboard_1h_v2",
+            _ => "otel_logs_and_spans",
+        };
+        TaskKey {
+            physical_table: table.to_owned(),
+            source: "otel_logs_and_spans".to_owned(),
+            project_id: project.to_owned(),
+            slice: TimeSlice::new(start, start + width).unwrap(),
+            operation: op,
+        }
+    }
+
+    fn empty_journal() -> TaskJournal {
+        let dir = tempfile::tempdir().unwrap();
+        TaskJournal::load(dir.path()).unwrap()
+    }
+
+    /// One completed frontier task per project, so stream extraction sees the
+    /// requested number of streams.
+    fn journal_with_streams(projects: usize) -> TaskJournal {
+        let mut journal = empty_journal();
+        for i in 0..projects {
+            let mut task = crate::maintenance_coordinator::MaintenanceTask {
+                key: key(&format!("p{i}"), Operation::BaseRollup, 60 * DAY_MICROS, crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+                state: TaskState::Complete,
+                deadline_micros: 0,
+                estimated_decoded_bytes: 0,
+                hash_shard: 0,
+                hash_shards: 1,
+                attempts: 0,
+                created_unix_ms: 0,
+                retry_reason: None,
+                publication: None,
+            };
+            journal.upsert(task.clone());
+            task.key.operation = Operation::DerivedRollup;
+            journal.upsert(task);
+        }
+        journal
+    }
+
+    fn cfg(hours: i64) -> SimConfig {
+        SimConfig { horizon_micros: hours * HOUR, ..Default::default() }
+    }
+
+    #[test]
+    fn an_idle_journal_stays_idle() {
+        let idle = SimConfig { mint_frontier: false, ..cfg(2) };
+        let report = run(empty_journal(), &idle, 100 * DAY_MICROS).unwrap();
+        assert_eq!(report.executions, 0, "nothing to do means nothing done");
+        assert_eq!(report.pending_end, 0);
+        // Minting with no streams to mint from is a caller error, not silence.
+        let report = run(empty_journal(), &cfg(1), 100 * DAY_MICROS);
+        assert!(report.is_err(), "no streams + minting must say so");
+    }
+
+    #[test]
+    fn frontier_keeps_up_at_13_projects_and_diverges_at_10x() {
+        // The G6 arithmetic from the plan, executable: 26 streams mint ~8,100
+        // units/day against ~15k/day of small-unit capacity; 260 streams mint
+        // ~81,000. The 10x case runs a shorter horizon — divergence shows up
+        // within two virtual hours.
+        let start = 100 * DAY_MICROS;
+        let report_13 = run(journal_with_streams(13), &cfg(6), start).unwrap();
+        let pending_13 = report_13.pending_end;
+        assert!(
+            report_13.frontier_lag_secs_max < 3 * crate::maintenance_coordinator::FRONTIER_LAG_BUDGET_SECS,
+            "13 projects must hold the frontier, lag {}s",
+            report_13.frontier_lag_secs_max
+        );
+
+        let cfg_10x = SimConfig { streams: Some(260), ..cfg(2) };
+        let report_10x = run(journal_with_streams(13), &cfg_10x, start).unwrap();
+        assert!(
+            report_10x.pending_end > 10 * pending_13.max(1),
+            "10x must diverge: pending {} vs {} at 13 projects",
+            report_10x.pending_end,
+            pending_13
+        );
+        assert!(report_10x.frontier_lag_secs_max > report_13.frontier_lag_secs_max + 600, "10x lag must clearly exceed the 13-project lag");
+    }
+
+    #[test]
+    fn a_sealed_backlog_builds_contiguous_coverage() {
+        // 2 projects x 30 sealed days x (base + derived day units), no minting.
+        // ~120 heavy units on 16 workers: ~400s each, so well under a virtual
+        // day to clear, and contiguity must reach 30.
+        let mut journal = journal_with_streams(0);
+        let start = 100 * DAY_MICROS;
+        for p in ["a", "b"] {
+            for day in 0..30i64 {
+                // Contiguity counts back from yesterday at sim END (start + 24h
+                // = day 101), so the window is days 100..=71 relative to start.
+                let day_start = start - day * DAY_MICROS;
+                for op in [Operation::BaseRollup, Operation::DerivedRollup] {
+                    journal.enqueue(key(p, op, day_start, DAY_MICROS), start, MAX_DECODED_BYTES, 0);
+                }
+            }
+        }
+        let cfg = SimConfig { mint_frontier: false, ..cfg(25) };
+        let report = run(journal, &cfg, start).unwrap();
+        assert_eq!(report.min_contiguous_days_end, 30, "all 30 sealed days built: {report:#?}");
+        assert!(report.hours_to_contiguous_30.is_some(), "the moment of arrival is recorded");
+        assert_eq!(report.pending_end, 0, "nothing left pending");
+    }
+
+    #[test]
+    fn a_unit_that_overruns_its_deadline_twice_is_bisected() {
+        // One day-sized dedup unit: sampled durations are 300-500s against the
+        // 300s dedup deadline, so timeouts are likely; a repeat timeout must
+        // split via the REAL abandon_running. With scale 10x, a timeout is
+        // certain.
+        let mut journal = journal_with_streams(0);
+        let start = 100 * DAY_MICROS;
+        journal.enqueue(key("a", Operation::Dedup, start - DAY_MICROS, DAY_MICROS), start, MAX_DECODED_BYTES, 0);
+        let cfg = SimConfig { mint_frontier: false, duration_scale: 10.0, workers: 1, ..cfg(12) };
+        let report = run(journal, &cfg, start).unwrap();
+        assert!(report.splits >= 1, "repeat overruns must bisect the unit: {report:#?}");
+    }
+
+    #[test]
+    fn restarts_reenqueue_whole_days_and_grow_the_queue() {
+        // The 2026-08-18 backtest finding: with no restarts the frontier is
+        // self-draining; each restart re-invalidates the whole current day per
+        // stream (the boot reconcile's ALL_HOURS), which is the queue's
+        // dominant growth source under deploy churn.
+        let start = 100 * DAY_MICROS;
+        let calm = run(journal_with_streams(4), &cfg(2), start).unwrap();
+        let churning = run(journal_with_streams(4), &SimConfig { restart_every_micros: HOUR, ..cfg(2) }, start).unwrap();
+        assert!(
+            churning.pending_end > calm.pending_end + 100,
+            "hourly restarts must re-enqueue whole days: calm {} vs churning {}",
+            calm.pending_end,
+            churning.pending_end
+        );
+    }
+
+    #[test]
+    fn the_sim_is_deterministic_per_seed() {
+        let start = 100 * DAY_MICROS;
+        let a = run(journal_with_streams(4), &cfg(3), start).unwrap();
+        let b = run(journal_with_streams(4), &cfg(3), start).unwrap();
+        assert_eq!(a.executions, b.executions);
+        assert_eq!(a.pending_end, b.pending_end);
+        assert_eq!(a.frontier_lag_secs_max, b.frontier_lag_secs_max);
+    }
+}

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -1758,7 +1758,6 @@ mod tests {
         assert_eq!(hours_from_stats_json("not json", day_start), None);
     }
 
-
     fn spec() -> RollupSpec {
         crate::schema_loader::get_schema(SOURCE).expect("source schema").rollups.first().expect("declared rollup").clone()
     }

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -103,6 +103,38 @@ pub fn build_partition_sql(spec: &RollupSpec, source: &str, project_id: &str, da
 /// One bit per hour of a UTC day. `ALL_HOURS` is the conservative value: every
 /// invalidation means it unless the caller can prove a narrower set.
 pub(crate) const ALL_HOURS: u32 = (1 << 24) - 1;
+
+/// The hours of a partition-day a committed file can hold rows for, from its
+/// Delta stats JSON (`minValues.timestamp` / `maxValues.timestamp`). `None`
+/// when stats or timestamp bounds are absent — the caller falls back to
+/// `ALL_HOURS`, never to skipping work. A computed mask of zero (bounds
+/// entirely outside the partition day) is likewise treated as absent.
+///
+/// This is what lets a boot reconcile invalidate the ONE hour a downtime
+/// commit actually touched instead of all 24 (`enqueue_maintenance_hours`
+/// with `ALL_HOURS` was ~312 durable tasks per active project per restart,
+/// prod 2026-08-18 — the queue's dominant growth source under deploy churn).
+pub(crate) fn hours_from_stats_json(stats: &str, day_start_micros: i64) -> Option<u32> {
+    let value: serde_json::Value = serde_json::from_str(stats).ok()?;
+    // Writers spell timestamp bounds either as epoch micros or RFC 3339.
+    let parse_ts = |side: &str| -> Option<i64> {
+        let v = value.get(side)?.get("timestamp")?;
+        if let Some(micros) = v.as_i64() {
+            return Some(micros);
+        }
+        chrono::DateTime::parse_from_rfc3339(v.as_str()?).ok().map(|t| t.timestamp_micros())
+    };
+    let (lo, hi) = (parse_ts("minValues")?, parse_ts("maxValues")?);
+    let (lo_h, hi_h) = ((lo - day_start_micros).div_euclid(HOUR_MICROS), (hi - day_start_micros).div_euclid(HOUR_MICROS));
+    if hi_h < 0 || lo_h >= 24 || lo_h > hi_h {
+        return None;
+    }
+    let mut mask = 0u32;
+    for hour in lo_h.clamp(0, 23)..=hi_h.clamp(0, 23) {
+        mask |= 1 << hour;
+    }
+    (mask != 0).then_some(mask)
+}
 pub(crate) const ROLLUP_COHORT_MAX_PROJECTS: usize = 64;
 pub(crate) const ROLLUP_COHORT_MAX_DECODED_BYTES: u64 = 512 * 1024 * 1024;
 pub(crate) const ROLLUP_WAVE_MAX_PROJECTS: usize = 1_024;
@@ -1696,6 +1728,36 @@ mod tests {
     use std::sync::Arc;
 
     const SOURCE: &str = "otel_logs_and_spans";
+
+    #[test]
+    fn hours_from_stats_json_bounds_the_hours_a_file_can_touch() {
+        let day_start = chrono::NaiveDate::from_ymd_opt(2026, 8, 18).unwrap().and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_micros();
+        let at = |hour: i64, minute: i64| day_start + hour * HOUR_MICROS + minute * 60 * 1_000_000;
+
+        // Epoch micros form: a file spanning 09:10..10:45 touches hours 9 and 10.
+        let stats = format!(r#"{{"numRecords": 100, "minValues": {{"timestamp": {}}}, "maxValues": {{"timestamp": {}}}}}"#, at(9, 10), at(10, 45));
+        assert_eq!(hours_from_stats_json(&stats, day_start), Some(0b11 << 9));
+
+        // RFC 3339 form: a point file touches exactly one hour.
+        let stats = r#"{"minValues": {"timestamp": "2026-08-18T03:00:00Z"}, "maxValues": {"timestamp": "2026-08-18T03:59:59.999999Z"}}"#;
+        assert_eq!(hours_from_stats_json(stats, day_start), Some(1 << 3));
+
+        // A whole-day file is honestly all hours.
+        let stats = format!(r#"{{"minValues": {{"timestamp": {}}}, "maxValues": {{"timestamp": {}}}}}"#, day_start, day_start + 24 * HOUR_MICROS - 1);
+        assert_eq!(hours_from_stats_json(&stats, day_start), Some(ALL_HOURS));
+
+        // Bounds spilling outside the partition day are clamped, never trusted
+        // into an empty mask.
+        let stats = format!(r#"{{"minValues": {{"timestamp": {}}}, "maxValues": {{"timestamp": {}}}}}"#, day_start - 5 * HOUR_MICROS, at(2, 0));
+        assert_eq!(hours_from_stats_json(&stats, day_start), Some(0b111));
+        let stats = format!(r#"{{"minValues": {{"timestamp": {}}}, "maxValues": {{"timestamp": {}}}}}"#, day_start - 5 * HOUR_MICROS, day_start - HOUR_MICROS);
+        assert_eq!(hours_from_stats_json(&stats, day_start), None, "a file wholly outside the day must read as unknown, not as nothing");
+
+        // No stats, no timestamp bounds, garbage: all unknown.
+        assert_eq!(hours_from_stats_json(r#"{"numRecords": 5}"#, day_start), None);
+        assert_eq!(hours_from_stats_json("not json", day_start), None);
+    }
+
 
     fn spec() -> RollupSpec {
         crate::schema_loader::get_schema(SOURCE).expect("source schema").rollups.first().expect("declared rollup").clone()


### PR DESCRIPTION
Plan Phase 0+1.2 of docs/plans/2026-08-18-an-architecture-that-keeps-up.md (included in this PR).

**Root cause (found by sim backtest against the real prod journal):** every restart re-enqueued ~312 durable tasks per active stream and reset the day's completed frontier work — `reconcile_maintenance_task_cursors` invalidated ALL_HOURS per partition named by missed commits, and unified-table flush commits name every project. Prod measured +5,876 pending base rollups in one hour across ONE OOM restart; the handover's unexplained +12,906 traces to the same mechanism across 5 restarts.

**Fix:** touched hours derived from Add-action timestamp stats; ALL_HOURS only for remove-only partitions or missing stats. Restart cost: ~13 tasks per touched stream-hour.

**Also in this PR (the tooling that produced the finding):** `timefusion sim` journal-replay simulator, `timefusion run-unit` CLI, shared `operation_cycle`.

Verified: cargo lint clean; sim 6/6; rollup 79/79 (incl. MinIO parity); maintenance/coordinator 110/110. Local sqllogictest concurrency failures reproduce on clean master (pre-existing env issue, CI runs the real gate).