### PR TITLE
obs(rollup): name why a sealed derived unit is refused

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -10282,6 +10282,12 @@ impl Database {
                 derived_unproven,
                 derived_quarantined,
                 derived_not_due,
+                derived_refusal = {
+                    let journal = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                    journal
+                        .first_refused_sealed(crate::maintenance_coordinator::Operation::DerivedRollup, crate::clock::now_micros())
+                        .map_or_else(|| "none_pending".to_owned(), |(project, date, reason)| format!("{reason}:{project:.8}:{date}"))
+                },
                 cells_admitted = want.len().min(BACKFILL_PARTITIONS_PER_PASS),
                 defer_enqueue,
                 event = "rollup_backfill_census"

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -756,6 +756,48 @@ impl TaskJournal {
         (pending, sealed, unproven, quarantined, not_due)
     }
 
+    /// The first SEALED task of `operation` that `claim_next` would refuse, and
+    /// why — as `(project, date, reason)`.
+    ///
+    /// Every count in `claimability_census` is a property of the task in
+    /// isolation. None of them answers the question that actually matters, which
+    /// is why `best_class(sealed_only = true)` returns None while sealed tasks
+    /// sit pending. Prod 2026-08-19 has been in exactly that state through four
+    /// fixes: 141 sealed derived units, ~60 neither quarantined nor future-dated,
+    /// and not one claimed — every derived claim an hour-wide slice of today.
+    ///
+    /// Bounded to `LIMIT` evaluations because `dependencies_complete` is a scan;
+    /// a sample is enough to name the reason, and naming it is the whole point.
+    pub fn first_refused_sealed(&self, operation: Operation, now_micros: i64) -> Option<(String, String, &'static str)> {
+        const LIMIT: usize = 64;
+        let why = |task: &MaintenanceTask| -> &'static str {
+            if task.deadline_micros > now_micros {
+                "not_due"
+            } else if Self::is_quarantined(task) {
+                "quarantined"
+            } else if !self.dependencies_complete(task) {
+                "dependencies"
+            } else {
+                // Nothing about the task refuses it, so the refusal is upstream —
+                // in class ordering or the operation cycle, not in eligibility.
+                "CLAIMABLE"
+            }
+        };
+        let describe = |task: &MaintenanceTask| {
+            let date = chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros)
+                .map(|time| time.date_naive().to_string())
+                .unwrap_or_else(|| "?".to_owned());
+            (task.key.project_id.clone(), date, why(task))
+        };
+        let mut sealed = self.snapshot.tasks.iter().filter(|task| {
+            task.key.operation == operation && matches!(task.state, TaskState::Pending | TaskState::Retry) && !is_live_frontier(task.key.slice, now_micros)
+        });
+        // A claimable one is the interesting answer: it means eligibility is fine
+        // and the refusal is in ordering. Otherwise report the first task's reason.
+        let sample: Vec<_> = sealed.by_ref().take(LIMIT).collect();
+        sample.iter().find(|task| why(task) == "CLAIMABLE").or_else(|| sample.first()).map(|task| describe(task))
+    }
+
     /// Publish which `(source, project, date)` have their BASE tier built, read
     /// from real rollup coverage. Replaces the set wholesale: coverage can go
     /// backwards (a rewrite, a vacuum), and a stale "ready" is the direction


### PR DESCRIPTION
## Why

**Four fixes in a row** — #197 (ready set), #199 (hole ranking), #202
(accumulate), #204 (quarantine predicate) — have each made sealed derived work
more claimable, and **none has produced a single sealed derived claim.**

Prod after #204:

```
derived_sealed = 141   derived_quarantined = 80   derived_not_due = 40
→ ~60 sealed units neither quarantined nor future-dated
→ every derived claim in 10 minutes: hour-wide, today
```

Every count in `claimability_census` is a property of a task **in isolation**, so
none of them can answer the question that matters: why
`best_class(sealed_only = true)` returns `None` while sealed tasks sit pending.

I have inferred that answer twice and been wrong twice. Measure it instead.

## What

Report the first sealed unit that is refused, and the reason:

| reason | meaning |
|---|---|
| `not_due` | deadline still in the future |
| `quarantined` | worker gave it back repeatedly |
| `dependencies` | `dependencies_complete` refuses it |
| **`CLAIMABLE`** | **nothing about the task refuses it** |

`CLAIMABLE` is the informative outcome: eligibility is fine and the refusal is
**upstream** — in class ordering or the operation cycle — which is a different
investigation entirely.

Bounded to 64 evaluations because `dependencies_complete` is a scan. A sample is
enough to name a reason.

812/812 lib tests pass; `cargo lint` / `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Up4aGzfj5UNcd8KKLQ96