### PR TITLE
fix(rollup): prove the base tier only for days that have stopped changing

### DIFF
--- a/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
+++ b/docs/plans/2026-08-18-an-architecture-that-keeps-up.md
@@ -611,6 +611,46 @@ guard above). **Not yet proven** — starvation alone could explain the old
 numbers. The discriminator is now available and cheap: with workers free, if
 `pending_derived_rollup` stays flat, it is the dependency gate.
 
+### The discriminator ran, and it is the dependency gate (#184)
+
+Two further 240s windows on the post-#181 process, workers free and zero
+timeouts:
+
+- `pending_derived_rollup` did not move by **one task**.
+- All **35** derived units claimed in 20 minutes were *frontier* slices whose
+  base had completed minutes earlier.
+- No project's 1h day count moved at all (94c5dc1f 17, 98fdd4f3 10, be87ebc1 9,
+  shipbubble 6 — unchanged across the whole window).
+
+Confirmed the sixth silent refusal. `dependencies_complete` requires COMPLETE
+`BaseRollup` *journal tasks* contiguously covering a derived unit's slice, and
+`claim_next` evaluates it inside a filter — so a historical day whose 1m tier was
+built weeks ago, by an older code path or with its journal records since
+collapsed, is unclaimable forever with no counter and no log.
+
+Fixed by making the evidence match the question: `plan_rollup_backfill` computes
+`missing` tiers from ACTUAL rollup coverage, so a day missing its derived tier
+while missing no base tier proves the base data is present. That fact is
+recorded on the task (`MaintenanceTask::base_tier_present`) and the gate honours
+it; frontier units, where the planner can prove nothing, keep the strict check.
+
+**This is the shortest path to G1/G2 that exists**, because derived units read no
+raw data at all — the 1h tier can backfill from the 1m tier that is already 33
+days deep.
+
+### Standing correction to this plan's method
+
+Three of the four defects found tonight were *silent refusals in a filter
+predicate* — work that is queued, eligible-looking on every gauge, and never
+claimed. Gauges cannot see them: `pending_derived_rollup` reads identically
+whether 757 tasks are waiting their turn or can never be claimed at all.
+
+What found all three was the same two-step: (1) diff two `timefusion_stats`
+snapshots to find what is NOT moving, then (2) go to the logs and histogram
+`maintenance_task_started` by `operation` and by `attempts`. **Add that histogram
+to the standing snapshots (Phase 0.5).** Every future scheduler question should
+start there, and no scheduling change should be evaluated without it.
+
 ---
 
 ## 6. Phase 2 — aim the backfill at the goal (enqueue control)

--- a/src/database.rs
+++ b/src/database.rs
@@ -10040,11 +10040,18 @@ impl Database {
                         // proves what `dependencies_complete` can otherwise only
                         // infer from journal records that a historical day does
                         // not have — see `MaintenanceTask::base_tier_present`.
-                        enqueue(
-                            spec.table_name(&source),
-                            operation,
-                            operation == crate::maintenance_coordinator::Operation::DerivedRollup && !needs_source_scan,
-                        );
+                        //
+                        // Sealed days only. `partitions_of` reports PRESENCE — a
+                        // partition with one file counts — which is a true
+                        // statement about a day that has stopped changing and a
+                        // misleading one about a day still being written, where
+                        // the base tier is mid-build by definition. Today's
+                        // derived work is the frontier's anyway (`invalidate`
+                        // mints it per hour with its base slices right there in
+                        // the journal), so it loses nothing and keeps the strict
+                        // check where the strict check is cheap and correct.
+                        let base_proven = operation == crate::maintenance_coordinator::Operation::DerivedRollup && !needs_source_scan && *date < today;
+                        enqueue(spec.table_name(&source), operation, base_proven);
                     }
                     queued = queued.saturating_add(1);
                 }


### PR DESCRIPTION
Follow-up narrowing of #184.

`partitions_of` reports **presence** — a partition with a single file counts as
covered. That makes `!needs_source_scan` a true statement about a sealed day and
a misleading one about a day still being written, where the base tier is
mid-build by definition.

#184 turned that inference into a licence to publish, which raises an existing
looseness into a potential under-counted 1h day. Per this plan's own rule — *a
slow dashboard is visible, an under-counted one is not* — restrict the proof to
`date < today`.

Nothing is lost: today's derived work is the frontier's, minted per hour by
`invalidate` with its base slices sitting right there in the journal, so the
strict dependency check still applies exactly where it is cheap and correct.

794/794 lib tests pass; `cargo lint` / `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Up4aGzfj5UNcd8KKLQ96