### PR TITLE
fix(rollup): let a derived unit run when its base tier already exists

### DIFF
--- a/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
+++ b/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
@@ -538,6 +538,79 @@ The honest resolution is the one already shipping: for a KNOWN-oversized day,
 the quarantine cap bounds what that lesson costs to two workers instead of
 sixteen. The two changes cover the two cases; neither covers both.
 
+### Measured after #181 shipped (2026-08-18 22:08 UTC, image `c8d3c6b`)
+
+240s window on the new process. The stall is gone:
+
+| metric | before | after |
+|---|---|---|
+| `tasks_complete` | **+0.67/min** | **+13.94/min** |
+| `tasks_pending` | rising | **−1,868/min** |
+| `pending_base_rollup` | +0.33/min (*rising*) | **−1,127/min** |
+| `rollup_output_rows_total` | +5.67/min | **+123,205/min** |
+| `rollup_rebuilds_full_total` | ~0 | +19.17/min |
+| `rollup_hits_full_total` | 0 | 66 (first ever non-zero) |
+| `rollup_hits_hybrid_total` | +9.33/min | +32.61/min |
+
+Caveat, stated because this plan's §12 demands it: the process was 5 minutes old,
+so part of the `pending` drop is boot-time coarsening rather than completion, and
+the ≥2h rule has not been met. `tasks_complete` (+21x) and `rollup_output_rows`
+are the honest throughput numbers; both are unambiguous.
+
+**G2 is NOT yet met.** Immediately after the deploy, shipbubble's 1d / 7d / 30d
+queries all still time out at 60s. Two causes visible in `EXPLAIN`, both
+independent of maintenance throughput:
+
+1. **The query does not route to a rollup at all** — the plan is a raw
+   mem+hot+delta union with no tier leg. Consistent with `rollup_miss_not_built`
+   dominating (+10.5/min).
+2. **`GatedScanExec: permits=0`** — the wide-scan gate is saturated, the exact
+   signature documented at `config.rs:2558` for 2026-08-01 (a query reading ONE
+   file and 8.24 KB paid 40-57s purely queued). A 1-day window is deeper than
+   `timefusion_wide_scan_lookback_hours`, so it is gated, and nothing is
+   available. The hot leg for that query also carries **430 file groups** for a
+   single day — the fragmentation above, seen from the read side.
+
+This confirms §3's claim that latency has two independent halves, and locates
+the second half precisely: it is the gate plus file count, not coverage depth.
+
+### Where the coverage actually is (ground truth, Phase 1.3 — done)
+
+Read directly from the tier tables rather than the gauge:
+
+| project | 1m tier days | 1h tier days |
+|---|---|---|
+| 94c5dc1f | 33 | 17 |
+| 98fdd4f3 | 33 | 10 |
+| be87ebc1 | 33 | 9 |
+| 8100121c | 33 | — |
+| shipbubble `28f62f01` | 14 | **6** (08-15..18, plus stale 07-25/26) |
+
+Two things follow, and both correct this plan:
+
+- **`rollup_min_contiguous_days` = 0 is an artifact**, again. The minimum is
+  dragged to zero by dormant tenants (`d828e6d5` has one day; `edb04135` stops
+  at 2026-08-03). It is a fleet MINIMUM, so one abandoned project pins
+  `coverage_is_short()` true forever — which currently biases the scheduler in a
+  direction we happen to want, but is not a signal anyone should trust or tune
+  against. **G1 must be restated per-project, not as a fleet minimum.**
+- **The gap is the DERIVED (1h) tier, not the base.** The base 1m tier is 33 days
+  deep on most projects while 1h sits at 9-17. Derived units need no raw scan —
+  they aggregate the base tier — so this is the cheapest work in the system and
+  the closest to the 30d goal. Yet `pending_derived_rollup` barely moves
+  (780 → 757, −5.7/min) while base drains at −1,127/min.
+
+**That makes derived-rollup throughput the next thing to attribute.** The
+candidate mechanism is `dependencies_complete`: a `DerivedRollup` is claimable
+only when COMPLETE `BaseRollup` *journal tasks* contiguously cover its slice —
+journal bookkeeping, not the base tier's actual coverage. A historical day whose
+1m tier exists but whose base journal records do not would be permanently
+unclaimable, and `claim_next` skips it silently, with no counter. That would be
+the sixth silent refusal in this family (#155, #159, #166, #169, and #180's
+guard above). **Not yet proven** — starvation alone could explain the old
+numbers. The discriminator is now available and cheap: with workers free, if
+`pending_derived_rollup` stays flat, it is the dependency gate.
+
 ---
 
 ## 6. Phase 2 — aim the backfill at the goal (enqueue control)

--- a/src/database.rs
+++ b/src/database.rs
@@ -9720,6 +9720,7 @@ impl Database {
                         created_unix_ms,
                         retry_reason: None,
                         publication: None,
+                        base_tier_present: false,
                     });
                 }
                 if date < today && !schema.sorting_columns.is_empty() {
@@ -9745,6 +9746,7 @@ impl Database {
                             created_unix_ms,
                             retry_reason: None,
                             publication: None,
+                            base_tier_present: false,
                         });
                     }
                 }
@@ -9997,8 +9999,8 @@ impl Database {
                 for (project_id, date) in &want {
                     let Some(day_start) = date.and_hms_opt(0, 0, 0).map(|time| time.and_utc().timestamp_micros()) else { continue };
                     let Ok(slice) = crate::maintenance_coordinator::TimeSlice::new(day_start, day_start.saturating_add(DAY_MICROS)) else { continue };
-                    let mut enqueue = |physical_table: String, operation| {
-                        journal.enqueue(
+                    let mut enqueue = |physical_table: String, operation, base_tier_present| {
+                        journal.enqueue_with_base_tier(
                             crate::maintenance_coordinator::TaskKey {
                                 physical_table,
                                 source: source.clone(),
@@ -10009,6 +10011,7 @@ impl Database {
                             now,
                             crate::maintenance_coordinator::MAX_DECODED_BYTES,
                             created_unix_ms,
+                            base_tier_present,
                         );
                     };
                     // Only the tiers this day is actually missing. Enqueueing
@@ -10022,7 +10025,7 @@ impl Database {
                     // the common case here: 1m is 22-32 days deep while 1h is
                     // 2-6, so most queued days need the coarse tier alone.
                     if needs_source_scan {
-                        enqueue(source.clone(), crate::maintenance_coordinator::Operation::Dedup);
+                        enqueue(source.clone(), crate::maintenance_coordinator::Operation::Dedup, false);
                     }
                     for index in missing {
                         let spec = &schema.rollups[index];
@@ -10031,7 +10034,17 @@ impl Database {
                         } else {
                             crate::maintenance_coordinator::Operation::BaseRollup
                         };
-                        enqueue(spec.table_name(&source), operation);
+                        // `!needs_source_scan` means no BASE tier is missing for
+                        // this day, i.e. the tier this derived unit aggregates is
+                        // already built. That is read from actual coverage, so it
+                        // proves what `dependencies_complete` can otherwise only
+                        // infer from journal records that a historical day does
+                        // not have — see `MaintenanceTask::base_tier_present`.
+                        enqueue(
+                            spec.table_name(&source),
+                            operation,
+                            operation == crate::maintenance_coordinator::Operation::DerivedRollup && !needs_source_scan,
+                        );
                     }
                     queued = queued.saturating_add(1);
                 }

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -213,6 +213,29 @@ pub struct MaintenanceTask {
     pub retry_reason: Option<String>,
     #[serde(default)]
     pub publication: Option<Publication>,
+    /// The base tier this derived unit aggregates is ALREADY PRESENT, proven
+    /// from real rollup coverage by `plan_rollup_backfill` rather than from
+    /// journal bookkeeping.
+    ///
+    /// `dependencies_complete` otherwise requires COMPLETE `BaseRollup` TASKS
+    /// contiguously covering the slice. For a frontier hour that is right. For a
+    /// historical day whose 1m tier was built weeks ago — possibly by an older
+    /// code path, possibly with its journal records long since collapsed — no
+    /// such task exists, so the unit is unclaimable forever and `claim_next`
+    /// skips it with no counter and no log.
+    ///
+    /// Prod 2026-08-18 22:30 UTC is that shape exactly: the 1m base tier is 33
+    /// days deep on most projects while the 1h derived tier it feeds sits at
+    /// 9-17, `pending_derived_rollup` did not move by ONE task across two 240s
+    /// windows with workers free, and all 35 derived units claimed in 20 minutes
+    /// were frontier slices whose base had completed minutes earlier.
+    ///
+    /// Only ever set from positive evidence — the planner computes `missing`
+    /// tiers from actual coverage, so a derived tier missing while no base tier
+    /// is missing means the base data is there. That is strictly better evidence
+    /// than the journal's, which is why this overrides rather than supplements.
+    #[serde(default)]
+    pub base_tier_present: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -632,6 +655,7 @@ impl TaskJournal {
                 created_unix_ms: u64::try_from(now_micros.div_euclid(1_000)).unwrap_or_default(),
                 retry_reason: None,
                 publication: None,
+                base_tier_present: false,
             });
         }
         collapsed
@@ -649,6 +673,13 @@ impl TaskJournal {
     }
 
     pub fn enqueue(&mut self, key: TaskKey, deadline_micros: i64, estimated_decoded_bytes: u64, created_unix_ms: u64) {
+        self.enqueue_with_base_tier(key, deadline_micros, estimated_decoded_bytes, created_unix_ms, false);
+    }
+
+    /// `base_tier_present` records that the tier this unit aggregates already
+    /// exists — see the field on [`MaintenanceTask`]. Only `plan_rollup_backfill`
+    /// can prove it, because only it reads actual tier coverage.
+    pub fn enqueue_with_base_tier(&mut self, key: TaskKey, deadline_micros: i64, estimated_decoded_bytes: u64, created_unix_ms: u64, base_tier_present: bool) {
         if let Some(index) = self.task_indices.get(&key).copied() {
             let task = &mut self.snapshot.tasks[index];
             if task.state != TaskState::Running {
@@ -657,13 +688,18 @@ impl TaskJournal {
                     || task.deadline_micros != new_deadline
                     || task.estimated_decoded_bytes != estimated_decoded_bytes
                     || task.retry_reason.is_some()
-                    || task.publication.is_some();
+                    || task.publication.is_some()
+                    // Latching, never clearing: the planner proves presence, and
+                    // a later enqueue that cannot prove it (the frontier's) is
+                    // silence, not evidence of absence.
+                    || (base_tier_present && !task.base_tier_present);
                 if changed {
                     task.state = TaskState::Pending;
                     task.deadline_micros = new_deadline;
                     task.estimated_decoded_bytes = estimated_decoded_bytes;
                     task.retry_reason = None;
                     task.publication = None;
+                    task.base_tier_present |= base_tier_present;
                     self.dirty_tasks.insert(key);
                 }
             }
@@ -683,6 +719,7 @@ impl TaskJournal {
             created_unix_ms,
             retry_reason: None,
             publication: None,
+            base_tier_present,
         });
     }
 
@@ -770,6 +807,7 @@ impl TaskJournal {
                         created_unix_ms,
                         retry_reason: None,
                         publication: None,
+                        base_tier_present: false,
                     });
                     self.dirty_tasks.insert(key);
                 }
@@ -965,6 +1003,11 @@ impl TaskJournal {
             Operation::DerivedRollup => Some(Operation::BaseRollup),
             _ => None,
         };
+        // Proven from real tier coverage, which is strictly better evidence than
+        // the journal's own record of who built what. See the field's comment.
+        if task.base_tier_present {
+            return true;
+        }
         required.is_none_or(|required| {
             let mut intervals = self
                 .snapshot
@@ -1642,6 +1685,7 @@ mod tests {
             created_unix_ms: 0,
             retry_reason: None,
             publication: None,
+            base_tier_present: false,
         }
     }
 
@@ -2218,6 +2262,58 @@ mod tests {
         assert_eq!(claimed.state, TaskState::Running);
         assert_eq!(claimed.attempts, 1);
         assert!(journal.claim_next(Operation::Dedup, 0, true).is_none());
+    }
+
+    /// A derived unit whose base TIER already exists must be claimable, even
+    /// when no `BaseRollup` journal task records that it was built.
+    ///
+    /// Prod 2026-08-18 22:30 UTC: the 1m base tier was 33 days deep on most
+    /// projects while the 1h derived tier it feeds sat at 9-17,
+    /// `pending_derived_rollup` did not move by ONE task across two 240s windows
+    /// with workers free, and every derived unit claimed in 20 minutes was a
+    /// frontier slice whose base had completed minutes earlier. Historical days
+    /// were unclaimable — `claim_next` skips a dependency-blocked task silently,
+    /// with no counter and no log, which is the sixth silent refusal in this
+    /// family.
+    #[test]
+    fn a_derived_unit_runs_when_its_base_tier_exists_without_a_journal_record() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let derived = |project: &str| TaskKey {
+            physical_table: "rollup_1h".to_owned(),
+            source: "source".to_owned(),
+            project_id: project.to_owned(),
+            slice: TimeSlice::new(0, 3_600_000_000).expect("slice"),
+            operation: Operation::DerivedRollup,
+        };
+
+        // The status quo, and correct on its own terms: no completed base task
+        // covers this slice, so the unit is refused.
+        journal.enqueue(derived("historical"), 0, 1, 0);
+        assert!(journal.claim_next(Operation::DerivedRollup, 0, true).is_none(), "without evidence the dependency gate still holds");
+
+        // The backfill planner reads real tier coverage, so it can prove the
+        // base tier is there. That must be enough.
+        journal.enqueue_with_base_tier(derived("historical"), 0, 1, 0, true);
+        assert_eq!(journal.claim_next(Operation::DerivedRollup, 0, true).expect("proven base tier makes the unit claimable").key.project_id, "historical");
+    }
+
+    /// The proof latches. The frontier re-enqueues the same key without it, and
+    /// silence is not evidence that coverage stopped existing.
+    #[test]
+    fn a_proven_base_tier_is_not_forgotten_by_a_later_enqueue() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let key = TaskKey {
+            physical_table: "rollup_1h".to_owned(),
+            source: "source".to_owned(),
+            project_id: "p".to_owned(),
+            slice: TimeSlice::new(0, 3_600_000_000).expect("slice"),
+            operation: Operation::DerivedRollup,
+        };
+        journal.enqueue_with_base_tier(key.clone(), 0, 1, 0, true);
+        journal.enqueue(key.clone(), 0, 1, 0);
+        assert!(journal.claim_next(Operation::DerivedRollup, 0, true).is_some(), "a later uninformed enqueue must not clear the proof");
     }
 
     /// A unit that has proven it cannot fit its deadline must not be able to


### PR DESCRIPTION
## Goal metric this moves

**G1**, directly and on the shortest path: `rollup_min_contiguous_days` per
project, measured as the 1h tier's day count — the tier 14d/30d dashboards read.

## The evidence

Read straight from the tier tables on prod (2026-08-18 22:30 UTC):

| project | 1m tier days | 1h tier days |
|---|---|---|
| 94c5dc1f | 33 | 17 |
| 98fdd4f3 | 33 | 10 |
| be87ebc1 | 33 | 9 |
| shipbubble `28f62f01` | 14 | **6** |

The base tier is deep; the derived tier it feeds is not. Derived units need **no
raw scan** — they aggregate the base tier — so this is the cheapest work in the
system and the closest to the coverage goal. It was not running.

With #181's capacity fix live and workers free:

- `pending_derived_rollup` did not move by **one** task across two 240s windows
- all **35** derived units claimed in 20 minutes were *frontier* slices whose
  base completed minutes earlier
- no 1h day count moved at all

## Root cause

`dependencies_complete` requires COMPLETE `BaseRollup` **journal tasks**
contiguously covering the slice. Correct for a frontier hour. For a historical
day whose 1m tier was built weeks ago — older code path, or journal records
since collapsed — no such task exists, so the unit is unclaimable forever.
`claim_next` evaluates the gate inside a filter, so it is skipped with **no
counter and no log**: the sixth silent refusal in this family (#155, #159, #166,
#169, plus #180's guard which cannot fire on `estimated_decoded_bytes: 0`).

## The change

Journal bookkeeping was standing in for a fact about the data, and it is the
weaker evidence. `plan_rollup_backfill` computes `missing` tiers from **actual
rollup coverage**, so a day missing its derived tier while missing no base tier
*proves* the base data is present. Record that on the task; let the gate honour
it. Frontier units, where the planner can prove nothing, keep the strict check
unchanged. The flag latches on re-enqueue — the frontier re-enqueues the same
key without the proof, and silence is not evidence coverage stopped existing.

Guards: `a_derived_unit_runs_when_its_base_tier_exists_without_a_journal_record`,
`a_proven_base_tier_is_not_forgotten_by_a_later_enqueue`.
794/794 lib tests pass; `cargo lint` / `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Up4aGzfj5UNcd8KKLQ96