### PR TITLE
A day with no source rows is answered, not missing

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -929,14 +929,42 @@ fn build_optimize_session_state_tuned(
 /// the rollup tier. A project whose ROLLUP is broken still has recent source
 /// partitions, so it stays counted; asking the tier instead would let the very
 /// failure this metric exists to catch exclude itself from it.
+/// The window the contiguity gauge reports over, and the value it saturates at.
+/// Equal to the 30d dashboard goal: 30 means a 30d panel is fully answerable.
+const CONTIGUITY_HORIZON_DAYS: u64 = 30;
+
 fn min_contiguous_days<'a>(
-    covered: &HashSet<(String, chrono::NaiveDate)>, today: chrono::NaiveDate, active_projects: &HashSet<&'a str>,
+    covered: &HashSet<(String, chrono::NaiveDate)>, source: &HashSet<(String, chrono::NaiveDate)>, today: chrono::NaiveDate, active_projects: &HashSet<&'a str>,
 ) -> (u64, Option<&'a str>) {
+    // A day the SOURCE never held counts as covered. A rollup cannot exist for
+    // rows that do not exist, and a query over that day correctly returns
+    // nothing whether or not a tier partition is there — so an absent day is
+    // answered, not missing.
+    //
+    // Without this the gauge is unreachable by construction, and it was:
+    // measured 2026-08-18, project 4f020cf8 held source rows on 08-14 (85),
+    // 08-16 (4) and 08-18 (8) and NOTHING on 08-15 or 08-17. Its tier matches
+    // that exactly, so the tier is correct and complete — yet counting back from
+    // yesterday it scored 0, and because this is a MINIMUM over active projects
+    // it pinned the whole fleet's gauge to 0 no matter how much coverage every
+    // other project had. `6297304f` scored 4 and `5ce1c976` 1 in the same sweep.
+    //
+    // The goal is "30 contiguous days a 30d panel can answer from the tier", not
+    // "30 days on which every tenant happened to send traffic". One quiet
+    // low-traffic tenant must not make the target unattainable for the fleet.
+    let answered = |project: &str, date: chrono::NaiveDate| {
+        let key = (project.to_owned(), date);
+        covered.contains(&key) || !source.contains(&key)
+    };
+    // Bounded, because "answered" is true for every day before a project's first
+    // row: without a cap a quiet tenant scores the age of the epoch. 30 is the
+    // goal itself, so the gauge reads as progress toward it and saturates exactly
+    // when a 30d panel is fully answerable.
     active_projects
         .iter()
         .map(|project| {
-            let days = (1u64..)
-                .take_while(|back| today.checked_sub_days(chrono::Days::new(*back)).is_some_and(|date| covered.contains(&((*project).to_owned(), date))))
+            let days = (1u64..=CONTIGUITY_HORIZON_DAYS)
+                .take_while(|back| today.checked_sub_days(chrono::Days::new(*back)).is_some_and(|date| answered(project, date)))
                 .count() as u64;
             (days, Some(*project))
         })
@@ -9905,7 +9933,7 @@ impl Database {
                 // the window sends it to a raw scan — which is why `MIN(date)`
                 // and `tasks_pending` both read as progress on 2026-08-17 while
                 // 14d/30d queries stayed unroutable.
-                let (contiguous, worst_project) = min_contiguous_days(&covered, today, &active_projects);
+                let (contiguous, worst_project) = min_contiguous_days(&covered, &source_partitions, today, &active_projects);
                 let gauge = &crate::metrics::maintenance_stats().rollup_min_contiguous_days;
                 let previous = gauge.load(std::sync::atomic::Ordering::Relaxed);
                 // Every tier folds into one number, so take the worst; reset
@@ -21104,33 +21132,77 @@ mod tests {
         let day = |n: u32| chrono::NaiveDate::from_ymd_opt(2026, 8, n).expect("date");
         let covered = |pairs: &[(&str, u32)]| pairs.iter().map(|(p, d)| ((*p).to_owned(), day(*d))).collect::<HashSet<_>>();
         let active = |names: &[&'static str]| names.iter().copied().collect::<HashSet<&str>>();
+        // Every day in the window held source rows, so an absent day in `covered`
+        // is a genuine hole rather than a day with nothing to roll up.
+        let dense = |names: &[&str]| names.iter().flat_map(|p| (1u32..=31).map(move |d| ((*p).to_owned(), day(d)))).collect::<HashSet<_>>();
 
         // 08-16, 08-15, 08-14 unbroken back from yesterday.
-        assert_eq!(min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("a", 14)]), today, &active(&["a"])).0, 3);
+        assert_eq!(min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("a", 14)]), &dense(&["a"]), today, &active(&["a"])).0, 3);
 
         // Prod's actual shape: plenty of days, but a hole right after yesterday.
         // Everything behind it is unreachable to a 30d panel, so it must not count.
-        assert_eq!(min_contiguous_days(&covered(&[("a", 16), ("a", 13), ("a", 12), ("a", 11), ("a", 10)]), today, &active(&["a"])).0, 1);
+        assert_eq!(min_contiguous_days(&covered(&[("a", 16), ("a", 13), ("a", 12), ("a", 11), ("a", 10)]), &dense(&["a"]), today, &active(&["a"])).0, 1);
 
         // Today is the frontier's job — covering it must not extend the run.
-        assert_eq!(min_contiguous_days(&covered(&[("a", 17)]), today, &active(&["a"])).0, 0, "yesterday missing is zero coverage however complete today is");
+        assert_eq!(
+            min_contiguous_days(&covered(&[("a", 17)]), &dense(&["a"]), today, &active(&["a"])).0,
+            0,
+            "yesterday missing is zero coverage however complete today is"
+        );
 
         // One starved project drags the fleet number down; averaging would hide it.
         assert_eq!(
-            min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("b", 16)]), today, &active(&["a", "b"])).0,
+            min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("b", 16)]), &dense(&["a", "b"]), today, &active(&["a", "b"])).0,
             1,
             "the worst project is the number that matters"
         );
-        assert_eq!(min_contiguous_days(&HashSet::new(), today, &active(&["a"])).0, 0);
+        assert_eq!(min_contiguous_days(&HashSet::new(), &dense(&["a"]), today, &active(&["a"])).0, 0);
 
         // A project that stopped ingesting can never have yesterday. Counting it
         // pinned the gauge at 0 forever on prod (`edb04135`, last wrote 08-03)
         // while every project anyone queries was fully covered.
         assert_eq!(
-            min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("dormant", 3)]), today, &active(&["a"])).0,
+            min_contiguous_days(&covered(&[("a", 16), ("a", 15), ("dormant", 3)]), &dense(&["a", "dormant"]), today, &active(&["a"])).0,
             2,
             "a project that no longer ingests must not pin the fleet number at zero"
         );
+    }
+
+    /// A day the SOURCE never held must count as answered, or the gauge is
+    /// unreachable by construction and one quiet tenant pins the fleet at zero.
+    ///
+    /// Measured on prod 2026-08-18. Project `4f020cf8` held source rows on 08-14
+    /// (85), 08-16 (4) and 08-18 (8) and NOTHING on 08-15 or 08-17. Its tier
+    /// matched that exactly — correct and complete — yet counting back from
+    /// yesterday it scored 0, and because this is a MINIMUM it pinned the whole
+    /// fleet's gauge to 0 while `6297304f` scored 4 and `5ce1c976` scored 1.
+    ///
+    /// The goal is "30 contiguous days a 30d panel can answer from the tier", not
+    /// "30 days on which every tenant happened to send traffic".
+    #[test]
+    fn a_day_with_no_source_rows_counts_as_answered() {
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 8, 18).expect("date");
+        let day = |n: u32| chrono::NaiveDate::from_ymd_opt(2026, 8, n).expect("date");
+        let set = |pairs: &[(&str, u32)]| pairs.iter().map(|(p, d)| ((*p).to_owned(), day(*d))).collect::<HashSet<_>>();
+        let active = |names: &[&'static str]| names.iter().copied().collect::<HashSet<&str>>();
+
+        // 4f020cf8's real shape: source on 14/16/18 only, tier matching exactly.
+        let source = set(&[("q", 14), ("q", 16), ("q", 18)]);
+        let covered = set(&[("q", 14), ("q", 16), ("q", 18)]);
+        assert_eq!(
+            min_contiguous_days(&covered, &source, today, &active(&["q"])).0,
+            CONTIGUITY_HORIZON_DAYS,
+            "17 and 15 had no rows to roll up, and neither did anything older — fully answered"
+        );
+
+        // A day the source DID hold and the tier does not is still a real hole.
+        let source = set(&[("q", 17), ("q", 16), ("q", 15)]);
+        let covered = set(&[("q", 17), ("q", 15)]);
+        assert_eq!(min_contiguous_days(&covered, &source, today, &active(&["q"])).0, 1, "16 has rows and no tier — a genuine gap");
+
+        // A project that emitted nothing at all in the window is fully answered
+        // rather than scoring zero.
+        assert_eq!(min_contiguous_days(&HashSet::new(), &HashSet::new(), today, &active(&["silent"])).0, CONTIGUITY_HORIZON_DAYS);
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 item 3 of `2026-08-18-an-architecture-that-keeps-up.md` asks to check `rollup_min_contiguous_days` against ground truth, because this codebase has shipped three lying gauges.

**This one does not lie — but it is unreachable by construction**, which is worse, because chasing it means chasing a number that cannot move.

Measured on prod 2026-08-18, contiguous days back from yesterday in `dashboard_1h_v2`:

| project | tier dates | contiguous |
| --- | --- | --- |
| `6297304f` | 08-18, 17, 16, 15, 14, then a hole | 4 |
| `5ce1c976` | 08-17, 15, 14 | 1 |
| `4f020cf8` | 08-18, 16, 14 | **0** ← pins the fleet |

`4f020cf8` is **not behind**. Its source holds 85 rows on 08-14, 4 on 08-16, 8 on 08-18 and **nothing** on 08-15 or 08-17. The tier matches the source exactly — correct and complete. But the gauge counts a day as covered only if the tier has a partition, so a day with nothing to roll up reads identically to a day never built. And because the gauge is a **minimum** over active projects, one quiet tenant holds the whole fleet at 0 however complete everyone else is.

So G1 required 30 consecutive days on which *every* tenant happened to send traffic.

## The change

A day the source never held counts as answered. A rollup cannot exist for rows that do not exist, and a query over that day correctly returns nothing either way.

Bounded at `CONTIGUITY_HORIZON_DAYS = 30` — the goal itself, so the gauge reads as progress toward it and saturates exactly when a 30d panel is fully answerable. Without the bound, "answered" holds for every day before a project's first row and a quiet tenant scores the age of the epoch: the first version returned **96,485,975**.

The existing tests keep their meaning — they now pass a dense source set, so an absent tier day is still a genuine hole. New test `a_day_with_no_source_rows_counts_as_answered` covers the real 4f020cf8 shape, a genuine gap, and a fully silent project.

793 lib tests pass; `cargo lint` and `cargo fmt` clean.