### PR TITLE
fix(rollup): prove the base tier for derived units the planner cannot re-enqueue

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -9990,6 +9990,45 @@ impl Database {
                     .collect();
                 want.retain(|key| !queued.contains(key));
             }
+            // The days just filtered out are the ones that most need the proof:
+            // a derived unit blocked by `dependencies_complete` stays queued
+            // forever, which makes its day permanently ineligible for the
+            // admission above, which is the only path that could have told it
+            // the base tier is there. Prod 2026-08-18 22:50 UTC:
+            // `pending_derived_rollup` did not move after #184 shipped, because
+            // every one of those 759 tasks predated it.
+            //
+            // So prove it directly, over ALL candidate days rather than the 24
+            // admitted per pass — this touches existing tasks only, mints
+            // nothing, and cannot affect admission or deadlines.
+            {
+                let mut journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let mut proven = 0usize;
+                for ((project_id, date), missing) in &missing_tiers {
+                    if *date >= today || missing.iter().any(|index| schema.rollups[*index].derive_from.is_none()) {
+                        continue;
+                    }
+                    let Some(day_start) = date.and_hms_opt(0, 0, 0).map(|time| time.and_utc().timestamp_micros()) else { continue };
+                    let Ok(slice) = crate::maintenance_coordinator::TimeSlice::new(day_start, day_start.saturating_add(DAY_MICROS)) else { continue };
+                    for index in missing {
+                        let spec = &schema.rollups[*index];
+                        if spec.derive_from.is_none() {
+                            continue;
+                        }
+                        proven += usize::from(journal.prove_base_tier(&crate::maintenance_coordinator::TaskKey {
+                            physical_table: spec.table_name(&source),
+                            source: source.clone(),
+                            project_id: project_id.clone(),
+                            slice,
+                            operation: crate::maintenance_coordinator::Operation::DerivedRollup,
+                        }));
+                    }
+                }
+                if proven != 0 {
+                    journal.checkpoint()?;
+                    info!(source, proven, event = "rollup_derived_base_tier_proven");
+                }
+            }
             if want.is_empty() {
                 continue;
             }

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -661,6 +661,26 @@ impl TaskJournal {
         collapsed
     }
 
+    /// Record that the base tier a queued derived unit aggregates already
+    /// exists. Returns whether anything changed.
+    ///
+    /// The planner cannot do this through `enqueue`, because it SKIPS every day
+    /// that already has rollup work queued (`want.retain(|key| !queued...)`) —
+    /// and a day with a stuck derived task is exactly such a day. So the tasks
+    /// that most need the proof are the ones `enqueue` can never reach: prod
+    /// 2026-08-18 22:50 UTC, `pending_derived_rollup` still did not move after
+    /// #184 shipped, because all 759 of them predated it.
+    pub fn prove_base_tier(&mut self, key: &TaskKey) -> bool {
+        let Some(index) = self.task_indices.get(key).copied() else { return false };
+        let task = &mut self.snapshot.tasks[index];
+        if task.base_tier_present {
+            return false;
+        }
+        task.base_tier_present = true;
+        self.dirty_tasks.insert(key.clone());
+        true
+    }
+
     pub fn upsert(&mut self, task: MaintenanceTask) {
         self.dirty_tasks.insert(task.key.clone());
         if let Some(index) = self.task_indices.get(&task.key).copied() {
@@ -2296,6 +2316,33 @@ mod tests {
         // base tier is there. That must be enough.
         journal.enqueue_with_base_tier(derived("historical"), 0, 1, 0, true);
         assert_eq!(journal.claim_next(Operation::DerivedRollup, 0, true).expect("proven base tier makes the unit claimable").key.project_id, "historical");
+    }
+
+    /// The planner must be able to prove the base tier for a task it can no
+    /// longer reach through `enqueue`.
+    ///
+    /// A blocked derived unit stays queued, which makes its day permanently
+    /// ineligible for backfill admission (`want.retain(|key| !queued...)`),
+    /// which is the only path that could have carried the proof. Prod
+    /// 2026-08-18 22:50 UTC: `pending_derived_rollup` did not move after #184
+    /// shipped, because all 759 tasks predated it.
+    #[test]
+    fn an_already_queued_derived_unit_can_still_be_told_its_base_tier_exists() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let key = TaskKey {
+            physical_table: "rollup_1h".to_owned(),
+            source: "source".to_owned(),
+            project_id: "p".to_owned(),
+            slice: TimeSlice::new(0, 3_600_000_000).expect("slice"),
+            operation: Operation::DerivedRollup,
+        };
+        journal.enqueue(key.clone(), 0, 1, 0);
+        assert!(journal.claim_next(Operation::DerivedRollup, 0, true).is_none(), "precondition: blocked by the dependency gate");
+
+        assert!(journal.prove_base_tier(&key), "the proof lands on an existing task");
+        assert!(!journal.prove_base_tier(&key), "and is idempotent");
+        assert!(journal.claim_next(Operation::DerivedRollup, 0, true).is_some(), "the unit becomes claimable without being re-enqueued");
     }
 
     /// The proof latches. The frontier re-enqueues the same key without it, and


### PR DESCRIPTION
Completes #184, which did not reach the tasks it was written for.

#184 gave the planner a way to tell a derived unit its base tier already exists,
but only through `enqueue` — and `plan_rollup_backfill` **skips every day that
already has rollup work queued** (`want.retain(|key| !queued.contains(key))`).

A derived unit blocked by `dependencies_complete` stays queued forever → its day
is permanently ineligible for that admission → the only path that could have
carried the proof never runs. The tasks that most need it are exactly the ones
`enqueue` can never reach.

**Prod confirms it:** with #184 live, `pending_derived_rollup` went **746 → 759**
across a 300s window. All of those tasks predate it.

Prove it directly on the existing task instead, over all candidate days rather
than the 24 admitted per pass. Touches queued tasks only — mints nothing, moves
no deadline, cannot affect admission. Still sealed days only, per #185.

Guard: `an_already_queued_derived_unit_can_still_be_told_its_base_tier_exists`.
796/796 lib tests pass; `cargo lint` / `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Up4aGzfj5UNcd8KKLQ96