### PR TITLE
fix(maintenance): back a not-yet-flushed slice off past its own end

### DIFF
--- a/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
+++ b/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
@@ -459,6 +459,59 @@ are untouched.
 `pending_base_rollup` turns over; `eligible_watermark_lag_seconds` stops
 tracking wall clock 1:1.
 
+### The loop this sits in, and why the same fix is the entry point
+
+Aggregate read counters over the same 180s window:
+
+```
+parquet.files_planned   +73,535   =  408 file-opens per second
+parquet.read_time_us    +28,640s  =  ~389 ms per file, ~159 readers' worth
+parquet.bytes_read      +8.09 GB  =  45 MB/s for all that effort
+parquet.scans           +218      =  ~337 files planned PER SCAN
+```
+
+A `ScanMetadataCompleted` line for one window reads `active_add_files=186,
+active_add_files_bytes=186,419,280` — **~1 MB per file against the 256 MB
+`COORDINATOR_SEALED_TARGET_BYTES`**. Partitions are fragmented by two orders of
+magnitude, so every query and every rollup unit pays hundreds of ~389 ms
+object-store round trips to read a few megabytes.
+
+That closes a self-sustaining loop:
+
+```
+fragmented partitions -> rollup day units exceed 900s -> timeouts burn 73%
+of capacity -> HotPacking/SealedConsolidation never run -> partitions stay
+fragmented
+```
+
+Queries and maintenance are not two problems; they are the same file count seen
+from two directions. The quarantine cap is the entry point precisely because it
+is the only one of these arrows that can be cut without first fixing the others
+— it reclaims the capacity that consolidation needs, and consolidation is what
+makes both the rollup units and the queries cheap.
+
+**Sequencing that follows:** measure the reclaimed capacity first, and only then
+decide whether consolidation throughput is itself sufficient. If partitions
+defragment, rollup day units start fitting and coverage builds without any
+further change. If they do not, the next lever is consolidation's own unit cost,
+not the scheduler.
+
+### Two secondary defects found while measuring (neither is today's blocker)
+
+1. **`decode_polls_inflight` leaks.** `decode_begin`/`decode_end` bracket an
+   `await` on the object store (`database.rs:19193/19208`), so a cancelled query
+   — and prod cancels 127 per 25 min — drops the future between them and never
+   decrements. The gauge rises monotonically with `peak == current` (10,408 and
+   climbing ~200/min). Harmless to the semaphore, which returns owned permits on
+   drop, but it makes `decode_peak_batch_bytes × decode_polls_inflight_peak` —
+   the figure the comment says to size a Transient budget from — meaningless.
+2. **`DataSourceExec.output_bytes` overstates by ~15x** when batches are split
+   (1,567 MB reported vs 106 MB at the FilterExec directly above it, same
+   228.1 K rows), because a sliced batch's `get_array_memory_size` still counts
+   the whole parent buffer. Do not read that field as I/O; the plan's earlier
+   "hot leg materialises 1.5 GB" reading came from this and is wrong. The hot
+   leg's real cost is `time_elapsed_opening = 2.88s` over 48 local files.
+
 ---
 
 ## 6. Phase 2 — aim the backfill at the goal (enqueue control)

--- a/src/database.rs
+++ b/src/database.rs
@@ -1081,6 +1081,31 @@ const COORDINATOR_FILE_REWRITE_TIMEOUT: std::time::Duration =
 /// or dispatcher without racing the file-rewrite timeout at the same instant.
 const COORDINATOR_LOOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(16 * 60);
 
+/// How long before a unit whose source is still buffered could possibly run.
+///
+/// `has_rows_in_range` is not a transient condition when the slice reaches into
+/// time that has not finished yet: a day-wide unit covering TODAY sees buffered
+/// rows on every attempt until midnight, so the flat five-second retry this used
+/// to take was an unbounded spin. Prod 2026-08-18 21:00 UTC had exactly that —
+/// one BaseRollup task at **attempts=195** on today's day-wide slice, re-claimed
+/// every 30-70 seconds for hours.
+///
+/// It is not a harmless spin, because a 5s backoff leaves the task permanently
+/// eligible while genuinely fresh work still waits on a real deadline, and
+/// `claim_next` takes the smallest ready `(class, order_key)`. So the doomed few
+/// monopolise claims: of 427 task starts in 90 minutes, **134 went to tasks with
+/// 100+ attempts and 267 to tasks with 10+**, against ~40,000 pending BaseRollup
+/// units that were never reached.
+///
+/// The earliest the slice can be complete is its own end plus the finalization
+/// delay the write path already honours. Floored at five seconds, so a sealed
+/// slice merely waiting on a slow flush behaves exactly as it did before.
+fn buffered_source_retry_delay(slice: crate::maintenance_coordinator::TimeSlice, now_micros: i64) -> std::time::Duration {
+    const FLOOR: std::time::Duration = std::time::Duration::from_secs(5);
+    let earliest = slice.end_micros.saturating_add(crate::maintenance_coordinator::FINALIZATION_DELAY_MICROS);
+    u64::try_from(earliest.saturating_sub(now_micros)).map_or(FLOOR, |micros| std::time::Duration::from_micros(micros).max(FLOOR))
+}
+
 fn coordinator_operation_timeout(operation: crate::maintenance_coordinator::Operation) -> std::time::Duration {
     use crate::maintenance_coordinator::Operation;
     match operation {
@@ -10054,7 +10079,7 @@ impl Database {
         };
 
         if self.buffered_layer().is_some_and(|layer| layer.has_rows_in_range(&key.project_id, &key.source, key.slice.start_micros, key.slice.end_micros)) {
-            retry("source_not_flushed".to_owned(), std::time::Duration::from_secs(5))?;
+            retry("source_not_flushed".to_owned(), buffered_source_retry_delay(key.slice, crate::clock::now_micros()))?;
             return Ok(true);
         }
         let Some(date) = chrono::DateTime::from_timestamp_micros(key.slice.start_micros).map(|time| time.date_naive()) else {
@@ -10196,7 +10221,7 @@ impl Database {
         if !derived
             && self.buffered_layer().is_some_and(|layer| layer.has_rows_in_range(&key.project_id, &key.source, key.slice.start_micros, key.slice.end_micros))
         {
-            retry("source_not_flushed".to_owned(), std::time::Duration::from_secs(5))?;
+            retry("source_not_flushed".to_owned(), buffered_source_retry_delay(key.slice, crate::clock::now_micros()))?;
             return Ok(true);
         }
 
@@ -20481,6 +20506,30 @@ mod tests {
     /// `Instant` has no MAX, and adding `Duration::MAX` overflows.
     fn far_future() -> std::time::Instant {
         std::time::Instant::now() + std::time::Duration::from_secs(86_400)
+    }
+
+    /// A unit whose slice has not finished yet must back off past the slice, not
+    /// spin. Prod 2026-08-18 had one BaseRollup task at attempts=195 on today's
+    /// day-wide slice: `has_rows_in_range` is true until midnight, and a flat 5s
+    /// retry left it permanently eligible, monopolising `claim_next` ahead of
+    /// ~40,000 pending units that had never run once.
+    #[test]
+    fn a_slice_that_has_not_finished_backs_off_past_its_own_end() {
+        use crate::maintenance_coordinator::{FINALIZATION_DELAY_MICROS, TimeSlice};
+        const HOUR: i64 = 3_600 * 1_000_000;
+        let now = 20 * HOUR;
+        let day = TimeSlice::new(0, 24 * HOUR).expect("day slice");
+
+        // Today's day-wide unit cannot succeed before midnight plus finalization.
+        let delay = super::buffered_source_retry_delay(day, now);
+        let expected = (24 * HOUR - now + FINALIZATION_DELAY_MICROS) as u64;
+        assert_eq!(delay.as_micros() as u64, expected, "a unit must wait out the rest of its own slice, not 5 seconds");
+        assert!(delay.as_secs() > 4 * 3_600, "the old 5s retry is what made this an unbounded spin");
+
+        // A sealed slice merely waiting on a slow flush is unchanged: the floor
+        // applies, so ordinary frontier work keeps retrying promptly.
+        let sealed = TimeSlice::new(0, HOUR).expect("sealed slice");
+        assert_eq!(super::buffered_source_retry_delay(sealed, now).as_secs(), 5, "an already-sealed slice keeps the fast retry");
     }
 
     /// The debt cap must leave workers for the rollup chain without starving debt


### PR DESCRIPTION
## Goal metric this moves

**G3**. Measured by the share of `maintenance_task_started` events carrying a
high `attempts` count, and by `pending_base_rollup` starting to turn over.

## The evidence

One BaseRollup task on today's day-wide slice, on a project ingesting 144 rows
per half hour:

```
20:16:10  slice=1787011200000000  attempts=171
...
21:18:38  slice=1787011200000000  attempts=195
```

Re-claimed every 30–70 seconds, 195 times. It is not slow and not big — it
cannot succeed. `has_rows_in_range` is true for any slice reaching into time
that has not finished, so a day-wide unit covering *today* sees buffered rows on
every attempt until midnight, and the flat 5s retry made that an unbounded spin.

The spin is not free: a 5s backoff leaves the task permanently eligible while
fresh work waits on a real deadline, and `claim_next` takes the smallest ready
`(class, order_key)`. Of **427 task starts in 90 minutes**:

| attempts | starts |
|---|---|
| 100+ | 134 |
| 10–99 | 133 |
| 2–9 | 81 |
| 0–1 | 79 |

**63% of every claim went to work that had already failed 10+ times**, against
~40,000 pending BaseRollup units that had never run once.

## The change

Back off to the earliest time the slice *could* be complete — its own end plus
`FINALIZATION_DELAY_MICROS`, which the write path already honours — instead of a
constant. Floored at 5s so a sealed slice waiting on a slow flush is unchanged.
Both call sites (dedup and rollup) shared the constant and the bug.

Regression guard: `a_slice_that_has_not_finished_backs_off_past_its_own_end`.
791/791 lib tests pass; `cargo lint` / `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Up4aGzfj5UNcd8KKLQ96